### PR TITLE
feat: add backend swagger.json contract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format format-check lint typecheck test tests integration_tests help run dev dev-ui tunnel web build-dashboard desktop install-desktop install-checkout
+.PHONY: all format format-check lint typecheck test tests integration_tests help run dev dev-ui tunnel web build-dashboard desktop install-desktop install-checkout swagger
 
 # Default target executed when no arguments are given to make.
 all: help
@@ -36,6 +36,9 @@ build-dashboard:
 
 run:
 	uv run uvicorn agent.webapp:app --reload --port 8000
+
+swagger:
+	uv run python -c 'import json; from pathlib import Path; from agent.webapp import app; Path("swagger.json").write_text(json.dumps(app.openapi(), indent=2, sort_keys=True) + "\n", encoding="utf-8")'
 
 desktop:
 	pnpm run dev:desktop
@@ -103,6 +106,7 @@ help:
 	@echo 'web                          - run the dashboard web server'
 	@echo 'tunnel                       - ngrok tunnel to :2024 on NGROK_DOMAIN, webhooks only (any other tunnel works too)'
 	@echo 'run                          - run webhook server'
+	@echo 'swagger                      - regenerate swagger.json from the backend routes'
 	@echo 'desktop                      - run the Electron desktop app (backend must be running)'
 	@echo 'install-desktop              - install or update Open SWE Desktop on macOS'
 	@echo 'install-checkout             - install the current checkout of Open SWE Desktop on macOS'

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ Each cloud coding thread is bound to its own persistent sandbox, so the agent ca
 - Define personal and repository coding instructions plus organization-wide review guidelines
 - Swap sandbox providers, middleware, skills, triggers, and delivery policies
 
+## API contract
+
+[`swagger.json`](swagger.json) is the generated OpenAPI 3.1 contract for the custom FastAPI backend (`agent.webapp:app`). Import it into an OpenAPI 3.1-compatible viewer, or run `make run` and open `http://localhost:8000/docs` for interactive API documentation (`/openapi.json` serves the live schema).
+
+Regenerate the file with `make swagger` after changing backend routes or models. It reflects the current route declarations: some request/response schemas and authentication requirements are not yet documented. LangGraph runtime endpoints (such as `/runs`, `/threads`, and `/assistants`) are not included.
+
 ## How it works
 
 ### Deep Agents is the harness

--- a/agent/dashboard/oauth.py
+++ b/agent/dashboard/oauth.py
@@ -14,7 +14,8 @@ from urllib.parse import quote, urlparse
 
 import httpx2
 import jwt
-from fastapi import HTTPException, Request
+from fastapi import Depends, HTTPException, Request
+from fastapi.security import APIKeyCookie
 from starlette.requests import HTTPConnection
 
 from agent.config import ENV
@@ -26,6 +27,7 @@ from agent.utils.http import DEFAULT_HTTP_TIMEOUT
 logger = logging.getLogger(__name__)
 
 COOKIE_NAME = "osw_session"
+SESSION_COOKIE = APIKeyCookie(name=COOKIE_NAME, scheme_name="DashboardSession", auto_error=False)
 STATE_COOKIE_NAME = "osw_oauth_state"
 _DESKTOP_APP_ORIGIN = "open-swe://app"
 SESSION_TTL_SECONDS = 7 * 24 * 60 * 60
@@ -400,7 +402,9 @@ def build_settings_url() -> str | None:
     return f"{frontend_base}{PROFILE_SETTINGS_PATH}"
 
 
-def require_session(request: HTTPConnection) -> dict[str, Any]:
+def require_session(
+    request: HTTPConnection, _cookie: str | None = Depends(SESSION_COOKIE)
+) -> dict[str, Any]:
     token = request.cookies.get(COOKIE_NAME)
     if not token:
         raise HTTPException(401, "not authenticated")

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -21,6 +21,7 @@ from fastapi import (
     WebSocketDisconnect,
 )
 from fastapi.responses import JSONResponse, RedirectResponse, Response, StreamingResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, Field
 
 from agent.config import ENV
