### PR TITLE
fix: preserve desktop thread on reload

### DIFF
--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -1061,7 +1061,10 @@ function createMenu() {
           label: "Reload",
           accelerator: "CmdOrCtrl+R",
           click: () => {
-            if (mainWindow) void loadApp(mainWindow);
+            if (!mainWindow || mainWindow.isDestroyed()) return;
+            if (isAppUrl(mainWindow.webContents.getURL()))
+              mainWindow.webContents.reload();
+            else void loadApp(mainWindow);
           },
         },
         ...(isDevelopment ? [{ role: "toggleDevTools" }] : []),


### PR DESCRIPTION
Cmd+R called the startup loader, navigating to `/` and losing the selected thread. Reload the current app URL instead; retain startup retry for error pages.

<details><summary>Alice’s thread after Reload</summary>

![Thread retained after Reload](https://01a087ac-2375-79ba-b355-b5b23592cc92--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGc1T0RNeE1UUXNJbXAwYVNJNklqQXhZVEE0TjJJekxXWmlNbUl0TjJNM09DMDRaR1ZrTFdGalpXWXdPR0l4TkdRd05DSXNJbk5wWkNJNklqQXhZVEE0TjJGakxUSXpOelV0TnpsaVlTMWlNelUxTFdJMVlqSXpOVGt5WTJNNU1pSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkRzF3TDJSbGMydDBiM0F0Y21WbWNtVnphQzFoYkdsalpTNXdibWNpTENKamRDSTZJbWx0WVdkbEwzQnVaeUlzSW1Oa0lqb2lhVzVzYVc1bEluMC5IU0x2SXZHUEwzSU5tNC1EVUUxMXlTN01tNldYd0ZjX000aFJwODNaR3BTdjkwMDNnZnpCbnhjN2gtR01iWUVYc0tJdmpfUGVRZ0RwTWVJT2ExZUZDQQ)

</details>

Made by [Open SWE](https://openswe.vercel.app/agents/01a087ac-1e9d-74b8-9fa5-2988127e8d0e) · openai:gpt-6-astra (low)