@@ -54,6 +55,7 @@ from agent.dashboard.notion_oauth import (
 )
 from agent.dashboard.oauth import (
     COOKIE_NAME,
+    SESSION_COOKIE,
     SESSION_TTL_SECONDS,
     STATE_COOKIE_NAME,
     STATE_TTL_SECONDS,
@@ -314,9 +316,20 @@ def _admin_session(session: dict[str, Any] = _SESSION_DEP) -> dict[str, Any]:
 
 
 _ADMIN_DEP = Depends(_admin_session)
+_ADMIN_BEARER_DEP = Depends(
+    HTTPBearer(
+        scheme_name="AdminBearer",
+        description="An admin's GitHub user token or an allowlisted GitHub Actions OIDC token.",
+        auto_error=False,
+    )
+)
 
 
-async def _admin_session_or_ci_token(request: Request) -> dict[str, Any]:
+async def _admin_session_or_ci_token(
+    request: Request,
+    _cookie: str | None = Depends(SESSION_COOKIE),
+    _bearer: HTTPAuthorizationCredentials | None = _ADMIN_BEARER_DEP,
+) -> dict[str, Any]:
     """Admin gate that also accepts CI credentials: an Actions OIDC token, or an
     admin's GitHub personal access token."""
     token = bearer_github_token(request)

--- a/swagger.json
+++ b/swagger.json
@@ -1,0 +1,8187 @@
+{
+  "components": {
+    "schemas": {
+      "AgentInstructions": {
+        "properties": {
+          "created_at": {
+            "default": "",
+            "title": "Created At",
+            "type": "string"
+          },
+          "created_by": {
+            "default": "",
+            "title": "Created By",
+            "type": "string"
+          },
+          "full_name": {
+            "title": "Full Name",
+            "type": "string"
+          },
+          "instructions": {
+            "default": "",
+            "title": "Instructions",
+            "type": "string"
+          },
+          "name": {
+            "default": "",
+            "title": "Name",
+            "type": "string"
+          },
+          "owner": {
+            "default": "",
+            "title": "Owner",
+            "type": "string"
+          },
+          "updated_at": {
+            "default": "",
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "full_name"
+        ],
+        "title": "AgentInstructions",
+        "type": "object"
+      },
+      "AgentInstructionsCreate": {
+        "properties": {
+          "full_name": {
+            "description": "GitHub repo in owner/name form",
+            "title": "Full Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "full_name"
+        ],
+        "title": "AgentInstructionsCreate",
+        "type": "object"
+      },
+      "AgentInstructionsUpdate": {
+        "properties": {
+          "instructions": {
+            "default": "",
+            "title": "Instructions",
+            "type": "string"
+          }
+        },
+        "title": "AgentInstructionsUpdate",
+        "type": "object"
+      },
+      "BlockSuggestionResponse": {
+        "properties": {
+          "options": {
+            "items": {
+              "$ref": "#/components/schemas/JsonObject"
+            },
+            "title": "Options",
+            "type": "array"
+          }
+        },
+        "required": [
+          "options"
+        ],
+        "title": "BlockSuggestionResponse",
+        "type": "object"
+      },
+      "ChallengeResponse": {
+        "properties": {
+          "challenge": {
+            "title": "Challenge",
+            "type": "string"
+          }
+        },
+        "required": [
+          "challenge"
+        ],
+        "title": "ChallengeResponse",
+        "type": "object"
+      },
+      "CommentBody": {
+        "properties": {
+          "anchor": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TextAnchor"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "body": {
+            "maxLength": 10000,
+            "minLength": 1,
+            "title": "Body",
+            "type": "string"
+          }
+        },
+        "required": [
+          "body"
+        ],
+        "title": "CommentBody",
+        "type": "object"
+      },
+      "CurrentsCredentialsUpdate": {
+        "description": "Connect Currents.dev with an organization API key.",
+        "properties": {
+          "api_key": {
+            "title": "Api Key",
+            "type": "string"
+          }
+        },
+        "required": [
+          "api_key"
+        ],
+        "title": "CurrentsCredentialsUpdate",
+        "type": "object"
+      },
+      "DashboardImageBody": {
+        "properties": {
+          "base64": {
+            "minLength": 1,
+            "title": "Base64",
+            "type": "string"
+          },
+          "fileName": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Filename"
+          },
+          "kind": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Kind"
+          },
+          "mimeType": {
+            "minLength": 1,
+            "title": "Mimetype",
+            "type": "string"
+          }
+        },
+        "required": [
+          "base64",
+          "mimeType"
+        ],
+        "title": "DashboardImageBody",
+        "type": "object"
+      },
+      "DatadogCredentialsUpdate": {
+        "description": "Connect Datadog with a scoped API + application key pair.",
+        "properties": {
+          "api_key": {
+            "title": "Api Key",
+            "type": "string"
+          },
+          "app_key": {
+            "title": "App Key",
+            "type": "string"
+          },
+          "site": {
+            "default": "datadoghq.com",
+            "title": "Site",
+            "type": "string"
+          }
+        },
+        "required": [
+          "api_key",
+          "app_key"
+        ],
+        "title": "DatadogCredentialsUpdate",
+        "type": "object"
+      },
+      "DesktopConnectExchange": {
+        "description": "Body of a desktop connect handoff redemption.",
+        "properties": {
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "verifier": {
+            "title": "Verifier",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "verifier"
+        ],
+        "title": "DesktopConnectExchange",
+        "type": "object"
+      },
+      "DesktopHandoffExchange": {
+        "properties": {
+          "code": {
+            "title": "Code",
+            "type": "string"
+          },
+          "verifier": {
+            "title": "Verifier",
+            "type": "string"
+          }
+        },
+        "required": [
+          "code",
+          "verifier"
+        ],
+        "title": "DesktopHandoffExchange",
+        "type": "object"
+      },
+      "EnabledReviewRepoUpdate": {
+        "properties": {
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "full_name": {
+            "title": "Full Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "full_name",
+          "enabled"
+        ],
+        "title": "EnabledReviewRepoUpdate",
+        "type": "object"
+      },
+      "Environment": {
+        "properties": {
+          "create_params": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/JsonValue"
+            },
+            "title": "Create Params",
+            "type": "object"
+          },
+          "created_at": {
+            "default": "",
+            "title": "Created At",
+            "type": "string"
+          },
+          "created_by": {
+            "default": "",
+            "title": "Created By",
+            "type": "string"
+          },
+          "fs_capacity_bytes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fs Capacity Bytes"
+          },
+          "last_captured_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Captured At"
+          },
+          "mem_bytes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mem Bytes"
+          },
+          "name": {
+            "default": "",
+            "title": "Name",
+            "type": "string"
+          },
+          "prompt": {
+            "default": "",
+            "title": "Prompt",
+            "type": "string"
+          },
+          "repos": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Repos",
+            "type": "array"
+          },
+          "slug": {
+            "title": "Slug",
+            "type": "string"
+          },
+          "snapshot_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Snapshot Id"
+          },
+          "snapshot_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Snapshot Name"
+          },
+          "snapshot_status": {
+            "default": "none",
+            "enum": [
+              "none",
+              "capturing",
+              "ready",
+              "failed"
+            ],
+            "title": "Snapshot Status",
+            "type": "string"
+          },
+          "source_sandbox_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Sandbox Id"
+          },
+          "status_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status Message"
+          },
+          "updated_at": {
+            "default": "",
+            "title": "Updated At",
+            "type": "string"
+          },
+          "vcpus": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vcpus"
+          }
+        },
+        "required": [
+          "slug"
+        ],
+        "title": "Environment",
+        "type": "object"
+      },
+      "EnvironmentCreate": {
+        "properties": {
+          "create_params": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/JsonValue"
+            },
+            "title": "Create Params",
+            "type": "object"
+          },
+          "fs_capacity_bytes": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fs Capacity Bytes"
+          },
+          "mem_bytes": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mem Bytes"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "prompt": {
+            "default": "",
+            "title": "Prompt",
+            "type": "string"
+          },
+          "repos": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Repos",
+            "type": "array"
+          },
+          "vcpus": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vcpus"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "EnvironmentCreate",
+        "type": "object"
+      },
+      "EnvironmentUpdate": {
+        "description": "Partial update: only the fields present are written.",
+        "properties": {
+          "create_params": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "$ref": "#/components/schemas/JsonValue"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Create Params"
+          },
+          "fs_capacity_bytes": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fs Capacity Bytes"
+          },
+          "mem_bytes": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mem Bytes"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "prompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prompt"
+          },
+          "repos": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Repos"
+          },
+          "vcpus": {
+            "anyOf": [
+              {
+                "exclusiveMinimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vcpus"
+          }
+        },
+        "title": "EnvironmentUpdate",
+        "type": "object"
+      },
+      "FeedbackResponse": {
+        "properties": {
+          "errors": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "title": "Errors",
+            "type": "object"
+          },
+          "response_action": {
+            "const": "errors",
+            "title": "Response Action",
+            "type": "string"
+          }
+        },
+        "title": "FeedbackResponse",
+        "type": "object"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "title": "Detail",
+            "type": "array"
+          }
+        },
+        "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "HealthResponse": {
+        "properties": {
+          "message": {
+            "title": "Message",
+            "type": "string"
+          },
+          "status": {
+            "const": "ok",
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "message"
+        ],
+        "title": "HealthResponse",
+        "type": "object"
+      },
+      "JsonObject": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "JsonValue": {},
+      "LangSmithCredentialsUpdate": {
+        "description": "Connect LangSmith with a read-scoped API key.",
+        "properties": {
+          "api_key": {
+            "title": "Api Key",
+            "type": "string"
+          },
+          "endpoint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Endpoint"
+          }
+        },
+        "required": [
+          "api_key"
+        ],
+        "title": "LangSmithCredentialsUpdate",
+        "type": "object"
+      },
+      "PlanRejection": {
+        "properties": {
+          "dispatch": {
+            "default": true,
+            "title": "Dispatch",
+            "type": "boolean"
+          }
+        },
+        "title": "PlanRejection",
+        "type": "object"
+      },
+      "PlanUpdate": {
+        "properties": {
+          "html": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Html"
+          },
+          "markdown": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Markdown"
+          }
+        },
+        "title": "PlanUpdate",
+        "type": "object"
+      },
+      "ProfileUpdate": {
+        "properties": {
+          "auto_fix_ci": {
+            "default": true,
+            "title": "Auto Fix Ci",
+            "type": "boolean"
+          },
+          "base_branch": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Branch"
+          },
+          "branch_prefix": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Branch Prefix"
+          },
+          "default_model": {
+            "title": "Default Model",
+            "type": "string"
+          },
+          "default_repo": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Repo"
+          },
+          "default_subagent_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Subagent Model"
+          },
+          "draft_prs": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Draft Prs"
+          },
+          "reasoning_effort": {
+            "title": "Reasoning Effort",
+            "type": "string"
+          },
+          "review_draft_prs": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Review Draft Prs"
+          },
+          "subagent_reasoning_effort": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Subagent Reasoning Effort"
+          }
+        },
+        "required": [
+          "default_model",
+          "reasoning_effort"
+        ],
+        "title": "ProfileUpdate",
+        "type": "object"
+      },
+      "PullRequestChecksRef": {
+        "properties": {
+          "number": {
+            "minimum": 1.0,
+            "title": "Number",
+            "type": "integer"
+          },
+          "repoFullName": {
+            "maxLength": 140,
+            "title": "Repofullname",
+            "type": "string"
+          }
+        },
+        "required": [
+          "repoFullName",
+          "number"
+        ],
+        "title": "PullRequestChecksRef",
+        "type": "object"
+      },
+      "PullRequestChecksRequest": {
+        "properties": {
+          "pullRequests": {
+            "items": {
+              "$ref": "#/components/schemas/PullRequestChecksRef"
+            },
+            "maxItems": 50,
+            "title": "Pullrequests",
+            "type": "array"
+          }
+        },
+        "title": "PullRequestChecksRequest",
+        "type": "object"
+      },
+      "PullRequestState": {
+        "description": "Live GitHub truth for one PR: check verdict plus open/merged/closed.",
+        "properties": {
+          "checks": {
+            "enum": [
+              "failing",
+              "passing",
+              "pending",
+              "unknown"
+            ],
+            "title": "Checks",
+            "type": "string"
+          },
+          "state": {
+            "anyOf": [
+              {
+                "enum": [
+                  "open",
+                  "draft",
+                  "merged",
+                  "closed"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "State"
+          }
+        },
+        "required": [
+          "checks",
+          "state"
+        ],
+        "title": "PullRequestState",
+        "type": "object"
+      },
+      "ReviewCommentCreate": {
+        "properties": {
+          "body": {
+            "title": "Body",
+            "type": "string"
+          },
+          "line": {
+            "title": "Line",
+            "type": "integer"
+          },
+          "path": {
+            "title": "Path",
+            "type": "string"
+          },
+          "side": {
+            "enum": [
+              "LEFT",
+              "RIGHT"
+            ],
+            "title": "Side",
+            "type": "string"
+          },
+          "start_line": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Line"
+          },
+          "start_side": {
+            "anyOf": [
+              {
+                "enum": [
+                  "LEFT",
+                  "RIGHT"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Side"
+          }
+        },
+        "required": [
+          "path",
+          "line",
+          "side",
+          "body"
+        ],
+        "title": "ReviewCommentCreate",
+        "type": "object"
+      },
+      "ReviewCommentUpdate": {
+        "properties": {
+          "body": {
+            "title": "Body",
+            "type": "string"
+          }
+        },
+        "required": [
+          "body"
+        ],
+        "title": "ReviewCommentUpdate",
+        "type": "object"
+      },
+      "ReviewStyle": {
+        "properties": {
+          "analysis_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Analysis Run Id"
+          },
+          "analysis_summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Analysis Summary"
+          },
+          "analysis_thread_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Analysis Thread Id"
+          },
+          "continual_cron_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Continual Cron Id"
+          },
+          "created_at": {
+            "default": "",
+            "title": "Created At",
+            "type": "string"
+          },
+          "created_by": {
+            "default": "",
+            "title": "Created By",
+            "type": "string"
+          },
+          "custom_prompt": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Custom Prompt"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "full_name": {
+            "title": "Full Name",
+            "type": "string"
+          },
+          "name": {
+            "default": "",
+            "title": "Name",
+            "type": "string"
+          },
+          "owner": {
+            "default": "",
+            "title": "Owner",
+            "type": "string"
+          },
+          "prs_sampled": {
+            "default": 0,
+            "title": "Prs Sampled",
+            "type": "integer"
+          },
+          "reviews_sampled": {
+            "default": 0,
+            "title": "Reviews Sampled",
+            "type": "integer"
+          },
+          "status": {
+            "default": "idle",
+            "enum": [
+              "idle",
+              "running",
+              "completed",
+              "failed"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "top_reviewers": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Top Reviewers",
+            "type": "array"
+          },
+          "updated_at": {
+            "default": "",
+            "title": "Updated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "full_name"
+        ],
+        "title": "ReviewStyle",
+        "type": "object"
+      },
+      "ReviewStyleCreate": {
+        "properties": {
+          "full_name": {
+            "description": "GitHub repo in owner/name form",
+            "title": "Full Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "full_name"
+        ],
+        "title": "ReviewStyleCreate",
+        "type": "object"
+      },
+      "ReviewStylePromptUpdate": {
+        "properties": {
+          "custom_prompt": {
+            "title": "Custom Prompt",
+            "type": "string"
+          }
+        },
+        "required": [
+          "custom_prompt"
+        ],
+        "title": "ReviewStylePromptUpdate",
+        "type": "object"
+      },
+      "SandboxSettingsUpdate": {
+        "properties": {
+          "base_snapshot_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Snapshot Id"
+          }
+        },
+        "title": "SandboxSettingsUpdate",
+        "type": "object"
+      },
+      "ScheduleCreateBody": {
+        "properties": {
+          "admin_thread": {
+            "default": false,
+            "title": "Admin Thread",
+            "type": "boolean"
+          },
+          "effort": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Effort"
+          },
+          "model_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "maxLength": 120,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "prompt": {
+            "maxLength": 20000,
+            "minLength": 1,
+            "title": "Prompt",
+            "type": "string"
+          },
+          "repo": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Repo"
+          },
+          "schedule": {
+            "maxLength": 120,
+            "minLength": 1,
+            "title": "Schedule",
+            "type": "string"
+          },
+          "slack_channel_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Slack Channel Id"
+          },
+          "slack_notification_mode": {
+            "default": "always",
+            "enum": [
+              "always",
+              "on_action"
+            ],
+            "title": "Slack Notification Mode",
+            "type": "string"
+          }
+        },
+        "required": [
+          "prompt",
+          "schedule"
+        ],
+        "title": "ScheduleCreateBody",
+        "type": "object"
+      },
+      "ScheduleUpdateBody": {
+        "properties": {
+          "admin_thread": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Admin Thread"
+          },
+          "effort": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Effort"
+          },
+          "enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Enabled"
+          },
+          "model_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "maxLength": 120,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "prompt": {
+            "anyOf": [
+              {
+                "maxLength": 20000,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prompt"
+          },
+          "repo": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Repo"
+          },
+          "schedule": {
+            "anyOf": [
+              {
+                "maxLength": 120,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Schedule"
+          },
+          "slack_channel_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Slack Channel Id"
+          },
+          "slack_notification_mode": {
+            "anyOf": [
+              {
+                "enum": [
+                  "always",
+                  "on_action"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Slack Notification Mode"
+          }
+        },
+        "title": "ScheduleUpdateBody",
+        "type": "object"
+      },
+      "SkillCreate": {
+        "properties": {
+          "description": {
+            "maxLength": 1024,
+            "minLength": 1,
+            "title": "Description",
+            "type": "string"
+          },
+          "instructions": {
+            "default": "",
+            "maxLength": 20000,
+            "title": "Instructions",
+            "type": "string"
+          },
+          "name": {
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "description"
+        ],
+        "title": "SkillCreate",
+        "type": "object"
+      },
+      "SkillUpdate": {
+        "properties": {
+          "description": {
+            "maxLength": 1024,
+            "minLength": 1,
+            "title": "Description",
+            "type": "string"
+          },
+          "instructions": {
+            "default": "",
+            "maxLength": 20000,
+            "title": "Instructions",
+            "type": "string"
+          }
+        },
+        "required": [
+          "description"
+        ],
+        "title": "SkillUpdate",
+        "type": "object"
+      },
+      "SlashCommandResponse": {
+        "properties": {
+          "response_type": {
+            "enum": [
+              "ephemeral",
+              "in_channel"
+            ],
+            "title": "Response Type",
+            "type": "string"
+          },
+          "text": {
+            "title": "Text",
+            "type": "string"
+          }
+        },
+        "required": [
+          "response_type",
+          "text"
+        ],
+        "title": "SlashCommandResponse",
+        "type": "object"
+      },
+      "TeamSettingsUpdate": {
+        "properties": {
+          "default_agent_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Agent Model"
+          },
+          "default_agent_reasoning_effort": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Agent Reasoning Effort"
+          },
+          "default_agent_subagent_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Agent Subagent Model"
+          },
+          "default_agent_subagent_reasoning_effort": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Agent Subagent Reasoning Effort"
+          },
+          "default_chat_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Chat Model"
+          },
+          "default_chat_reasoning_effort": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Chat Reasoning Effort"
+          },
+          "default_grouping_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Grouping Model"
+          },
+          "default_grouping_reasoning_effort": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Grouping Reasoning Effort"
+          },
+          "default_repo": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Repo"
+          },
+          "default_reviewer_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Reviewer Model"
+          },
+          "default_reviewer_reasoning_effort": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Reviewer Reasoning Effort"
+          },
+          "default_reviewer_subagent_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Reviewer Subagent Model"
+          },
+          "default_reviewer_subagent_reasoning_effort": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Reviewer Subagent Reasoning Effort"
+          },
+          "default_thread_title_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Thread Title Model"
+          },
+          "default_thread_title_reasoning_effort": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Thread Title Reasoning Effort"
+          },
+          "fable_enabled": {
+            "default": false,
+            "title": "Fable Enabled",
+            "type": "boolean"
+          },
+          "gateway_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gateway Enabled"
+          },
+          "org_guidelines": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Org Guidelines"
+          },
+          "pr_summaries": {
+            "default": true,
+            "title": "Pr Summaries",
+            "type": "boolean"
+          },
+          "review_draft_prs": {
+            "default": false,
+            "title": "Review Draft Prs",
+            "type": "boolean"
+          },
+          "review_trace_links": {
+            "default": true,
+            "title": "Review Trace Links",
+            "type": "boolean"
+          },
+          "review_tracing_project": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Review Tracing Project"
+          },
+          "transcription_model": {
+            "default": "gpt-transcribe",
+            "title": "Transcription Model",
+            "type": "string"
+          }
+        },
+        "title": "TeamSettingsUpdate",
+        "type": "object"
+      },
+      "TextAnchor": {
+        "properties": {
+          "context_after": {
+            "default": "",
+            "maxLength": 1000,
+            "title": "Context After",
+            "type": "string"
+          },
+          "context_before": {
+            "default": "",
+            "maxLength": 1000,
+            "title": "Context Before",
+            "type": "string"
+          },
+          "end": {
+            "exclusiveMinimum": 0.0,
+            "maximum": 2000000.0,
+            "title": "End",
+            "type": "integer"
+          },
+          "exact": {
+            "maxLength": 1000,
+            "minLength": 1,
+            "title": "Exact",
+            "type": "string"
+          },
+          "prefix": {
+            "maxLength": 64,
+            "title": "Prefix",
+            "type": "string"
+          },
+          "start": {
+            "maximum": 2000000.0,
+            "minimum": 0.0,
+            "title": "Start",
+            "type": "integer"
+          },
+          "suffix": {
+            "maxLength": 64,
+            "title": "Suffix",
+            "type": "string"
+          }
+        },
+        "required": [
+          "exact",
+          "prefix",
+          "suffix",
+          "start",
+          "end"
+        ],
+        "title": "TextAnchor",
+        "type": "object"
+      },
+      "ThreadMessageBody": {
+        "properties": {
+          "client_message_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Message Id"
+          },
+          "content": {
+            "default": "",
+            "maxLength": 20000,
+            "title": "Content",
+            "type": "string"
+          },
+          "effort": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Effort"
+          },
+          "images": {
+            "items": {
+              "$ref": "#/components/schemas/DashboardImageBody"
+            },
+            "title": "Images",
+            "type": "array"
+          },
+          "model_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Id"
+          },
+          "plan_mode": {
+            "default": false,
+            "title": "Plan Mode",
+            "type": "boolean"
+          }
+        },
+        "title": "ThreadMessageBody",
+        "type": "object"
+      },
+      "ThreadRenameBody": {
+        "properties": {
+          "title": {
+            "maxLength": 80,
+            "minLength": 1,
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "title"
+        ],
+        "title": "ThreadRenameBody",
+        "type": "object"
+      },
+      "ThreadResolveBody": {
+        "properties": {
+          "resolved": {
+            "default": true,
+            "title": "Resolved",
+            "type": "boolean"
+          }
+        },
+        "title": "ThreadResolveBody",
+        "type": "object"
+      },
+      "TranscriptionSettingsUpdate": {
+        "properties": {
+          "transcription_model": {
+            "default": "gpt-transcribe",
+            "title": "Transcription Model",
+            "type": "string"
+          }
+        },
+        "title": "TranscriptionSettingsUpdate",
+        "type": "object"
+      },
+      "UserInstructionsUpdate": {
+        "properties": {
+          "instructions": {
+            "default": "",
+            "maxLength": 20000,
+            "title": "Instructions",
+            "type": "string"
+          }
+        },
+        "title": "UserInstructionsUpdate",
+        "type": "object"
+      },
+      "UserLangSmithCredentialsUpdate": {
+        "additionalProperties": false,
+        "description": "Connect LangSmith with an API key.",
+        "properties": {
+          "api_key": {
+            "title": "Api Key",
+            "type": "string"
+          }
+        },
+        "required": [
+          "api_key"
+        ],
+        "title": "UserLangSmithCredentialsUpdate",
+        "type": "object"
+      },
+      "ValidationError": {
+        "properties": {
+          "ctx": {
+            "title": "Context",
+            "type": "object"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "title": "Location",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError",
+        "type": "object"
+      },
+      "WebhookResponse": {
+        "properties": {
+          "error_id": {
+            "title": "Error Id",
+            "type": "string"
+          },
+          "message": {
+            "title": "Message",
+            "type": "string"
+          },
+          "reason": {
+            "title": "Reason",
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "accepted",
+              "ignored",
+              "error"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "WebhookResponse",
+        "type": "object"
+      },
+      "WorkspaceMCPUpdate": {
+        "additionalProperties": false,
+        "properties": {
+          "allowed_tools": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Allowed Tools",
+            "type": "array"
+          },
+          "enabled": {
+            "default": true,
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "headers": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Headers"
+          },
+          "name": {
+            "pattern": "^[a-z][a-z0-9_-]{0,31}$",
+            "title": "Name",
+            "type": "string"
+          },
+          "transport": {
+            "default": "streamable_http",
+            "enum": [
+              "streamable_http",
+              "sse"
+            ],
+            "title": "Transport",
+            "type": "string"
+          },
+          "url": {
+            "maxLength": 2048,
+            "title": "Url",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "url"
+        ],
+        "title": "WorkspaceMCPUpdate",
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "title": "FastAPI",
+    "version": "0.1.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/dashboard/api/admin/evals/reviewer": {
+      "get": {
+        "description": "Read-only status for the reviewer eval (triggered from the GitHub Action).",
+        "operationId": "admin_get_reviewer_eval_dashboard_api_admin_evals_reviewer_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Admin Get Reviewer Eval Dashboard Api Admin Evals Reviewer Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Admin Get Reviewer Eval",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/admin/threads/{thread_id}/cancel": {
+      "post": {
+        "operationId": "admin_cancel_thread_dashboard_api_admin_threads__thread_id__cancel_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Admin Cancel Thread Dashboard Api Admin Threads  Thread Id  Cancel Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Admin Cancel Thread",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/admin/user-mappings": {
+      "get": {
+        "operationId": "admin_list_user_mappings_dashboard_api_admin_user_mappings_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 1,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "title": "Page Size",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Admin List User Mappings Dashboard Api Admin User Mappings Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Admin List User Mappings",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/admin/user-mappings/{github_login}": {
+      "delete": {
+        "operationId": "admin_delete_user_mapping_dashboard_api_admin_user_mappings__github_login__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "github_login",
+            "required": true,
+            "schema": {
+              "title": "Github Login",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "boolean"
+                  },
+                  "title": "Response Admin Delete User Mapping Dashboard Api Admin User Mappings  Github Login  Delete",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Admin Delete User Mapping",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/agent-instructions": {
+      "get": {
+        "operationId": "api_list_agent_instructions_dashboard_api_agent_instructions_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AgentInstructions"
+                  },
+                  "title": "Response Api List Agent Instructions Dashboard Api Agent Instructions Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Api List Agent Instructions",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "post": {
+        "operationId": "api_create_agent_instructions_dashboard_api_agent_instructions_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentInstructionsCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentInstructions"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Create Agent Instructions",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/agent-instructions/{full_name}": {
+      "delete": {
+        "operationId": "api_delete_agent_instructions_dashboard_api_agent_instructions__full_name__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "full_name",
+            "required": true,
+            "schema": {
+              "title": "Full Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Delete Agent Instructions",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "get": {
+        "operationId": "api_get_agent_instructions_dashboard_api_agent_instructions__full_name__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "full_name",
+            "required": true,
+            "schema": {
+              "title": "Full Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentInstructions"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Get Agent Instructions",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "put": {
+        "operationId": "api_update_agent_instructions_dashboard_api_agent_instructions__full_name__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "full_name",
+            "required": true,
+            "schema": {
+              "title": "Full Name",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentInstructionsUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentInstructions"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Update Agent Instructions",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/agent-usage-leaderboard": {
+      "get": {
+        "operationId": "api_agent_usage_leaderboard_dashboard_api_agent_usage_leaderboard_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "period",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": "30d",
+              "title": "Period"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Agent Usage Leaderboard Dashboard Api Agent Usage Leaderboard Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Agent Usage Leaderboard",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/auth/callback": {
+      "get": {
+        "operationId": "auth_callback_dashboard_api_auth_callback_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "state",
+            "required": true,
+            "schema": {
+              "title": "State",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Auth Callback",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/auth/desktop/exchange": {
+      "post": {
+        "operationId": "auth_desktop_exchange_dashboard_api_auth_desktop_exchange_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DesktopHandoffExchange"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Auth Desktop Exchange Dashboard Api Auth Desktop Exchange Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Auth Desktop Exchange",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/auth/login": {
+      "get": {
+        "operationId": "auth_login_dashboard_api_auth_login_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "redirect_to",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Redirect To"
+            }
+          },
+          {
+            "in": "query",
+            "name": "desktop",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Desktop",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "desktop_handoff",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Desktop Handoff"
+            }
+          },
+          {
+            "in": "query",
+            "name": "desktop_port",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maximum": 65535,
+                  "minimum": 1024,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Desktop Port"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Auth Login",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/auth/logout": {
+      "post": {
+        "operationId": "auth_logout_dashboard_api_auth_logout_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Auth Logout",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/enabled-review-repos": {
+      "get": {
+        "operationId": "api_list_enabled_review_repos_dashboard_api_enabled_review_repos_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "title": "Response Api List Enabled Review Repos Dashboard Api Enabled Review Repos Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Api List Enabled Review Repos",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "put": {
+        "operationId": "api_set_enabled_review_repo_dashboard_api_enabled_review_repos_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EnabledReviewRepoUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "title": "Response Api Set Enabled Review Repo Dashboard Api Enabled Review Repos Put",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Set Enabled Review Repo",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/environments": {
+      "get": {
+        "operationId": "api_list_environments_dashboard_api_environments_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api List Environments Dashboard Api Environments Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Api List Environments",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "post": {
+        "operationId": "api_create_environment_dashboard_api_environments_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EnvironmentCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Environment"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Create Environment",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/environments/options": {
+      "get": {
+        "description": "Pickable environments for any signed-in user: names only, no prompts.",
+        "operationId": "api_environment_options_dashboard_api_environments_options_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Environment Options Dashboard Api Environments Options Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Api Environment Options",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/environments/{slug}": {
+      "delete": {
+        "operationId": "api_delete_environment_dashboard_api_environments__slug__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "title": "Slug",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Delete Environment",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "get": {
+        "operationId": "api_get_environment_dashboard_api_environments__slug__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "title": "Slug",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Environment"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Get Environment",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "put": {
+        "operationId": "api_update_environment_dashboard_api_environments__slug__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "title": "Slug",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EnvironmentUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Environment"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Update Environment",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/me": {
+      "get": {
+        "operationId": "me_dashboard_api_me_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Me Dashboard Api Me Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Me",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/me/instructions": {
+      "delete": {
+        "operationId": "api_delete_my_instructions_dashboard_api_me_instructions_delete",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Api Delete My Instructions",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "get": {
+        "operationId": "api_get_my_instructions_dashboard_api_me_instructions_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Get My Instructions Dashboard Api Me Instructions Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Api Get My Instructions",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "put": {
+        "operationId": "api_put_my_instructions_dashboard_api_me_instructions_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserInstructionsUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Put My Instructions Dashboard Api Me Instructions Put",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Put My Instructions",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/my-credentials/currents": {
+      "delete": {
+        "operationId": "disconnect_my_currents_dashboard_api_my_credentials_currents_delete",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Disconnect My Currents Dashboard Api My Credentials Currents Delete",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Disconnect My Currents",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "get": {
+        "operationId": "get_my_currents_status_dashboard_api_my_credentials_currents_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get My Currents Status Dashboard Api My Credentials Currents Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get My Currents Status",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "put": {
+        "operationId": "connect_my_currents_dashboard_api_my_credentials_currents_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CurrentsCredentialsUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Connect My Currents Dashboard Api My Credentials Currents Put",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Connect My Currents",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/my-credentials/langsmith": {
+      "delete": {
+        "operationId": "disconnect_my_langsmith_dashboard_api_my_credentials_langsmith_delete",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Disconnect My Langsmith Dashboard Api My Credentials Langsmith Delete",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Disconnect My Langsmith",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "get": {
+        "operationId": "get_my_langsmith_status_dashboard_api_my_credentials_langsmith_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get My Langsmith Status Dashboard Api My Credentials Langsmith Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get My Langsmith Status",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "put": {
+        "operationId": "connect_my_langsmith_dashboard_api_my_credentials_langsmith_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserLangSmithCredentialsUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Connect My Langsmith Dashboard Api My Credentials Langsmith Put",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Connect My Langsmith",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/my-credentials/notion": {
+      "delete": {
+        "operationId": "disconnect_my_notion_dashboard_api_my_credentials_notion_delete",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Disconnect My Notion Dashboard Api My Credentials Notion Delete",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Disconnect My Notion",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "get": {
+        "operationId": "get_my_notion_status_dashboard_api_my_credentials_notion_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get My Notion Status Dashboard Api My Credentials Notion Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get My Notion Status",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/my-mapping": {
+      "get": {
+        "description": "Return the logged-in user's own GitHub\u2194Slack mapping (or empty).",
+        "operationId": "get_my_mapping_dashboard_api_my_mapping_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get My Mapping Dashboard Api My Mapping Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get My Mapping",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/notion/callback": {
+      "get": {
+        "operationId": "notion_callback_dashboard_api_notion_callback_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "state",
+            "required": true,
+            "schema": {
+              "title": "State",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "code",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Code"
+            }
+          },
+          {
+            "in": "query",
+            "name": "error",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Error"
+            }
+          },
+          {
+            "in": "query",
+            "name": "error_description",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Error Description"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Notion Callback",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/notion/desktop/exchange": {
+      "post": {
+        "description": "Finish a desktop Notion connection with the app's own session.",
+        "operationId": "notion_desktop_exchange_dashboard_api_notion_desktop_exchange_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DesktopConnectExchange"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Notion Desktop Exchange Dashboard Api Notion Desktop Exchange Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Notion Desktop Exchange",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/notion/login": {
+      "get": {
+        "operationId": "notion_login_dashboard_api_notion_login_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "desktop_handoff",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Desktop Handoff"
+            }
+          },
+          {
+            "in": "query",
+            "name": "desktop_port",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maximum": 65535,
+                  "minimum": 1024,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Desktop Port"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Notion Login",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/options": {
+      "get": {
+        "operationId": "options_dashboard_api_options_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Options Dashboard Api Options Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Options",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/organization-skills": {
+      "get": {
+        "operationId": "api_list_organization_skills_dashboard_api_organization_skills_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 256,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api List Organization Skills Dashboard Api Organization Skills Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api List Organization Skills",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "post": {
+        "operationId": "api_create_organization_skill_dashboard_api_organization_skills_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SkillCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Create Organization Skill Dashboard Api Organization Skills Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Create Organization Skill",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/organization-skills/{name}": {
+      "delete": {
+        "operationId": "api_delete_organization_skill_dashboard_api_organization_skills__name__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "title": "Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Delete Organization Skill",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "put": {
+        "operationId": "api_update_organization_skill_dashboard_api_organization_skills__name__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "title": "Name",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SkillUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Update Organization Skill Dashboard Api Organization Skills  Name  Put",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Update Organization Skill",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/plan/{thread_id}": {
+      "get": {
+        "operationId": "get_plan_dashboard_api_plan__thread_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Plan Dashboard Api Plan  Thread Id  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Plan",
+        "tags": [
+          "plan"
+        ]
+      },
+      "put": {
+        "description": "Save an edited HTML artifact while preserving review comments.",
+        "operationId": "update_plan_dashboard_api_plan__thread_id__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlanUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Update Plan Dashboard Api Plan  Thread Id  Put",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Plan",
+        "tags": [
+          "plan"
+        ]
+      }
+    },
+    "/dashboard/api/plan/{thread_id}/approve": {
+      "post": {
+        "operationId": "approve_plan_dashboard_api_plan__thread_id__approve_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Approve Plan Dashboard Api Plan  Thread Id  Approve Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Approve Plan",
+        "tags": [
+          "plan"
+        ]
+      }
+    },
+    "/dashboard/api/plan/{thread_id}/comments": {
+      "get": {
+        "operationId": "get_plan_comments_dashboard_api_plan__thread_id__comments_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Plan Comments Dashboard Api Plan  Thread Id  Comments Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Plan Comments",
+        "tags": [
+          "plan"
+        ]
+      },
+      "post": {
+        "operationId": "post_plan_comment_dashboard_api_plan__thread_id__comments_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CommentBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Post Plan Comment Dashboard Api Plan  Thread Id  Comments Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Post Plan Comment",
+        "tags": [
+          "plan"
+        ]
+      }
+    },
+    "/dashboard/api/plan/{thread_id}/comments/{comment_id}": {
+      "delete": {
+        "operationId": "remove_plan_comment_dashboard_api_plan__thread_id__comments__comment_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "comment_id",
+            "required": true,
+            "schema": {
+              "title": "Comment Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Remove Plan Comment Dashboard Api Plan  Thread Id  Comments  Comment Id  Delete",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Remove Plan Comment",
+        "tags": [
+          "plan"
+        ]
+      }
+    },
+    "/dashboard/api/plan/{thread_id}/reject": {
+      "post": {
+        "operationId": "reject_plan_dashboard_api_plan__thread_id__reject_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/PlanRejection"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Rejection"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Reject Plan Dashboard Api Plan  Thread Id  Reject Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Reject Plan",
+        "tags": [
+          "plan"
+        ]
+      }
+    },
+    "/dashboard/api/profile": {
+      "get": {
+        "operationId": "get_my_profile_dashboard_api_profile_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get My Profile Dashboard Api Profile Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get My Profile",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "put": {
+        "operationId": "put_my_profile_dashboard_api_profile_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProfileUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Put My Profile Dashboard Api Profile Put",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Put My Profile",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/repos": {
+      "get": {
+        "description": "List repos where Open SWE is installed and the user has access.\n\nServed from the per-login cache (stale-while-revalidate) unless\n``refresh=true``, because the fan-out over every installation takes 10s+\nfor users with hundreds of accessible repos.",
+        "operationId": "list_repos_dashboard_api_repos_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "refresh",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Refresh",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Repos Dashboard Api Repos Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Repos",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/review-styles": {
+      "get": {
+        "operationId": "api_list_review_styles_dashboard_api_review_styles_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ReviewStyle"
+                  },
+                  "title": "Response Api List Review Styles Dashboard Api Review Styles Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Api List Review Styles",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "post": {
+        "operationId": "api_create_review_style_dashboard_api_review_styles_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReviewStyleCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReviewStyle"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Create Review Style",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/review-styles/{full_name}": {
+      "delete": {
+        "operationId": "api_delete_review_style_dashboard_api_review_styles__full_name__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "full_name",
+            "required": true,
+            "schema": {
+              "title": "Full Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Delete Review Style",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "get": {
+        "operationId": "api_get_review_style_dashboard_api_review_styles__full_name__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "full_name",
+            "required": true,
+            "schema": {
+              "title": "Full Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReviewStyle"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Get Review Style",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "put": {
+        "operationId": "api_update_review_style_prompt_dashboard_api_review_styles__full_name__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "full_name",
+            "required": true,
+            "schema": {
+              "title": "Full Name",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReviewStylePromptUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReviewStyle"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Update Review Style Prompt",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/review-styles/{full_name}/analyze": {
+      "post": {
+        "operationId": "api_analyze_review_style_dashboard_api_review_styles__full_name__analyze_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "full_name",
+            "required": true,
+            "schema": {
+              "title": "Full Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReviewStyle"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Analyze Review Style",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/review-styles/{full_name}/cancel": {
+      "post": {
+        "operationId": "api_cancel_review_style_dashboard_api_review_styles__full_name__cancel_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "full_name",
+            "required": true,
+            "schema": {
+              "title": "Full Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReviewStyle"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Cancel Review Style",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/reviews": {
+      "get": {
+        "operationId": "api_list_reviews_dashboard_api_reviews_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "title": "Page",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "mine",
+            "required": false,
+            "schema": {
+              "default": true,
+              "title": "Mine",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api List Reviews Dashboard Api Reviews Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api List Reviews",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/reviews/{owner}/{repo}/{pr_number}": {
+      "get": {
+        "operationId": "api_get_review_dashboard_api_reviews__owner___repo___pr_number__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "schema": {
+              "title": "Owner",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "schema": {
+              "title": "Repo",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pr_number",
+            "required": true,
+            "schema": {
+              "title": "Pr Number",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Get Review Dashboard Api Reviews  Owner   Repo   Pr Number  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Get Review",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/reviews/{owner}/{repo}/{pr_number}/chat": {
+      "get": {
+        "operationId": "api_get_review_chat_dashboard_api_reviews__owner___repo___pr_number__chat_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "schema": {
+              "title": "Owner",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "schema": {
+              "title": "Repo",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pr_number",
+            "required": true,
+            "schema": {
+              "title": "Pr Number",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Get Review Chat Dashboard Api Reviews  Owner   Repo   Pr Number  Chat Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Get Review Chat",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/reviews/{owner}/{repo}/{pr_number}/chat/threads": {
+      "get": {
+        "operationId": "api_list_review_chat_threads_dashboard_api_reviews__owner___repo___pr_number__chat_threads_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "schema": {
+              "title": "Owner",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "schema": {
+              "title": "Repo",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pr_number",
+            "required": true,
+            "schema": {
+              "title": "Pr Number",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api List Review Chat Threads Dashboard Api Reviews  Owner   Repo   Pr Number  Chat Threads Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api List Review Chat Threads",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/reviews/{owner}/{repo}/{pr_number}/chat/threads/{thread_id}": {
+      "delete": {
+        "operationId": "api_delete_review_chat_thread_dashboard_api_reviews__owner___repo___pr_number__chat_threads__thread_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "schema": {
+              "title": "Owner",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "schema": {
+              "title": "Repo",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pr_number",
+            "required": true,
+            "schema": {
+              "title": "Pr Number",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Delete Review Chat Thread",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/reviews/{owner}/{repo}/{pr_number}/chat/threads/{thread_id}/commands": {
+      "post": {
+        "operationId": "api_review_chat_commands_dashboard_api_reviews__owner___repo___pr_number__chat_threads__thread_id__commands_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "schema": {
+              "title": "Owner",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "schema": {
+              "title": "Repo",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pr_number",
+            "required": true,
+            "schema": {
+              "title": "Pr Number",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Review Chat Commands",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/reviews/{owner}/{repo}/{pr_number}/chat/threads/{thread_id}/history": {
+      "post": {
+        "operationId": "api_review_chat_history_dashboard_api_reviews__owner___repo___pr_number__chat_threads__thread_id__history_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "schema": {
+              "title": "Owner",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "schema": {
+              "title": "Repo",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pr_number",
+            "required": true,
+            "schema": {
+              "title": "Pr Number",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Review Chat History",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/reviews/{owner}/{repo}/{pr_number}/chat/threads/{thread_id}/state": {
+      "get": {
+        "operationId": "api_review_chat_state_dashboard_api_reviews__owner___repo___pr_number__chat_threads__thread_id__state_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "schema": {
+              "title": "Owner",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "schema": {
+              "title": "Repo",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pr_number",
+            "required": true,
+            "schema": {
+              "title": "Pr Number",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Review Chat State",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/reviews/{owner}/{repo}/{pr_number}/chat/threads/{thread_id}/stream/events": {
+      "post": {
+        "operationId": "api_review_chat_stream_events_dashboard_api_reviews__owner___repo___pr_number__chat_threads__thread_id__stream_events_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "schema": {
+              "title": "Owner",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "schema": {
+              "title": "Repo",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pr_number",
+            "required": true,
+            "schema": {
+              "title": "Pr Number",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Review Chat Stream Events",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/reviews/{owner}/{repo}/{pr_number}/comments": {
+      "get": {
+        "operationId": "api_list_review_comments_dashboard_api_reviews__owner___repo___pr_number__comments_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "schema": {
+              "title": "Owner",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "schema": {
+              "title": "Repo",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pr_number",
+            "required": true,
+            "schema": {
+              "title": "Pr Number",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api List Review Comments Dashboard Api Reviews  Owner   Repo   Pr Number  Comments Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api List Review Comments",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "post": {
+        "operationId": "api_create_review_comment_dashboard_api_reviews__owner___repo___pr_number__comments_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "schema": {
+              "title": "Owner",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "schema": {
+              "title": "Repo",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pr_number",
+            "required": true,
+            "schema": {
+              "title": "Pr Number",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReviewCommentCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Create Review Comment Dashboard Api Reviews  Owner   Repo   Pr Number  Comments Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Create Review Comment",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/reviews/{owner}/{repo}/{pr_number}/comments/{comment_id}": {
+      "patch": {
+        "operationId": "api_update_review_comment_dashboard_api_reviews__owner___repo___pr_number__comments__comment_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "schema": {
+              "title": "Owner",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "schema": {
+              "title": "Repo",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pr_number",
+            "required": true,
+            "schema": {
+              "title": "Pr Number",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "path",
+            "name": "comment_id",
+            "required": true,
+            "schema": {
+              "title": "Comment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReviewCommentUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Update Review Comment Dashboard Api Reviews  Owner   Repo   Pr Number  Comments  Comment Id  Patch",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Update Review Comment",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/reviews/{owner}/{repo}/{pr_number}/diff": {
+      "get": {
+        "operationId": "api_get_review_diff_dashboard_api_reviews__owner___repo___pr_number__diff_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "schema": {
+              "title": "Owner",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "schema": {
+              "title": "Repo",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pr_number",
+            "required": true,
+            "schema": {
+              "title": "Pr Number",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Get Review Diff Dashboard Api Reviews  Owner   Repo   Pr Number  Diff Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Get Review Diff",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/reviews/{owner}/{repo}/{pr_number}/image": {
+      "get": {
+        "operationId": "api_get_review_image_dashboard_api_reviews__owner___repo___pr_number__image_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "schema": {
+              "title": "Owner",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "schema": {
+              "title": "Repo",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pr_number",
+            "required": true,
+            "schema": {
+              "title": "Pr Number",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "url",
+            "required": true,
+            "schema": {
+              "title": "Url",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Get Review Image",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/reviews/{owner}/{repo}/{pr_number}/re-review": {
+      "post": {
+        "operationId": "api_re_review_dashboard_api_reviews__owner___repo___pr_number__re_review_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "schema": {
+              "title": "Owner",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "schema": {
+              "title": "Repo",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pr_number",
+            "required": true,
+            "schema": {
+              "title": "Pr Number",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Re Review Dashboard Api Reviews  Owner   Repo   Pr Number  Re Review Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Re Review",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/reviews/{owner}/{repo}/{pr_number}/resolve-trace": {
+      "post": {
+        "operationId": "api_resolve_trace_dashboard_api_reviews__owner___repo___pr_number__resolve_trace_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "schema": {
+              "title": "Owner",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "repo",
+            "required": true,
+            "schema": {
+              "title": "Repo",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "pr_number",
+            "required": true,
+            "schema": {
+              "title": "Pr Number",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Resolve Trace Dashboard Api Reviews  Owner   Repo   Pr Number  Resolve Trace Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Resolve Trace",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/sandbox-settings": {
+      "get": {
+        "operationId": "api_get_sandbox_settings_dashboard_api_sandbox_settings_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Get Sandbox Settings Dashboard Api Sandbox Settings Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Api Get Sandbox Settings",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "put": {
+        "operationId": "api_set_sandbox_settings_dashboard_api_sandbox_settings_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SandboxSettingsUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Set Sandbox Settings Dashboard Api Sandbox Settings Put",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Set Sandbox Settings",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/schedules": {
+      "get": {
+        "operationId": "api_list_schedules_dashboard_api_schedules_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  "title": "Response Api List Schedules Dashboard Api Schedules Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Api List Schedules",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "post": {
+        "operationId": "api_create_schedule_dashboard_api_schedules_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScheduleCreateBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Create Schedule Dashboard Api Schedules Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Create Schedule",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/schedules/{schedule_id}": {
+      "delete": {
+        "operationId": "api_delete_schedule_dashboard_api_schedules__schedule_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "schedule_id",
+            "required": true,
+            "schema": {
+              "title": "Schedule Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Delete Schedule",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "patch": {
+        "operationId": "api_update_schedule_dashboard_api_schedules__schedule_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "schedule_id",
+            "required": true,
+            "schema": {
+              "title": "Schedule Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScheduleUpdateBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Update Schedule Dashboard Api Schedules  Schedule Id  Patch",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Update Schedule",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/schedules/{schedule_id}/trigger": {
+      "post": {
+        "operationId": "api_trigger_schedule_dashboard_api_schedules__schedule_id__trigger_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "schedule_id",
+            "required": true,
+            "schema": {
+              "title": "Schedule Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Trigger Schedule Dashboard Api Schedules  Schedule Id  Trigger Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Trigger Schedule",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/skills": {
+      "get": {
+        "operationId": "api_list_skills_dashboard_api_skills_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api List Skills Dashboard Api Skills Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api List Skills",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "post": {
+        "operationId": "api_create_skill_dashboard_api_skills_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SkillCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Create Skill Dashboard Api Skills Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Create Skill",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/skills/{name}": {
+      "delete": {
+        "operationId": "api_delete_skill_dashboard_api_skills__name__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "title": "Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Delete Skill",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "put": {
+        "operationId": "api_update_skill_dashboard_api_skills__name__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "title": "Name",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SkillUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Update Skill Dashboard Api Skills  Name  Put",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Update Skill",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/slack/callback": {
+      "get": {
+        "description": "Link the verified Slack identity to the logged-in GitHub user.\n\nThe Slack member id and email come from Slack's verified OIDC claims, so a\nuser can only ever link their own Slack account \u2014 no self-asserted values.",
+        "operationId": "slack_callback_dashboard_api_slack_callback_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "code",
+            "required": true,
+            "schema": {
+              "title": "Code",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "state",
+            "required": true,
+            "schema": {
+              "title": "State",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Slack Callback",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/slack/desktop/exchange": {
+      "post": {
+        "description": "Finish a desktop Slack link with the app's own session.",
+        "operationId": "slack_desktop_exchange_dashboard_api_slack_desktop_exchange_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DesktopConnectExchange"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Slack Desktop Exchange Dashboard Api Slack Desktop Exchange Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Slack Desktop Exchange",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/slack/login": {
+      "get": {
+        "description": "Start the Sign in with Slack flow to link the current GitHub account.",
+        "operationId": "slack_login_dashboard_api_slack_login_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "desktop_handoff",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Desktop Handoff"
+            }
+          },
+          {
+            "in": "query",
+            "name": "desktop_port",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maximum": 65535,
+                  "minimum": 1024,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Desktop Port"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Slack Login",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/team-credentials": {
+      "get": {
+        "operationId": "api_get_team_credentials_dashboard_api_team_credentials_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Get Team Credentials Dashboard Api Team Credentials Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Api Get Team Credentials",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/team-credentials/datadog": {
+      "delete": {
+        "operationId": "api_disconnect_datadog_dashboard_api_team_credentials_datadog_delete",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Disconnect Datadog Dashboard Api Team Credentials Datadog Delete",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Api Disconnect Datadog",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "put": {
+        "operationId": "api_connect_datadog_dashboard_api_team_credentials_datadog_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DatadogCredentialsUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Connect Datadog Dashboard Api Team Credentials Datadog Put",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Connect Datadog",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/team-credentials/langsmith": {
+      "delete": {
+        "operationId": "api_disconnect_langsmith_dashboard_api_team_credentials_langsmith_delete",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Disconnect Langsmith Dashboard Api Team Credentials Langsmith Delete",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Api Disconnect Langsmith",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "put": {
+        "operationId": "api_connect_langsmith_dashboard_api_team_credentials_langsmith_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LangSmithCredentialsUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Connect Langsmith Dashboard Api Team Credentials Langsmith Put",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Connect Langsmith",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/team-settings": {
+      "get": {
+        "operationId": "api_get_team_settings_dashboard_api_team_settings_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Get Team Settings Dashboard Api Team Settings Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Api Get Team Settings",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "put": {
+        "operationId": "api_put_team_settings_dashboard_api_team_settings_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TeamSettingsUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Put Team Settings Dashboard Api Team Settings Put",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Put Team Settings",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/team-settings/transcription": {
+      "put": {
+        "operationId": "api_put_transcription_settings_dashboard_api_team_settings_transcription_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TranscriptionSettingsUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Put Transcription Settings Dashboard Api Team Settings Transcription Put",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Put Transcription Settings",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/threads": {
+      "get": {
+        "operationId": "api_list_threads_dashboard_api_threads_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "all",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "All",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  "title": "Response Api List Threads Dashboard Api Threads Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api List Threads",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/threads/page": {
+      "get": {
+        "operationId": "api_list_threads_page_dashboard_api_threads_page_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 25,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "all",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "All",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "resolved",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Resolved"
+            }
+          },
+          {
+            "in": "query",
+            "name": "viewed",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Viewed"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Source"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Q"
+            }
+          },
+          {
+            "in": "query",
+            "name": "scope",
+            "required": false,
+            "schema": {
+              "default": "all",
+              "enum": [
+                "all",
+                "interactive",
+                "automation"
+              ],
+              "title": "Scope",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "automation_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Automation Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "repo",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Repo"
+            }
+          },
+          {
+            "in": "query",
+            "name": "ownerless",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Ownerless",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort_by",
+            "required": false,
+            "schema": {
+              "default": "updated_at",
+              "enum": [
+                "created_at",
+                "updated_at"
+              ],
+              "title": "Sort By",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api List Threads Page Dashboard Api Threads Page Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api List Threads Page",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/threads/pinned": {
+      "get": {
+        "operationId": "api_list_pinned_threads_dashboard_api_threads_pinned_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  "title": "Response Api List Pinned Threads Dashboard Api Threads Pinned Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Api List Pinned Threads",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/threads/projects": {
+      "get": {
+        "operationId": "api_list_thread_projects_dashboard_api_threads_projects_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "include_resolved",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Resolved",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "include_automations",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Automations",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "all",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "All",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  "title": "Response Api List Thread Projects Dashboard Api Threads Projects Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api List Thread Projects",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/threads/pull-request-checks": {
+      "post": {
+        "operationId": "api_get_pull_request_checks_dashboard_api_threads_pull_request_checks_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PullRequestChecksRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "$ref": "#/components/schemas/PullRequestState"
+                  },
+                  "title": "Response Api Get Pull Request Checks Dashboard Api Threads Pull Request Checks Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Get Pull Request Checks",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/threads/{thread_id}": {
+      "delete": {
+        "operationId": "api_delete_thread_dashboard_api_threads__thread_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Delete Thread",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "get": {
+        "operationId": "api_get_thread_dashboard_api_threads__thread_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "mark_viewed",
+            "required": false,
+            "schema": {
+              "default": true,
+              "title": "Mark Viewed",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Get Thread Dashboard Api Threads  Thread Id  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Get Thread",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "patch": {
+        "operationId": "api_rename_thread_dashboard_api_threads__thread_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ThreadRenameBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Rename Thread Dashboard Api Threads  Thread Id  Patch",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Rename Thread",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/threads/{thread_id}/branch-diff": {
+      "get": {
+        "operationId": "api_get_thread_branch_diff_dashboard_api_threads__thread_id__branch_diff_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Get Thread Branch Diff Dashboard Api Threads  Thread Id  Branch Diff Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Get Thread Branch Diff",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/threads/{thread_id}/cancel": {
+      "post": {
+        "operationId": "api_cancel_thread_dashboard_api_threads__thread_id__cancel_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Cancel Thread Dashboard Api Threads  Thread Id  Cancel Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Cancel Thread",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/threads/{thread_id}/commands": {
+      "post": {
+        "operationId": "api_thread_commands_dashboard_api_threads__thread_id__commands_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Thread Commands",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/threads/{thread_id}/history": {
+      "post": {
+        "operationId": "api_thread_history_dashboard_api_threads__thread_id__history_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Thread History",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/threads/{thread_id}/messages": {
+      "post": {
+        "operationId": "api_send_thread_message_dashboard_api_threads__thread_id__messages_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ThreadMessageBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Send Thread Message Dashboard Api Threads  Thread Id  Messages Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Send Thread Message",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/threads/{thread_id}/pin": {
+      "delete": {
+        "operationId": "api_unpin_thread_dashboard_api_threads__thread_id__pin_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Unpin Thread",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "post": {
+        "operationId": "api_pin_thread_dashboard_api_threads__thread_id__pin_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Pin Thread",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/threads/{thread_id}/pr-diff": {
+      "get": {
+        "operationId": "api_get_thread_pr_diff_dashboard_api_threads__thread_id__pr_diff_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Get Thread Pr Diff Dashboard Api Threads  Thread Id  Pr Diff Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Get Thread Pr Diff",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/threads/{thread_id}/pull-request-context": {
+      "get": {
+        "operationId": "api_get_thread_pull_request_context_dashboard_api_threads__thread_id__pull_request_context_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "repo_full_name",
+            "required": true,
+            "schema": {
+              "title": "Repo Full Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "number",
+            "required": true,
+            "schema": {
+              "title": "Number",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Get Thread Pull Request Context Dashboard Api Threads  Thread Id  Pull Request Context Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Get Thread Pull Request Context",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/threads/{thread_id}/pull-request-status": {
+      "get": {
+        "operationId": "api_get_thread_pull_request_status_dashboard_api_threads__thread_id__pull_request_status_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Get Thread Pull Request Status Dashboard Api Threads  Thread Id  Pull Request Status Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Get Thread Pull Request Status",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/threads/{thread_id}/recovery.patch": {
+      "get": {
+        "operationId": "api_get_thread_recovery_patch_dashboard_api_threads__thread_id__recovery_patch_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Get Thread Recovery Patch",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/threads/{thread_id}/resolve": {
+      "post": {
+        "operationId": "api_resolve_thread_dashboard_api_threads__thread_id__resolve_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ThreadResolveBody"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Resolve Thread Dashboard Api Threads  Thread Id  Resolve Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Resolve Thread",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/threads/{thread_id}/runs/{run_id}/cancel": {
+      "post": {
+        "operationId": "api_cancel_thread_run_dashboard_api_threads__thread_id__runs__run_id__cancel_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "run_id",
+            "required": true,
+            "schema": {
+              "title": "Run Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "wait",
+            "required": false,
+            "schema": {
+              "default": "0",
+              "title": "Wait",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "action",
+            "required": false,
+            "schema": {
+              "default": "interrupt",
+              "title": "Action",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Cancel Thread Run",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/threads/{thread_id}/state": {
+      "get": {
+        "operationId": "api_get_thread_state_dashboard_api_threads__thread_id__state_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Get Thread State",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/threads/{thread_id}/stream/events": {
+      "post": {
+        "operationId": "api_thread_stream_events_dashboard_api_threads__thread_id__stream_events_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Thread Stream Events",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/threads/{thread_id}/terminal/connect": {
+      "post": {
+        "operationId": "api_thread_terminal_connection_dashboard_api_threads__thread_id__terminal_connect_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Api Thread Terminal Connection Dashboard Api Threads  Thread Id  Terminal Connect Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Thread Terminal Connection",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/threads/{thread_id}/working-tree-diff": {
+      "get": {
+        "operationId": "api_get_thread_working_tree_diff_dashboard_api_threads__thread_id__working_tree_diff_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Get Thread Working Tree Diff Dashboard Api Threads  Thread Id  Working Tree Diff Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Get Thread Working Tree Diff",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/voice/transcriptions": {
+      "post": {
+        "operationId": "create_voice_transcription_dashboard_api_voice_transcriptions_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Create Voice Transcription Dashboard Api Voice Transcriptions Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Create Voice Transcription",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/workflow-approval/{thread_id}": {
+      "get": {
+        "operationId": "list_workflow_push_approvals_dashboard_api_workflow_approval__thread_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Workflow Push Approvals Dashboard Api Workflow Approval  Thread Id  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Workflow Push Approvals",
+        "tags": [
+          "workflow-approval"
+        ]
+      }
+    },
+    "/dashboard/api/workflow-approval/{thread_id}/{fingerprint}/approve": {
+      "post": {
+        "operationId": "approve_workflow_push_dashboard_api_workflow_approval__thread_id___fingerprint__approve_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "fingerprint",
+            "required": true,
+            "schema": {
+              "title": "Fingerprint",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Approve Workflow Push Dashboard Api Workflow Approval  Thread Id   Fingerprint  Approve Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Approve Workflow Push",
+        "tags": [
+          "workflow-approval"
+        ]
+      }
+    },
+    "/dashboard/api/workflow-approval/{thread_id}/{fingerprint}/reject": {
+      "post": {
+        "operationId": "reject_workflow_push_dashboard_api_workflow_approval__thread_id___fingerprint__reject_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "fingerprint",
+            "required": true,
+            "schema": {
+              "title": "Fingerprint",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Reject Workflow Push Dashboard Api Workflow Approval  Thread Id   Fingerprint  Reject Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Reject Workflow Push",
+        "tags": [
+          "workflow-approval"
+        ]
+      }
+    },
+    "/dashboard/api/workspace-mcps": {
+      "get": {
+        "operationId": "api_list_workspace_mcps_dashboard_api_workspace_mcps_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "additionalProperties": true,
+                    "type": "object"
+                  },
+                  "title": "Response Api List Workspace Mcps Dashboard Api Workspace Mcps Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Api List Workspace Mcps",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/workspace-mcps/{name}": {
+      "delete": {
+        "operationId": "api_delete_workspace_mcp_dashboard_api_workspace_mcps__name__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "title": "Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Delete Workspace Mcp",
+        "tags": [
+          "dashboard"
+        ]
+      },
+      "put": {
+        "operationId": "api_save_workspace_mcp_dashboard_api_workspace_mcps__name__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "title": "Name",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkspaceMCPUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Save Workspace Mcp Dashboard Api Workspace Mcps  Name  Put",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Save Workspace Mcp",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/workspace-mcps/{name}/discover": {
+      "post": {
+        "operationId": "api_discover_workspace_mcp_dashboard_api_workspace_mcps__name__discover_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "title": "Name",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/WorkspaceMCPUpdate"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Update"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "type": "object"
+                  },
+                  "title": "Response Api Discover Workspace Mcp Dashboard Api Workspace Mcps  Name  Discover Post",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Discover Workspace Mcp",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/workspace-mcps/{name}/headers/reveal": {
+      "post": {
+        "operationId": "api_reveal_workspace_mcp_headers_dashboard_api_workspace_mcps__name__headers_reveal_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "title": "Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Api Reveal Workspace Mcp Headers",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/health": {
+      "get": {
+        "operationId": "health_check_health_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Health Check Health Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Health Check"
+      }
+    },
+    "/webhooks/github": {
+      "post": {
+        "description": "Handle GitHub webhooks for issue and PR events that tag @open-swe.",
+        "operationId": "github_webhook_webhooks_github_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Github Webhook Webhooks Github Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Github Webhook"
+      }
+    },
+    "/webhooks/linear": {
+      "get": {
+        "description": "Verify endpoint for Linear webhook setup.",
+        "operationId": "linear_webhook_verify_webhooks_linear_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Linear Webhook Verify Webhooks Linear Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Linear Webhook Verify"
+      },
+      "post": {
+        "description": "Handle Linear webhooks.\n\nTriggers a new LangGraph run when an issue gets the 'open-swe' label added.",
+        "operationId": "linear_webhook_webhooks_linear_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Linear Webhook Webhooks Linear Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Linear Webhook"
+      }
+    },
+    "/webhooks/run-complete": {
+      "post": {
+        "operationId": "run_complete_webhook_webhooks_run_complete_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Run Complete Webhook Webhooks Run Complete Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Run Complete Webhook"
+      }
+    },
+    "/webhooks/slack": {
+      "get": {
+        "description": "Verify endpoint for Slack webhook setup.",
+        "operationId": "slack_webhook_verify_webhooks_slack_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Slack Webhook Verify"
+      },
+      "post": {
+        "description": "Handle Slack Event API webhooks for app mentions.",
+        "operationId": "slack_webhook_webhooks_slack_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/WebhookResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ChallengeResponse"
+                    }
+                  ],
+                  "title": "Response Slack Webhook Webhooks Slack Post"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Slack Webhook"
+      }
+    },
+    "/webhooks/slack/code-channel-commands": {
+      "post": {
+        "description": "Handle runtime slash commands registered for a Slack code channel.",
+        "operationId": "slack_code_channel_command_webhooks_slack_code_channel_commands_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SlashCommandResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Slack Code Channel Command"
+      }
+    },
+    "/webhooks/slack/interactivity": {
+      "post": {
+        "description": "Handle Slack Block Kit interactions.",
+        "operationId": "slack_interactivity_webhooks_slack_interactivity_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/WebhookResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/BlockSuggestionResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/FeedbackResponse"
+                    }
+                  ],
+                  "title": "Response Slack Interactivity Webhooks Slack Interactivity Post"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Slack Interactivity"
+      }
+    }
+  }
+}

--- a/swagger.json
+++ b/swagger.json
@@ -1926,6 +1926,18 @@
         "title": "WorkspaceMCPUpdate",
         "type": "object"
       }
+    },
+    "securitySchemes": {
+      "AdminBearer": {
+        "description": "An admin's GitHub user token or an allowlisted GitHub Actions OIDC token.",
+        "scheme": "bearer",
+        "type": "http"
+      },
+      "DashboardSession": {
+        "in": "cookie",
+        "name": "osw_session",
+        "type": "apiKey"
+      }
     }
   },
   "info": {
@@ -1952,6 +1964,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Admin Get Reviewer Eval",
         "tags": [
           "dashboard"
@@ -1996,6 +2013,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Admin Cancel Thread",
         "tags": [
           "dashboard"
@@ -2051,6 +2073,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Admin List User Mappings",
         "tags": [
           "dashboard"
@@ -2097,6 +2124,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Admin Delete User Mapping",
         "tags": [
           "dashboard"
@@ -2122,6 +2154,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api List Agent Instructions",
         "tags": [
           "dashboard"
@@ -2161,6 +2198,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Create Agent Instructions",
         "tags": [
           "dashboard"
@@ -2201,6 +2243,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Delete Agent Instructions",
         "tags": [
           "dashboard"
@@ -2241,6 +2288,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Get Agent Instructions",
         "tags": [
           "dashboard"
@@ -2291,6 +2343,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Update Agent Instructions",
         "tags": [
           "dashboard"
@@ -2353,6 +2410,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Agent Usage Leaderboard",
         "tags": [
           "dashboard"
@@ -2583,6 +2645,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api List Enabled Review Repos",
         "tags": [
           "dashboard"
@@ -2629,6 +2696,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Set Enabled Review Repo",
         "tags": [
           "dashboard"
@@ -2652,6 +2724,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api List Environments",
         "tags": [
           "dashboard"
@@ -2691,6 +2768,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Create Environment",
         "tags": [
           "dashboard"
@@ -2715,6 +2797,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Environment Options",
         "tags": [
           "dashboard"
@@ -2755,6 +2842,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Delete Environment",
         "tags": [
           "dashboard"
@@ -2795,6 +2887,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Get Environment",
         "tags": [
           "dashboard"
@@ -2845,6 +2942,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Update Environment",
         "tags": [
           "dashboard"
@@ -2868,6 +2970,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Me",
         "tags": [
           "dashboard"
@@ -2887,6 +2994,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Delete My Instructions",
         "tags": [
           "dashboard"
@@ -2908,6 +3020,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Get My Instructions",
         "tags": [
           "dashboard"
@@ -2949,6 +3066,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Put My Instructions",
         "tags": [
           "dashboard"
@@ -2972,6 +3094,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Disconnect My Currents",
         "tags": [
           "dashboard"
@@ -2993,6 +3120,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Get My Currents Status",
         "tags": [
           "dashboard"
@@ -3034,6 +3166,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Connect My Currents",
         "tags": [
           "dashboard"
@@ -3057,6 +3194,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Disconnect My Langsmith",
         "tags": [
           "dashboard"
@@ -3078,6 +3220,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Get My Langsmith Status",
         "tags": [
           "dashboard"
@@ -3119,6 +3266,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Connect My Langsmith",
         "tags": [
           "dashboard"
@@ -3142,6 +3294,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Disconnect My Notion",
         "tags": [
           "dashboard"
@@ -3163,6 +3320,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Get My Notion Status",
         "tags": [
           "dashboard"
@@ -3187,6 +3349,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Get My Mapping",
         "tags": [
           "dashboard"
@@ -3319,6 +3486,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Notion Desktop Exchange",
         "tags": [
           "dashboard"
@@ -3384,6 +3556,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Notion Login",
         "tags": [
           "dashboard"
@@ -3471,6 +3648,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api List Organization Skills",
         "tags": [
           "dashboard"
@@ -3512,6 +3694,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Create Organization Skill",
         "tags": [
           "dashboard"
@@ -3552,6 +3739,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Delete Organization Skill",
         "tags": [
           "dashboard"
@@ -3604,6 +3796,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Update Organization Skill",
         "tags": [
           "dashboard"
@@ -3648,6 +3845,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Get Plan",
         "tags": [
           "plan"
@@ -3701,6 +3903,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Update Plan",
         "tags": [
           "plan"
@@ -3745,6 +3952,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Approve Plan",
         "tags": [
           "plan"
@@ -3789,6 +4001,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Get Plan Comments",
         "tags": [
           "plan"
@@ -3841,6 +4058,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Post Plan Comment",
         "tags": [
           "plan"
@@ -3894,6 +4116,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Remove Plan Comment",
         "tags": [
           "plan"
@@ -3955,6 +4182,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Reject Plan",
         "tags": [
           "plan"
@@ -3978,6 +4210,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Get My Profile",
         "tags": [
           "dashboard"
@@ -4019,6 +4256,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Put My Profile",
         "tags": [
           "dashboard"
@@ -4065,6 +4307,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "List Repos",
         "tags": [
           "dashboard"
@@ -4090,6 +4337,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api List Review Styles",
         "tags": [
           "dashboard"
@@ -4129,6 +4381,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Create Review Style",
         "tags": [
           "dashboard"
@@ -4169,6 +4426,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Delete Review Style",
         "tags": [
           "dashboard"
@@ -4209,6 +4471,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Get Review Style",
         "tags": [
           "dashboard"
@@ -4259,6 +4526,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Update Review Style Prompt",
         "tags": [
           "dashboard"
@@ -4301,6 +4573,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Analyze Review Style",
         "tags": [
           "dashboard"
@@ -4343,6 +4620,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Cancel Review Style",
         "tags": [
           "dashboard"
@@ -4398,6 +4680,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api List Reviews",
         "tags": [
           "dashboard"
@@ -4460,6 +4747,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Get Review",
         "tags": [
           "dashboard"
@@ -4522,6 +4814,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Get Review Chat",
         "tags": [
           "dashboard"
@@ -4584,6 +4881,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api List Review Chat Threads",
         "tags": [
           "dashboard"
@@ -4651,6 +4953,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Delete Review Chat Thread",
         "tags": [
           "dashboard"
@@ -4718,6 +5025,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Review Chat Commands",
         "tags": [
           "dashboard"
@@ -4785,6 +5097,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Review Chat History",
         "tags": [
           "dashboard"
@@ -4852,6 +5169,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Review Chat State",
         "tags": [
           "dashboard"
@@ -4919,6 +5241,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Review Chat Stream Events",
         "tags": [
           "dashboard"
@@ -4981,6 +5308,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api List Review Comments",
         "tags": [
           "dashboard"
@@ -5051,6 +5383,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Create Review Comment",
         "tags": [
           "dashboard"
@@ -5132,6 +5469,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Update Review Comment",
         "tags": [
           "dashboard"
@@ -5194,6 +5536,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Get Review Diff",
         "tags": [
           "dashboard"
@@ -5261,6 +5608,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Get Review Image",
         "tags": [
           "dashboard"
@@ -5323,6 +5675,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Re Review",
         "tags": [
           "dashboard"
@@ -5385,6 +5742,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Resolve Trace",
         "tags": [
           "dashboard"
@@ -5408,6 +5770,14 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          },
+          {
+            "AdminBearer": []
+          }
+        ],
         "summary": "Api Get Sandbox Settings",
         "tags": [
           "dashboard"
@@ -5449,6 +5819,14 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          },
+          {
+            "AdminBearer": []
+          }
+        ],
         "summary": "Api Set Sandbox Settings",
         "tags": [
           "dashboard"
@@ -5475,6 +5853,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api List Schedules",
         "tags": [
           "dashboard"
@@ -5516,6 +5899,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Create Schedule",
         "tags": [
           "dashboard"
@@ -5556,6 +5944,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Delete Schedule",
         "tags": [
           "dashboard"
@@ -5608,6 +6001,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Update Schedule",
         "tags": [
           "dashboard"
@@ -5652,6 +6050,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Trigger Schedule",
         "tags": [
           "dashboard"
@@ -5710,6 +6113,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api List Skills",
         "tags": [
           "dashboard"
@@ -5751,6 +6159,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Create Skill",
         "tags": [
           "dashboard"
@@ -5791,6 +6204,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Delete Skill",
         "tags": [
           "dashboard"
@@ -5843,6 +6261,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Update Skill",
         "tags": [
           "dashboard"
@@ -5937,6 +6360,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Slack Desktop Exchange",
         "tags": [
           "dashboard"
@@ -6003,6 +6431,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Slack Login",
         "tags": [
           "dashboard"
@@ -6026,6 +6459,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Get Team Credentials",
         "tags": [
           "dashboard"
@@ -6049,6 +6487,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Disconnect Datadog",
         "tags": [
           "dashboard"
@@ -6090,6 +6533,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Connect Datadog",
         "tags": [
           "dashboard"
@@ -6113,6 +6561,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Disconnect Langsmith",
         "tags": [
           "dashboard"
@@ -6154,6 +6607,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Connect Langsmith",
         "tags": [
           "dashboard"
@@ -6177,6 +6635,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Get Team Settings",
         "tags": [
           "dashboard"
@@ -6218,6 +6681,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Put Team Settings",
         "tags": [
           "dashboard"
@@ -6261,6 +6729,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Put Transcription Settings",
         "tags": [
           "dashboard"
@@ -6309,6 +6782,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api List Threads",
         "tags": [
           "dashboard"
@@ -6525,6 +7003,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api List Threads Page",
         "tags": [
           "dashboard"
@@ -6551,6 +7034,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api List Pinned Threads",
         "tags": [
           "dashboard"
@@ -6619,6 +7107,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api List Thread Projects",
         "tags": [
           "dashboard"
@@ -6664,6 +7157,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Get Pull Request Checks",
         "tags": [
           "dashboard"
@@ -6704,6 +7202,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Delete Thread",
         "tags": [
           "dashboard"
@@ -6756,6 +7259,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Get Thread",
         "tags": [
           "dashboard"
@@ -6808,6 +7316,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Rename Thread",
         "tags": [
           "dashboard"
@@ -6852,6 +7365,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Get Thread Branch Diff",
         "tags": [
           "dashboard"
@@ -6896,6 +7414,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Cancel Thread",
         "tags": [
           "dashboard"
@@ -6936,6 +7459,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Thread Commands",
         "tags": [
           "dashboard"
@@ -6976,6 +7504,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Thread History",
         "tags": [
           "dashboard"
@@ -7030,6 +7563,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Send Thread Message",
         "tags": [
           "dashboard"
@@ -7065,6 +7603,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Unpin Thread",
         "tags": [
           "dashboard"
@@ -7098,6 +7641,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Pin Thread",
         "tags": [
           "dashboard"
@@ -7142,6 +7690,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Get Thread Pr Diff",
         "tags": [
           "dashboard"
@@ -7204,6 +7757,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Get Thread Pull Request Context",
         "tags": [
           "dashboard"
@@ -7248,6 +7806,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Get Thread Pull Request Status",
         "tags": [
           "dashboard"
@@ -7288,6 +7851,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Get Thread Recovery Patch",
         "tags": [
           "dashboard"
@@ -7342,6 +7910,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Resolve Thread",
         "tags": [
           "dashboard"
@@ -7411,6 +7984,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Cancel Thread Run",
         "tags": [
           "dashboard"
@@ -7451,6 +8029,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Get Thread State",
         "tags": [
           "dashboard"
@@ -7491,6 +8074,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Thread Stream Events",
         "tags": [
           "dashboard"
@@ -7537,6 +8125,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Thread Terminal Connection",
         "tags": [
           "dashboard"
@@ -7581,6 +8174,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Get Thread Working Tree Diff",
         "tags": [
           "dashboard"
@@ -7606,6 +8204,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Create Voice Transcription",
         "tags": [
           "dashboard"
@@ -7650,6 +8253,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "List Workflow Push Approvals",
         "tags": [
           "workflow-approval"
@@ -7703,6 +8311,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Approve Workflow Push",
         "tags": [
           "workflow-approval"
@@ -7756,6 +8369,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Reject Workflow Push",
         "tags": [
           "workflow-approval"
@@ -7782,6 +8400,11 @@
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api List Workspace Mcps",
         "tags": [
           "dashboard"
@@ -7817,6 +8440,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Delete Workspace Mcp",
         "tags": [
           "dashboard"
@@ -7869,6 +8497,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Save Workspace Mcp",
         "tags": [
           "dashboard"
@@ -7935,6 +8568,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Discover Workspace Mcp",
         "tags": [
           "dashboard"
@@ -7975,6 +8613,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
         "summary": "Api Reveal Workspace Mcp Headers",
         "tags": [
           "dashboard"


### PR DESCRIPTION
Add the generated OpenAPI 3.1 contract for the custom FastAPI backend (104 paths), `make swagger` to regenerate it, and viewing instructions in the README.

Reflects existing route declarations; incomplete auth/response documentation and LangGraph runtime endpoints remain outside this export. No runtime behavior changes or new dependencies.

Made by [Open SWE](https://openswe.vercel.app/agents/01a087a9-ee67-741f-a955-dd0410b7ab74) · openai:gpt-6-astra (low)