### PR TITLE
Replace dashboard scans with durable PostgreSQL analytics

### DIFF
--- a/agent/agent_cost.py
+++ b/agent/agent_cost.py
@@ -142,12 +142,14 @@ async def run_agent_cost_refresh(
 
 
 async def finalize_agent_run_usage(
-    *, run_id: str, thread_id: str, state: dict[str, Any] | None
+    *, run_id: str, thread_id: str, state: dict[str, Any] | None, status: str = "success"
 ) -> None:
     """Persist terminal run usage and schedule deferred cost enrichment."""
     try:
         recorded = await record_agent_run_completion(
             run_id=run_id,
+            thread_id=thread_id,
+            status=status,
             usage=summarize_run_usage(state, run_id=run_id),
         )
         if not recorded and not await agent_run_needs_cost_refresh(run_id=run_id):

--- a/agent/analytics/__init__.py
+++ b/agent/analytics/__init__.py
@@ -1,0 +1,5 @@
+"""Durable Open SWE analytics."""
+
+from agent.analytics.events import EventEnvelope, EventName
+
+__all__ = ["EventEnvelope", "EventName"]

--- a/agent/analytics/admin.py
+++ b/agent/analytics/admin.py
@@ -1,0 +1,27 @@
+"""Authorized directory joins and audited named exports."""
+
+from uuid import uuid4
+
+from sqlalchemy import text
+
+from agent.analytics.database import transaction
+from agent.analytics.emitter import opaque_person, workspace_id
+
+
+async def audit_named_export(*, actor_login: str, scope: str) -> None:
+    actor = opaque_person("github", actor_login)
+    if actor is None:
+        raise ValueError("named exports require an identified actor")
+    async with transaction() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO named_export_audit (audit_id, workspace_id, actor_person_id, scope) "
+                "VALUES (:audit_id, :workspace_id, :actor_person_id, :scope)"
+            ),
+            {
+                "audit_id": uuid4(),
+                "workspace_id": workspace_id(),
+                "actor_person_id": actor,
+                "scope": scope[:200],
+            },
+        )

--- a/agent/analytics/database.py
+++ b/agent/analytics/database.py
@@ -1,0 +1,143 @@
+"""SQLAlchemy async access to the dedicated analytics PostgreSQL datastore."""
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, create_async_engine
+
+from agent.config import ENV
+
+logger = logging.getLogger(__name__)
+
+_ENGINE: AsyncEngine | None = None
+_ENGINE_URI: str | None = None
+_MIGRATION_DIR = Path(__file__).with_name("migrations")
+_MIGRATION_LOCK = 557314367248862439
+
+
+def analytics_uri() -> str | None:
+    value = ENV.ANALYTICS_POSTGRES_URI.optional() or ENV.POSTGRES_URI.optional()
+    if value is None:
+        return None
+    if value.startswith("postgres://"):
+        value = "postgresql://" + value.removeprefix("postgres://")
+    if value.startswith("postgresql://"):
+        value = "postgresql+asyncpg://" + value.removeprefix("postgresql://")
+    if not value.startswith("postgresql+asyncpg://"):
+        raise ValueError("analytics PostgreSQL URI must use a PostgreSQL scheme")
+    return value
+
+
+def configured() -> bool:
+    return analytics_uri() is not None and ENV.ANALYTICS_WORKSPACE_ID.optional() is not None
+
+
+def engine() -> AsyncEngine:
+    global _ENGINE, _ENGINE_URI
+    uri = analytics_uri()
+    if uri is None:
+        raise RuntimeError("analytics PostgreSQL is not configured")
+    if _ENGINE is None or _ENGINE_URI != uri:
+        _ENGINE = create_async_engine(
+            uri,
+            pool_pre_ping=True,
+            pool_size=ENV.ANALYTICS_POOL_SIZE.get_int(5),
+            max_overflow=ENV.ANALYTICS_POOL_OVERFLOW.get_int(5),
+            pool_timeout=ENV.ANALYTICS_POOL_TIMEOUT_SECONDS.get_int(5),
+            connect_args={"server_settings": {"application_name": "open-swe-analytics"}},
+        )
+        _ENGINE_URI = uri
+    return _ENGINE
+
+
+@asynccontextmanager
+async def connection() -> AsyncIterator[AsyncConnection]:
+    async with engine().connect() as conn:
+        await conn.execute(text("SET search_path TO open_swe_analytics, public"))
+        yield conn
+
+
+@asynccontextmanager
+async def transaction() -> AsyncIterator[AsyncConnection]:
+    async with engine().begin() as conn:
+        await conn.execute(text("SET LOCAL search_path TO open_swe_analytics, public"))
+        yield conn
+
+
+async def migrate() -> None:
+    if not configured():
+        return
+    async with engine().begin() as conn:
+        await conn.execute(text("SELECT pg_advisory_xact_lock(:key)"), {"key": _MIGRATION_LOCK})
+        await _run_script(conn, "CREATE SCHEMA IF NOT EXISTS open_swe_analytics")
+        await _run_script(
+            conn,
+            "CREATE TABLE IF NOT EXISTS open_swe_analytics.schema_migrations "
+            "(version integer PRIMARY KEY, applied_at timestamptz NOT NULL "
+            "DEFAULT clock_timestamp())",
+        )
+        for path in sorted(_MIGRATION_DIR.glob("*.sql")):
+            version = int(path.name.split("_", 1)[0])
+            applied = await conn.scalar(
+                text(
+                    "SELECT EXISTS (SELECT 1 FROM open_swe_analytics.schema_migrations "
+                    "WHERE version = :version)"
+                ),
+                {"version": version},
+            )
+            if applied:
+                continue
+            await _run_script(conn, path.read_text())
+            await conn.execute(
+                text(
+                    "INSERT INTO open_swe_analytics.schema_migrations (version) VALUES (:version) "
+                    "ON CONFLICT DO NOTHING"
+                ),
+                {"version": version},
+            )
+
+
+async def _run_script(conn: AsyncConnection, script: str) -> None:
+    """Run trusted multi-statement DDL through asyncpg's simple query protocol."""
+    raw = await conn.get_raw_connection()
+    driver_connection = raw.driver_connection
+    if driver_connection is None:
+        raise RuntimeError("analytics migration requires an asyncpg driver connection")
+    await driver_connection.execute(script)
+
+
+async def readiness() -> dict[str, Any]:
+    if not configured():
+        return {"configured": False, "ready": False, "reason": "not configured"}
+    try:
+        async with asyncio.timeout(ENV.ANALYTICS_HEALTH_TIMEOUT_SECONDS.get_int(3)):
+            async with connection() as conn:
+                event_count = await conn.scalar(text("SELECT count(*) FROM events WHERE false"))
+                pending = await conn.scalar(
+                    text("SELECT count(*) FROM outbox WHERE state = 'pending'")
+                )
+                dead_letters = await conn.scalar(
+                    text("SELECT count(*) FROM outbox WHERE state = 'dead_letter'")
+                )
+        return {
+            "configured": True,
+            "ready": event_count == 0,
+            "pending_outbox": int(pending or 0),
+            "dead_letters": int(dead_letters or 0),
+        }
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Analytics readiness check failed", exc_info=True)
+        return {"configured": True, "ready": False, "reason": type(exc).__name__}
+
+
+async def close() -> None:
+    global _ENGINE, _ENGINE_URI
+    if _ENGINE is not None:
+        await _ENGINE.dispose()
+    _ENGINE = None
+    _ENGINE_URI = None

--- a/agent/analytics/directory.py
+++ b/agent/analytics/directory.py
@@ -1,0 +1,91 @@
+"""Protected analytics identity and repository directories."""
+
+from sqlalchemy import text
+
+from agent.analytics.database import configured, transaction
+from agent.analytics.emitter import opaque_id, opaque_person, workspace_id
+from agent.config import ENV
+
+
+async def upsert_person(
+    *,
+    provider: str,
+    immutable_person_key: str | int | None,
+    github_login: str | None = None,
+    display_name: str | None = None,
+    email: str | None = None,
+    team_key: str | None = None,
+) -> None:
+    person_id = opaque_person(provider, immutable_person_key)
+    if not configured() or person_id is None:
+        return
+    async with transaction() as conn:
+        await conn.execute(
+            text(
+                """
+                INSERT INTO identity_directory (
+                    workspace_id, person_id, github_login, display_name, email, team_id,
+                    anonymize_after
+                ) VALUES (
+                    :workspace_id, :person_id, :github_login, :display_name, :email, :team_id,
+                    clock_timestamp() + (:months * interval '1 month')
+                ) ON CONFLICT (workspace_id, person_id) DO UPDATE SET
+                    github_login = COALESCE(EXCLUDED.github_login, identity_directory.github_login),
+                    display_name = COALESCE(EXCLUDED.display_name, identity_directory.display_name),
+                    email = COALESCE(EXCLUDED.email, identity_directory.email),
+                    team_id = COALESCE(EXCLUDED.team_id, identity_directory.team_id),
+                    anonymize_after = EXCLUDED.anonymize_after,
+                    updated_at = clock_timestamp()
+                """
+            ),
+            {
+                "workspace_id": workspace_id(),
+                "person_id": person_id,
+                "github_login": github_login,
+                "display_name": display_name,
+                "email": email,
+                "team_id": opaque_id("team", team_key),
+                "months": ENV.ANALYTICS_PERSON_MONTHS.get_int(13),
+            },
+        )
+
+
+async def upsert_model(provider_model_id: str | None) -> None:
+    model_id = opaque_id("model", provider_model_id)
+    if not configured() or model_id is None or provider_model_id is None:
+        return
+    async with transaction() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO model_directory (workspace_id, model_id, provider_model_id) VALUES "
+                "(:workspace_id, :model_id, :provider_model_id) ON CONFLICT (workspace_id, model_id) "
+                "DO UPDATE SET provider_model_id = EXCLUDED.provider_model_id, updated_at = "
+                "clock_timestamp()"
+            ),
+            {
+                "workspace_id": workspace_id(),
+                "model_id": model_id,
+                "provider_model_id": provider_model_id,
+            },
+        )
+
+
+async def upsert_repository(*, full_name: str, private: bool | None) -> None:
+    repository_id = opaque_id("repository", full_name.lower())
+    if not configured() or repository_id is None or private is None:
+        return
+    async with transaction() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO repository_directory (workspace_id, repository_id, full_name, private) "
+                "VALUES (:workspace_id, :repository_id, :full_name, :private) ON CONFLICT "
+                "(workspace_id, repository_id) DO UPDATE SET full_name = EXCLUDED.full_name, "
+                "private = EXCLUDED.private, updated_at = clock_timestamp()"
+            ),
+            {
+                "workspace_id": workspace_id(),
+                "repository_id": repository_id,
+                "full_name": full_name,
+                "private": private,
+            },
+        )

--- a/agent/analytics/emitter.py
+++ b/agent/analytics/emitter.py
@@ -1,0 +1,401 @@
+"""Fail-soft lifecycle event capture at product transition points."""
+
+import logging
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Literal
+from uuid import UUID
+
+from agent.analytics.database import configured
+from agent.analytics.events import (
+    EntryPoint,
+    EventName,
+    FeedbackSubmittedPayload,
+    FindingStatePayload,
+    FindingSurfacedPayload,
+    PROpenedPayload,
+    PRRunLinkedPayload,
+    PRStatePayload,
+    ReviewPublishedPayload,
+    RunCanceledPayload,
+    RunCompletedPayload,
+    RunCostRecordedPayload,
+    RunFailedPayload,
+    RunStartedPayload,
+    StrictPayload,
+    TaskAcceptedPayload,
+    TaskMarkedCompletePayload,
+    TaskReworkRequestedPayload,
+    make_event,
+    person_uuid,
+    subject_uuid,
+)
+from agent.analytics.outbox import enqueue
+from agent.config import ENV
+
+logger = logging.getLogger(__name__)
+
+_ENTRY_POINTS = {
+    "dashboard": EntryPoint.DASHBOARD,
+    "web": EntryPoint.DASHBOARD,
+    "github": EntryPoint.GITHUB,
+    "github_issue": EntryPoint.GITHUB,
+    "slack": EntryPoint.SLACK,
+    "schedule": EntryPoint.SCHEDULED,
+    "scheduled": EntryPoint.SCHEDULED,
+    "desktop": EntryPoint.DESKTOP,
+    "api": EntryPoint.API,
+    "linear": EntryPoint.LINEAR,
+}
+
+
+def workspace_id() -> UUID:
+    return UUID(ENV.ANALYTICS_WORKSPACE_ID.require())
+
+
+def opaque_id(kind: str, value: str | int | None) -> UUID | None:
+    normalized = str(value or "").strip()
+    return subject_uuid(workspace_id(), kind, normalized) if normalized else None
+
+
+def opaque_person(provider: str, immutable_id: str | int | None) -> UUID | None:
+    normalized = str(immutable_id or "").strip().lower()
+    return person_uuid(workspace_id(), provider, normalized) if normalized else None
+
+
+def entry_point(source: str | None) -> EntryPoint:
+    return _ENTRY_POINTS.get(str(source or "").lower(), EntryPoint.UNKNOWN)
+
+
+async def emit(
+    event_name: EventName,
+    producer_event_id: str,
+    payload: StrictPayload,
+    *,
+    occurred_at: datetime | None = None,
+    source: str | None = None,
+    source_version: int | None = None,
+    **identifiers: object,
+) -> None:
+    if not configured():
+        return
+    try:
+        event = make_event(
+            event_name=event_name,
+            workspace_id=workspace_id(),
+            producer="open-swe",
+            producer_event_id=producer_event_id,
+            occurred_at=occurred_at or datetime.now(UTC),
+            payload=payload,
+            environment=ENV.ANALYTICS_ENVIRONMENT.get(),
+            source_version=source_version,
+            entry_point=entry_point(source),
+            **identifiers,
+        )
+        await enqueue(event)
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "Analytics event enqueue failed",
+            extra={"analytics_event_name": event_name.value},
+            exc_info=True,
+        )
+
+
+async def run_started(
+    *,
+    run_key: str,
+    thread_key: str,
+    model: str | None,
+    source: str | None,
+    immutable_person_key: str | int | None,
+    repository_key: str | None,
+    occurred_at: datetime | None = None,
+) -> None:
+    model_id = opaque_id("model", model)
+    from agent.analytics.directory import upsert_model
+
+    await upsert_model(model)
+    await emit(
+        EventName.RUN_STARTED,
+        f"run:{run_key}:started",
+        RunStartedPayload(
+            configured_model_id=model_id,
+            effective_model_id=model_id,
+            model_attribution_quality="configured" if model_id else "unavailable",
+        ),
+        occurred_at=occurred_at,
+        source=source,
+        run_id=opaque_id("run", run_key),
+        preparation_run_id=opaque_id("preparation_run", run_key),
+        thread_id=opaque_id("thread", thread_key),
+        task_id=opaque_id("task", thread_key),
+        user_id=opaque_person("github", immutable_person_key),
+        repository_id=opaque_id("repository", repository_key),
+        model_id=model_id,
+    )
+
+
+async def run_terminal(
+    *,
+    run_key: str,
+    thread_key: str,
+    status: str,
+    input_tokens: int | None = None,
+    output_tokens: int | None = None,
+    total_tokens: int | None = None,
+    failure_code: str | None = None,
+    producer_suffix: str = "terminal",
+) -> None:
+    if status == "success":
+        name = EventName.RUN_COMPLETED
+        payload: StrictPayload = RunCompletedPayload(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            total_tokens=total_tokens,
+        )
+    elif status in {"interrupted", "canceled"}:
+        name = EventName.RUN_CANCELED
+        payload = RunCanceledPayload(
+            cancellation_source="superseded" if status == "interrupted" else "user"
+        )
+    else:
+        name = EventName.RUN_FAILED
+        payload = RunFailedPayload(
+            failure_class="timeout" if status == "timeout" else "error",
+            failure_code=failure_code,
+        )
+    await emit(
+        name,
+        f"run:{run_key}:{producer_suffix}:{name.value}",
+        payload,
+        run_id=opaque_id("run", run_key),
+        preparation_run_id=opaque_id("preparation_run", run_key),
+        thread_id=opaque_id("thread", thread_key),
+        task_id=opaque_id("task", thread_key),
+    )
+
+
+async def run_cost(
+    *,
+    run_key: str,
+    cost_usd: float | None,
+    revision: int = 1,
+    status: Literal["complete", "partial", "unavailable"] = "complete",
+    source: Literal["provider", "langsmith", "unavailable"] = "langsmith",
+    missing_reason: str | None = None,
+    input_tokens: int | None = None,
+    output_tokens: int | None = None,
+    total_tokens: int | None = None,
+) -> None:
+    await emit(
+        EventName.RUN_COST_RECORDED,
+        f"run:{run_key}:cost:{revision}",
+        RunCostRecordedPayload(
+            cost_usd=Decimal(str(cost_usd)) if cost_usd is not None else None,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            total_tokens=total_tokens,
+            status=status,
+            source=source,
+            missing_reason=missing_reason,
+            observation_revision=revision,
+            observed_at=datetime.now(UTC),
+        ),
+        run_id=opaque_id("run", run_key),
+    )
+
+
+async def pr_opened(
+    *,
+    owner: str,
+    repo: str,
+    number: int,
+    run_key: str,
+    model: str | None,
+    source: str | None,
+    repository_private: bool | None,
+    occurred_at: datetime,
+) -> None:
+    pr_key = f"{owner.lower()}/{repo.lower()}#{number}"
+    model_id = opaque_id("model", model)
+    pr_id = opaque_id("pr", pr_key)
+    run_id = opaque_id("run", run_key)
+    repository_id = opaque_id("repository", f"{owner.lower()}/{repo.lower()}")
+    if pr_id is None or run_id is None or repository_id is None:
+        return
+    from agent.analytics.directory import upsert_model, upsert_repository
+
+    await upsert_model(model)
+    await upsert_repository(full_name=f"{owner}/{repo}", private=repository_private)
+    await emit(
+        EventName.PR_OPENED,
+        f"pr:{pr_key}:opened",
+        PROpenedPayload(
+            opening_run_id=run_id,
+            originating_model_id=model_id,
+            model_attribution_quality="configured" if model_id else "unavailable",
+            repository_private=repository_private,
+        ),
+        occurred_at=occurred_at,
+        source=source,
+        pr_id=pr_id,
+        run_id=run_id,
+        repository_id=repository_id,
+        model_id=model_id,
+    )
+    await emit(
+        EventName.PR_RUN_LINKED,
+        f"pr:{pr_key}:run:{run_key}:opening",
+        PRRunLinkedPayload(link_role="opening"),
+        occurred_at=occurred_at,
+        source=source,
+        pr_id=pr_id,
+        run_id=run_id,
+        repository_id=repository_id,
+        model_id=model_id,
+    )
+
+
+async def pr_state(
+    *,
+    owner: str,
+    repo: str,
+    number: int,
+    action: str,
+    merged: bool,
+    source_version: int | None,
+    occurred_at: datetime,
+) -> None:
+    name = (
+        EventName.PR_MERGED
+        if merged
+        else EventName.PR_REOPENED
+        if action == "reopened"
+        else EventName.PR_CLOSED_WITHOUT_MERGE
+    )
+    pr_key = f"{owner.lower()}/{repo.lower()}#{number}"
+    await emit(
+        name,
+        f"github:pr:{pr_key}:{source_version or occurred_at.isoformat()}:{name.value}",
+        PRStatePayload(previous_state=None),
+        occurred_at=occurred_at,
+        source="github",
+        source_version=source_version,
+        pr_id=opaque_id("pr", pr_key),
+        repository_id=opaque_id("repository", f"{owner.lower()}/{repo.lower()}"),
+    )
+
+
+async def task_marked_complete(thread_key: str, *, source: str, auto: bool = False) -> None:
+    await emit(
+        EventName.TASK_MARKED_COMPLETE,
+        f"task:{thread_key}:complete:{source}",
+        TaskMarkedCompletePayload(completion_source="pr_terminal" if auto else "user"),
+        source=source,
+        task_id=opaque_id("task", thread_key),
+        thread_id=opaque_id("thread", thread_key),
+    )
+
+
+async def task_accepted(thread_key: str, *, source: str, actor_key: str | int | None) -> None:
+    await emit(
+        EventName.TASK_ACCEPTED,
+        f"task:{thread_key}:accepted:{source}",
+        TaskAcceptedPayload(acceptance_source="explicit_user"),
+        source=source,
+        task_id=opaque_id("task", thread_key),
+        thread_id=opaque_id("thread", thread_key),
+        user_id=opaque_person("github", actor_key),
+    )
+
+
+async def task_rework(
+    thread_key: str,
+    *,
+    source: str,
+    scope: Literal["minor", "major"],
+    reason: Literal["explicit_user", "plan_review", "pr_reopened"],
+) -> None:
+    await emit(
+        EventName.TASK_REWORK_REQUESTED,
+        f"task:{thread_key}:rework:{source}:{datetime.now(UTC).isoformat()}",
+        TaskReworkRequestedPayload(scope=scope, request_source=reason),
+        source=source,
+        task_id=opaque_id("task", thread_key),
+        thread_id=opaque_id("thread", thread_key),
+    )
+
+
+async def feedback_submitted(
+    *, run_key: str, person_key: str, rating: int, producer_version: str
+) -> None:
+    sentiment = "negative" if rating <= 2 else "neutral" if rating == 3 else "positive"
+    await emit(
+        EventName.FEEDBACK_SUBMITTED,
+        f"feedback:{run_key}:{person_key}:{producer_version}",
+        FeedbackSubmittedPayload(sentiment=sentiment, rating=rating),
+        source="slack",
+        run_id=opaque_id("run", run_key),
+        user_id=opaque_person("slack", person_key),
+    )
+
+
+async def review_published(
+    *, thread_key: str, owner: str, repo: str, number: int, head_sha: str, finding_count: int
+) -> None:
+    pr_key = f"{owner.lower()}/{repo.lower()}#{number}"
+    await emit(
+        EventName.REVIEW_PUBLISHED,
+        f"review:{thread_key}:{head_sha}:published",
+        ReviewPublishedPayload(finding_count=finding_count),
+        source="github",
+        review_id=opaque_id("review", f"{thread_key}:{head_sha}"),
+        pr_id=opaque_id("pr", pr_key),
+        repository_id=opaque_id("repository", f"{owner.lower()}/{repo.lower()}"),
+    )
+
+
+async def finding_transition(
+    *,
+    thread_key: str,
+    finding_key: str,
+    owner: str,
+    repo: str,
+    number: int,
+    state: str,
+    severity: Literal["low", "medium", "high", "critical"],
+    category: str,
+    version: str,
+) -> None:
+    pr_key = f"{owner.lower()}/{repo.lower()}#{number}"
+    finding_id = opaque_id("finding", f"{thread_key}:{finding_key}")
+    pr_id = opaque_id("pr", pr_key)
+    repository_id = opaque_id("repository", f"{owner.lower()}/{repo.lower()}")
+    if finding_id is None or pr_id is None or repository_id is None:
+        return
+    if state == "surfaced":
+        await emit(
+            EventName.FINDING_SURFACED,
+            f"finding:{thread_key}:{finding_key}:surfaced:{version}",
+            FindingSurfacedPayload(severity=severity, category=category or "unknown"),
+            source="github",
+            finding_id=finding_id,
+            pr_id=pr_id,
+            repository_id=repository_id,
+        )
+        return
+    name = {
+        "resolved": EventName.FINDING_RESOLVED,
+        "dismissed": EventName.FINDING_DISMISSED,
+        "reopened": EventName.FINDING_REOPENED,
+    }.get(state)
+    if name is not None:
+        await emit(
+            name,
+            f"finding:{thread_key}:{finding_key}:{state}:{version}",
+            FindingStatePayload(previous_state=None),
+            source="github",
+            finding_id=finding_id,
+            pr_id=pr_id,
+            repository_id=repository_id,
+        )

--- a/agent/analytics/events.py
+++ b/agent/analytics/events.py
@@ -1,0 +1,326 @@
+"""Storage-neutral analytics event contract."""
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from enum import StrEnum
+from typing import Annotated, Literal
+from uuid import UUID, uuid5
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+_FORBIDDEN_KEYS = {
+    "prompt",
+    "response",
+    "feedback_text",
+    "source_code",
+    "diff",
+    "branch",
+    "branch_name",
+    "path",
+    "raw_path",
+    "email",
+    "display_name",
+}
+
+EVENT_NAMESPACE = UUID("22baaec2-b143-5686-b408-79f30584a831")
+PERSON_NAMESPACE = UUID("6e711fef-ae6f-5307-a8bf-893b2bb8546d")
+SUBJECT_NAMESPACE = UUID("0384a662-ef87-5c07-9d02-4fa90f14c860")
+SCHEMA_VERSION = 1
+
+
+class EventName(StrEnum):
+    RUN_STARTED = "run.started"
+    RUN_COMPLETED = "run.completed"
+    RUN_FAILED = "run.failed"
+    RUN_CANCELED = "run.canceled"
+    RUN_COST_RECORDED = "run.cost_recorded"
+    FEEDBACK_SUBMITTED = "user.feedback_submitted"
+    FEEDBACK_WITHDRAWN = "user.feedback_withdrawn"
+    TASK_MARKED_COMPLETE = "task.marked_complete"
+    TASK_ACCEPTED = "task.accepted"
+    TASK_REWORK_REQUESTED = "task.rework_requested"
+    PR_OPENED = "pr.opened"
+    PR_RUN_LINKED = "pr.run_linked"
+    PR_MERGED = "pr.merged"
+    PR_CLOSED_WITHOUT_MERGE = "pr.closed_without_merge"
+    PR_REOPENED = "pr.reopened"
+    REVIEW_PUBLISHED = "review.published"
+    FINDING_SURFACED = "finding.surfaced"
+    FINDING_RESOLVED = "finding.resolved"
+    FINDING_DISMISSED = "finding.dismissed"
+    FINDING_REOPENED = "finding.reopened"
+
+
+class EntryPoint(StrEnum):
+    DASHBOARD = "dashboard"
+    GITHUB = "github"
+    SLACK = "slack"
+    SCHEDULED = "scheduled"
+    DESKTOP = "desktop"
+    API = "api"
+    LINEAR = "linear"
+    UNKNOWN = "unknown"
+
+
+class StrictPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class RunStartedPayload(StrictPayload):
+    configured_model_id: UUID | None = None
+    effective_model_id: UUID | None = None
+    model_attribution_quality: Literal["effective", "configured", "unavailable"]
+
+
+class RunCompletedPayload(StrictPayload):
+    input_tokens: int | None = Field(default=None, ge=0)
+    output_tokens: int | None = Field(default=None, ge=0)
+    total_tokens: int | None = Field(default=None, ge=0)
+
+
+class RunFailedPayload(StrictPayload):
+    failure_class: Literal["error", "timeout", "unavailable"]
+    failure_code: str | None = Field(default=None, max_length=100)
+
+
+class RunCanceledPayload(StrictPayload):
+    cancellation_source: Literal["user", "system", "superseded", "unavailable"]
+
+
+class RunCostRecordedPayload(StrictPayload):
+    cost_usd: Decimal | None = Field(default=None, ge=0)
+    input_tokens: int | None = Field(default=None, ge=0)
+    output_tokens: int | None = Field(default=None, ge=0)
+    total_tokens: int | None = Field(default=None, ge=0)
+    status: Literal["complete", "partial", "unavailable"]
+    source: Literal["provider", "langsmith", "unavailable"]
+    missing_reason: str | None = Field(default=None, max_length=200)
+    observation_revision: int = Field(ge=1)
+    observed_at: datetime
+
+
+class FeedbackSubmittedPayload(StrictPayload):
+    sentiment: Literal["positive", "neutral", "negative"]
+    rating: int | None = Field(default=None, ge=1, le=5)
+
+
+class FeedbackWithdrawnPayload(StrictPayload):
+    submission_event_id: UUID
+
+
+class TaskMarkedCompletePayload(StrictPayload):
+    completion_source: Literal["user", "pr_terminal"]
+
+
+class TaskAcceptedPayload(StrictPayload):
+    acceptance_source: Literal["explicit_user", "external_system"]
+
+
+class TaskReworkRequestedPayload(StrictPayload):
+    scope: Literal["minor", "major"]
+    request_source: Literal["explicit_user", "plan_review", "pr_reopened"]
+
+
+class PROpenedPayload(StrictPayload):
+    opening_run_id: UUID
+    originating_model_id: UUID | None = None
+    model_attribution_quality: Literal["effective", "configured", "unavailable"]
+    repository_private: bool | None = None
+
+
+class PRRunLinkedPayload(StrictPayload):
+    link_role: Literal["opening", "follow_up", "review"]
+
+
+class PRStatePayload(StrictPayload):
+    previous_state: Literal["open", "draft", "closed", "merged", "unknown"] | None = None
+
+
+class ReviewPublishedPayload(StrictPayload):
+    finding_count: int = Field(ge=0)
+
+
+class FindingSurfacedPayload(StrictPayload):
+    severity: Literal["low", "medium", "high", "critical"]
+    category: str = Field(min_length=1, max_length=100)
+
+
+class FindingStatePayload(StrictPayload):
+    previous_state: Literal["open", "resolved", "dismissed", "unknown"] | None = None
+
+
+EventPayload = Annotated[
+    RunStartedPayload
+    | RunCompletedPayload
+    | RunFailedPayload
+    | RunCanceledPayload
+    | RunCostRecordedPayload
+    | FeedbackSubmittedPayload
+    | FeedbackWithdrawnPayload
+    | TaskMarkedCompletePayload
+    | TaskAcceptedPayload
+    | TaskReworkRequestedPayload
+    | PROpenedPayload
+    | PRRunLinkedPayload
+    | PRStatePayload
+    | ReviewPublishedPayload
+    | FindingSurfacedPayload
+    | FindingStatePayload,
+    Field(union_mode="left_to_right"),
+]
+
+_PAYLOAD_MODELS: dict[EventName, type[StrictPayload]] = {
+    EventName.RUN_STARTED: RunStartedPayload,
+    EventName.RUN_COMPLETED: RunCompletedPayload,
+    EventName.RUN_FAILED: RunFailedPayload,
+    EventName.RUN_CANCELED: RunCanceledPayload,
+    EventName.RUN_COST_RECORDED: RunCostRecordedPayload,
+    EventName.FEEDBACK_SUBMITTED: FeedbackSubmittedPayload,
+    EventName.FEEDBACK_WITHDRAWN: FeedbackWithdrawnPayload,
+    EventName.TASK_MARKED_COMPLETE: TaskMarkedCompletePayload,
+    EventName.TASK_ACCEPTED: TaskAcceptedPayload,
+    EventName.TASK_REWORK_REQUESTED: TaskReworkRequestedPayload,
+    EventName.PR_OPENED: PROpenedPayload,
+    EventName.PR_RUN_LINKED: PRRunLinkedPayload,
+    EventName.PR_MERGED: PRStatePayload,
+    EventName.PR_CLOSED_WITHOUT_MERGE: PRStatePayload,
+    EventName.PR_REOPENED: PRStatePayload,
+    EventName.REVIEW_PUBLISHED: ReviewPublishedPayload,
+    EventName.FINDING_SURFACED: FindingSurfacedPayload,
+    EventName.FINDING_RESOLVED: FindingStatePayload,
+    EventName.FINDING_DISMISSED: FindingStatePayload,
+    EventName.FINDING_REOPENED: FindingStatePayload,
+}
+
+
+class EventEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    event_id: UUID
+    event_name: EventName
+    schema_version: Literal[1] = SCHEMA_VERSION
+    occurred_at: datetime
+    recorded_at: datetime
+    workspace_id: UUID
+    environment: str = Field(min_length=1, max_length=100)
+    producer: str = Field(min_length=1, max_length=100)
+    producer_event_id: str = Field(min_length=1, max_length=500)
+    source_version: int | None = Field(default=None, ge=0)
+    correlation_id: UUID | None = None
+    causation_id: UUID | None = None
+    run_id: UUID | None = None
+    preparation_run_id: UUID | None = None
+    thread_id: UUID | None = None
+    task_id: UUID | None = None
+    pr_id: UUID | None = None
+    review_id: UUID | None = None
+    finding_id: UUID | None = None
+    user_id: UUID | None = None
+    team_id: UUID | None = None
+    repository_id: UUID | None = None
+    model_id: UUID | None = None
+    entry_point: EntryPoint = EntryPoint.UNKNOWN
+    privacy_classification: Literal["non_personal", "pseudonymous"]
+    payload: EventPayload
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_payload_model(cls, value: object) -> object:
+        if not isinstance(value, dict):
+            return value
+        event_name = EventName(value.get("event_name"))
+        model = _PAYLOAD_MODELS[event_name]
+        return {**value, "payload": model.model_validate(value.get("payload"))}
+
+    @model_validator(mode="after")
+    def validate_identity_and_time(self) -> EventEnvelope:
+        expected = event_uuid(
+            self.workspace_id,
+            self.producer,
+            self.producer_event_id,
+            self.event_name,
+            self.schema_version,
+        )
+        if self.event_id != expected:
+            raise ValueError("event_id does not match deterministic event identity")
+        if self.occurred_at.tzinfo is None or self.recorded_at.tzinfo is None:
+            raise ValueError("event timestamps must be timezone-aware")
+        _reject_forbidden_fields(self.payload.model_dump(mode="json"))
+        return self
+
+
+def _reject_forbidden_fields(value: object) -> None:
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if str(key).lower() in _FORBIDDEN_KEYS:
+                raise ValueError(f"forbidden analytics field: {key}")
+            _reject_forbidden_fields(nested)
+    elif isinstance(value, list | tuple):
+        for nested in value:
+            _reject_forbidden_fields(nested)
+
+
+def deterministic_event_id(
+    workspace_id: UUID,
+    event_name: EventName,
+    immutable_natural_key: str,
+    source_version: str,
+) -> UUID:
+    return event_uuid(
+        workspace_id,
+        "open-swe",
+        f"{immutable_natural_key}:{source_version}",
+        event_name,
+    )
+
+
+def event_uuid(
+    workspace_id: UUID,
+    producer: str,
+    producer_event_id: str,
+    event_name: EventName,
+    schema_version: int = SCHEMA_VERSION,
+) -> UUID:
+    return uuid5(
+        EVENT_NAMESPACE,
+        f"{workspace_id}:{producer}:{producer_event_id}:{event_name.value}:v{schema_version}",
+    )
+
+
+def person_uuid(workspace_id: UUID, provider: str, immutable_provider_id: str) -> UUID:
+    return uuid5(PERSON_NAMESPACE, f"{workspace_id}:{provider}:{immutable_provider_id}")
+
+
+def subject_uuid(workspace_id: UUID, subject_type: str, immutable_key: str) -> UUID:
+    return uuid5(SUBJECT_NAMESPACE, f"{workspace_id}:{subject_type}:{immutable_key}")
+
+
+def make_event(
+    *,
+    event_name: EventName,
+    workspace_id: UUID,
+    producer: str,
+    producer_event_id: str,
+    occurred_at: datetime,
+    payload: StrictPayload,
+    environment: str,
+    **identifiers: object,
+) -> EventEnvelope:
+    recorded_at = datetime.now(UTC)
+    return EventEnvelope.model_validate(
+        {
+            "event_id": event_uuid(workspace_id, producer, producer_event_id, event_name),
+            "event_name": event_name,
+            "occurred_at": occurred_at,
+            "recorded_at": recorded_at,
+            "workspace_id": workspace_id,
+            "environment": environment,
+            "producer": producer,
+            "producer_event_id": producer_event_id,
+            "privacy_classification": "pseudonymous"
+            if identifiers.get("user_id")
+            else "non_personal",
+            "payload": payload,
+            **identifiers,
+        }
+    )

--- a/agent/analytics/ingestion.py
+++ b/agent/analytics/ingestion.py
@@ -1,0 +1,513 @@
+"""Idempotent ingestion, projection, and summary invalidation."""
+
+import json
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+from agent.analytics.database import transaction
+from agent.analytics.events import EventEnvelope, EventName
+from agent.config import ENV
+
+_INSERT_ID = text(
+    "INSERT INTO event_ids(event_id, occurred_at) VALUES (:event_id, :occurred_at) "
+    "ON CONFLICT (event_id) DO NOTHING RETURNING event_id"
+)
+_INSERT_EVENT = text(
+    """
+    INSERT INTO events (
+        event_id, event_name, schema_version, occurred_at, recorded_at, workspace_id,
+        environment, producer, producer_event_id, source_version, correlation_id,
+        causation_id, run_id, preparation_run_id, thread_id, task_id, pr_id, review_id,
+        finding_id, user_id, team_id, repository_id, model_id, entry_point,
+        privacy_classification, payload
+    ) VALUES (
+        :event_id, :event_name, :schema_version, :occurred_at, :recorded_at, :workspace_id,
+        :environment, :producer, :producer_event_id, :source_version, :correlation_id,
+        :causation_id, :run_id, :preparation_run_id, :thread_id, :task_id, :pr_id, :review_id,
+        :finding_id, :user_id, :team_id, :repository_id, :model_id, :entry_point,
+        :privacy_classification, CAST(:payload AS jsonb)
+    )
+    """
+)
+
+
+def _params(event: EventEnvelope) -> dict[str, object]:
+    data = event.model_dump(mode="python")
+    data["event_name"] = event.event_name.value
+    data["entry_point"] = event.entry_point.value
+    data["payload"] = json.dumps(event.payload.model_dump(mode="json"), separators=(",", ":"))
+    return data
+
+
+def _epoch() -> datetime:
+    raw = ENV.ANALYTICS_EPOCH.optional()
+    if raw is None:
+        raise RuntimeError("ANALYTICS_EPOCH is required")
+    parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("ANALYTICS_EPOCH must be timezone-aware")
+    return parsed
+
+
+async def ingest(event: EventEnvelope) -> bool:
+    if event.occurred_at < _epoch():
+        raise ValueError("event occurred before the configured analytics epoch")
+    async with transaction() as conn:
+        inserted = await conn.scalar(
+            _INSERT_ID, {"event_id": event.event_id, "occurred_at": event.occurred_at}
+        )
+        if inserted is None:
+            return False
+        await conn.execute(_INSERT_EVENT, _params(event))
+        await conn.execute(
+            text(
+                "INSERT INTO ingestion_receipts (workspace_id, producer, producer_event_id, "
+                "event_name, event_id, expires_at) VALUES (:workspace_id, :producer, "
+                ":producer_event_id, :event_name, :event_id, clock_timestamp() + "
+                "(:receipt_days * interval '1 day')) ON CONFLICT DO NOTHING"
+            ),
+            {
+                "workspace_id": event.workspace_id,
+                "producer": event.producer,
+                "producer_event_id": event.producer_event_id,
+                "event_name": event.event_name.value,
+                "event_id": event.event_id,
+                "receipt_days": ENV.ANALYTICS_RECEIPT_DAYS.get_int(90),
+            },
+        )
+        await _project(conn, event)
+        await _mark_dirty(conn, event)
+    return True
+
+
+async def _project(conn: AsyncConnection, event: EventEnvelope) -> None:
+    name = event.event_name
+    if name == EventName.RUN_STARTED:
+        payload = event.payload.model_dump(mode="json")
+        await conn.execute(
+            text(
+                """
+                INSERT INTO run_projection (
+                    workspace_id, run_id, preparation_run_id, thread_id, task_id, user_id,
+                    team_id, repository_id, configured_model_id, effective_model_id,
+                    model_attribution_quality, entry_point, started_at
+                ) VALUES (
+                    :workspace_id, :run_id, :preparation_run_id, :thread_id, :task_id, :user_id,
+                    :team_id, :repository_id, :configured_model_id, :effective_model_id,
+                    :quality, :entry_point, :occurred_at
+                ) ON CONFLICT (workspace_id, run_id) DO UPDATE SET
+                    started_at = LEAST(run_projection.started_at, EXCLUDED.started_at),
+                    configured_model_id = COALESCE(EXCLUDED.configured_model_id, run_projection.configured_model_id),
+                    effective_model_id = COALESCE(EXCLUDED.effective_model_id, run_projection.effective_model_id),
+                    model_attribution_quality = CASE WHEN EXCLUDED.model_attribution_quality = 'effective'
+                        THEN EXCLUDED.model_attribution_quality ELSE run_projection.model_attribution_quality END,
+                    entry_point = CASE WHEN run_projection.entry_point = 'unknown'
+                        THEN EXCLUDED.entry_point ELSE run_projection.entry_point END,
+                    thread_id = COALESCE(run_projection.thread_id, EXCLUDED.thread_id),
+                    task_id = COALESCE(run_projection.task_id, EXCLUDED.task_id),
+                    user_id = COALESCE(run_projection.user_id, EXCLUDED.user_id),
+                    team_id = COALESCE(run_projection.team_id, EXCLUDED.team_id),
+                    repository_id = COALESCE(run_projection.repository_id, EXCLUDED.repository_id),
+                    updated_at = clock_timestamp()
+                """
+            ),
+            {
+                **_identity_params(event),
+                "configured_model_id": payload.get("configured_model_id"),
+                "effective_model_id": payload.get("effective_model_id"),
+                "quality": payload["model_attribution_quality"],
+                "entry_point": event.entry_point.value,
+                "occurred_at": event.occurred_at,
+            },
+        )
+    elif name in {EventName.RUN_COMPLETED, EventName.RUN_FAILED, EventName.RUN_CANCELED}:
+        await _project_run_terminal(conn, event)
+    elif name == EventName.RUN_COST_RECORDED:
+        payload = event.payload.model_dump(mode="json")
+        await conn.execute(
+            text(
+                """
+                INSERT INTO latest_cost_projection (
+                    workspace_id, run_id, observation_revision, observed_at, status, cost_usd,
+                    input_tokens, output_tokens, total_tokens, source, missing_reason, event_id
+                ) VALUES (
+                    :workspace_id, :run_id, :revision, :observed_at, :status, :cost_usd,
+                    :input_tokens, :output_tokens, :total_tokens, :source, :missing_reason, :event_id
+                ) ON CONFLICT (workspace_id, run_id) DO UPDATE SET
+                    observation_revision = EXCLUDED.observation_revision,
+                    observed_at = EXCLUDED.observed_at, status = EXCLUDED.status,
+                    cost_usd = EXCLUDED.cost_usd, input_tokens = EXCLUDED.input_tokens,
+                    output_tokens = EXCLUDED.output_tokens, total_tokens = EXCLUDED.total_tokens,
+                    source = EXCLUDED.source, missing_reason = EXCLUDED.missing_reason,
+                    event_id = EXCLUDED.event_id
+                WHERE EXCLUDED.observation_revision > latest_cost_projection.observation_revision
+                   OR (EXCLUDED.observation_revision = latest_cost_projection.observation_revision
+                       AND EXCLUDED.observed_at > latest_cost_projection.observed_at)
+                """
+            ),
+            {
+                "workspace_id": event.workspace_id,
+                "run_id": event.run_id,
+                "revision": payload["observation_revision"],
+                "observed_at": payload["observed_at"],
+                "status": payload["status"],
+                "cost_usd": payload.get("cost_usd"),
+                "input_tokens": payload.get("input_tokens"),
+                "output_tokens": payload.get("output_tokens"),
+                "total_tokens": payload.get("total_tokens"),
+                "source": payload["source"],
+                "missing_reason": payload.get("missing_reason"),
+                "event_id": event.event_id,
+            },
+        )
+    elif name == EventName.PR_OPENED:
+        payload = event.payload.model_dump(mode="json")
+        await conn.execute(
+            text(
+                """
+                INSERT INTO pr_projection (
+                    workspace_id, pr_id, repository_id, opening_run_id, originating_model_id,
+                    model_attribution_quality, opened_at, current_state, source_version,
+                    repository_private
+                ) VALUES (
+                    :workspace_id, :pr_id, :repository_id, :opening_run_id, :model_id,
+                    :quality, :occurred_at, 'open', :source_version, :repository_private
+                ) ON CONFLICT (workspace_id, pr_id) DO NOTHING
+                """
+            ),
+            {
+                "workspace_id": event.workspace_id,
+                "pr_id": event.pr_id,
+                "repository_id": event.repository_id,
+                "opening_run_id": payload["opening_run_id"],
+                "model_id": payload.get("originating_model_id"),
+                "quality": payload["model_attribution_quality"],
+                "occurred_at": event.occurred_at,
+                "source_version": event.source_version,
+                "repository_private": payload.get("repository_private"),
+            },
+        )
+    elif name == EventName.PR_RUN_LINKED:
+        await conn.execute(
+            text(
+                "INSERT INTO pr_run_link_projection (workspace_id, pr_id, run_id, link_role, "
+                "linked_at) VALUES (:workspace_id, :pr_id, :run_id, :link_role, :occurred_at) "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {
+                "workspace_id": event.workspace_id,
+                "pr_id": event.pr_id,
+                "run_id": event.run_id,
+                "link_role": event.payload.model_dump()["link_role"],
+                "occurred_at": event.occurred_at,
+            },
+        )
+    elif name == EventName.FEEDBACK_SUBMITTED:
+        payload = event.payload.model_dump(mode="json")
+        await conn.execute(
+            text(
+                "INSERT INTO feedback_projection (workspace_id, feedback_id, run_id, task_id, "
+                "user_id, sentiment, rating, submitted_at) VALUES (:workspace_id, :feedback_id, "
+                ":run_id, :task_id, :user_id, :sentiment, :rating, :occurred_at) ON CONFLICT "
+                "(workspace_id, feedback_id) DO NOTHING"
+            ),
+            {
+                "workspace_id": event.workspace_id,
+                "feedback_id": event.event_id,
+                "run_id": event.run_id,
+                "task_id": event.task_id,
+                "user_id": event.user_id,
+                "sentiment": payload["sentiment"],
+                "rating": payload.get("rating"),
+                "occurred_at": event.occurred_at,
+            },
+        )
+    elif name == EventName.FEEDBACK_WITHDRAWN:
+        await conn.execute(
+            text(
+                "UPDATE feedback_projection SET withdrawn_at = :occurred_at WHERE workspace_id "
+                "= :workspace_id AND feedback_id = :feedback_id AND withdrawn_at IS NULL"
+            ),
+            {
+                "occurred_at": event.occurred_at,
+                "workspace_id": event.workspace_id,
+                "feedback_id": event.payload.model_dump()["submission_event_id"],
+            },
+        )
+    elif name in {
+        EventName.TASK_MARKED_COMPLETE,
+        EventName.TASK_ACCEPTED,
+        EventName.TASK_REWORK_REQUESTED,
+    }:
+        payload = event.payload.model_dump()
+        await conn.execute(
+            text(
+                "INSERT INTO task_projection (workspace_id, task_id, thread_id, user_id, "
+                "marked_complete_at, accepted_at, major_rework_count, minor_rework_count) VALUES "
+                "(:workspace_id, :task_id, :thread_id, :user_id, :complete_at, :accepted_at, "
+                ":major, :minor) ON CONFLICT (workspace_id, task_id) DO UPDATE SET "
+                "thread_id = COALESCE(task_projection.thread_id, EXCLUDED.thread_id), user_id = "
+                "COALESCE(task_projection.user_id, EXCLUDED.user_id), marked_complete_at = "
+                "COALESCE(task_projection.marked_complete_at, EXCLUDED.marked_complete_at), "
+                "accepted_at = COALESCE(task_projection.accepted_at, EXCLUDED.accepted_at), "
+                "major_rework_count = task_projection.major_rework_count + EXCLUDED.major_rework_count, "
+                "minor_rework_count = task_projection.minor_rework_count + EXCLUDED.minor_rework_count, "
+                "updated_at = clock_timestamp()"
+            ),
+            {
+                "workspace_id": event.workspace_id,
+                "task_id": event.task_id,
+                "thread_id": event.thread_id,
+                "user_id": event.user_id,
+                "complete_at": event.occurred_at
+                if name == EventName.TASK_MARKED_COMPLETE
+                else None,
+                "accepted_at": event.occurred_at if name == EventName.TASK_ACCEPTED else None,
+                "major": 1
+                if name == EventName.TASK_REWORK_REQUESTED and payload["scope"] == "major"
+                else 0,
+                "minor": 1
+                if name == EventName.TASK_REWORK_REQUESTED and payload["scope"] == "minor"
+                else 0,
+            },
+        )
+    elif name in {
+        EventName.PR_MERGED,
+        EventName.PR_CLOSED_WITHOUT_MERGE,
+        EventName.PR_REOPENED,
+    }:
+        state = {
+            EventName.PR_MERGED: "merged",
+            EventName.PR_CLOSED_WITHOUT_MERGE: "closed_without_merge",
+            EventName.PR_REOPENED: "open",
+        }[name]
+        await conn.execute(
+            text(
+                "UPDATE pr_projection SET current_state = :state, outcome_at = CASE WHEN "
+                ":state = 'open' THEN NULL ELSE :occurred_at END, source_version = :source_version, "
+                "updated_at = clock_timestamp() WHERE workspace_id = :workspace_id AND pr_id = :pr_id "
+                "AND ((:source_version IS NOT NULL AND (source_version IS NULL OR :source_version > source_version)) "
+                "OR (:source_version IS NULL AND source_version IS NULL AND "
+                "(outcome_at IS NULL OR :occurred_at >= outcome_at)))"
+            ),
+            {
+                "state": state,
+                "occurred_at": event.occurred_at,
+                "source_version": event.source_version,
+                "workspace_id": event.workspace_id,
+                "pr_id": event.pr_id,
+            },
+        )
+    elif name == EventName.REVIEW_PUBLISHED:
+        await conn.execute(
+            text(
+                "INSERT INTO review_projection (workspace_id, review_id, pr_id, repository_id, "
+                "published_at, finding_count) VALUES (:workspace_id, :review_id, :pr_id, "
+                ":repository_id, :occurred_at, :finding_count) ON CONFLICT DO NOTHING"
+            ),
+            {
+                "workspace_id": event.workspace_id,
+                "review_id": event.review_id,
+                "pr_id": event.pr_id,
+                "repository_id": event.repository_id,
+                "occurred_at": event.occurred_at,
+                "finding_count": event.payload.model_dump()["finding_count"],
+            },
+        )
+    elif name == EventName.FINDING_SURFACED:
+        payload = event.payload.model_dump()
+        await conn.execute(
+            text(
+                "INSERT INTO finding_projection (workspace_id, finding_id, review_id, pr_id, "
+                "repository_id, severity, category, surfaced_at) VALUES (:workspace_id, "
+                ":finding_id, :review_id, :pr_id, :repository_id, :severity, :category, "
+                ":occurred_at) ON CONFLICT (workspace_id, finding_id) DO UPDATE SET surfaced_at = "
+                "COALESCE(finding_projection.surfaced_at, EXCLUDED.surfaced_at), updated_at = clock_timestamp()"
+            ),
+            {
+                "workspace_id": event.workspace_id,
+                "finding_id": event.finding_id,
+                "review_id": event.review_id,
+                "pr_id": event.pr_id,
+                "repository_id": event.repository_id,
+                "severity": payload["severity"],
+                "category": payload["category"],
+                "occurred_at": event.occurred_at,
+            },
+        )
+    elif name in {
+        EventName.FINDING_RESOLVED,
+        EventName.FINDING_DISMISSED,
+        EventName.FINDING_REOPENED,
+    }:
+        state = {
+            EventName.FINDING_RESOLVED: "resolved",
+            EventName.FINDING_DISMISSED: "dismissed",
+            EventName.FINDING_REOPENED: "open",
+        }[name]
+        await conn.execute(
+            text(
+                "UPDATE finding_projection SET current_state = :state, resolved_at = CASE WHEN "
+                ":state = 'resolved' THEN :occurred_at ELSE resolved_at END, dismissed_at = CASE "
+                "WHEN :state = 'dismissed' THEN :occurred_at ELSE dismissed_at END, reopened_count = "
+                "reopened_count + CASE WHEN :state = 'open' THEN 1 ELSE 0 END, source_version = "
+                ":source_version, latest_occurred_at = :occurred_at, updated_at = clock_timestamp() "
+                "WHERE workspace_id = :workspace_id AND finding_id = :finding_id AND "
+                "((:source_version IS NOT NULL AND (source_version IS NULL OR :source_version > source_version)) "
+                "OR (:source_version IS NULL AND source_version IS NULL AND "
+                "(latest_occurred_at IS NULL OR :occurred_at > latest_occurred_at)))"
+            ),
+            {
+                "state": state,
+                "occurred_at": event.occurred_at,
+                "source_version": event.source_version,
+                "workspace_id": event.workspace_id,
+                "finding_id": event.finding_id,
+            },
+        )
+
+
+async def _project_run_terminal(conn: AsyncConnection, event: EventEnvelope) -> None:
+    requested = {
+        EventName.RUN_COMPLETED: "completed",
+        EventName.RUN_FAILED: "failed",
+        EventName.RUN_CANCELED: "canceled",
+    }[event.event_name]
+    payload = event.payload.model_dump()
+    input_tokens = payload.get("input_tokens")
+    output_tokens = payload.get("output_tokens")
+    total_tokens = payload.get("total_tokens")
+    current = await conn.execute(
+        text(
+            "SELECT technical_status, terminal_event_ids FROM run_projection WHERE workspace_id = "
+            ":workspace_id AND run_id = :run_id FOR UPDATE"
+        ),
+        {"workspace_id": event.workspace_id, "run_id": event.run_id},
+    )
+    row = current.mappings().one_or_none()
+    if row is None:
+        await conn.execute(
+            text(
+                "INSERT INTO run_projection (workspace_id, run_id, technical_status, terminal_at, "
+                "terminal_event_ids, input_tokens, output_tokens, total_tokens) VALUES "
+                "(:workspace_id, :run_id, :status, :occurred_at, ARRAY[:event_id]::uuid[], "
+                ":input_tokens, :output_tokens, :total_tokens)"
+            ),
+            {
+                "workspace_id": event.workspace_id,
+                "run_id": event.run_id,
+                "status": requested,
+                "occurred_at": event.occurred_at,
+                "event_id": event.event_id,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "total_tokens": total_tokens,
+            },
+        )
+        return
+    current_status = row["technical_status"]
+    event_ids = list(row["terminal_event_ids"] or [])
+    if event.event_id not in event_ids:
+        event_ids.append(event.event_id)
+    conflict = current_status not in {"pending", requested}
+    status = "conflicted" if conflict else requested
+    await conn.execute(
+        text(
+            "UPDATE run_projection SET technical_status = :status, terminal_at = LEAST(COALESCE("
+            "terminal_at, :occurred_at), :occurred_at), terminal_conflict = :conflict, "
+            "terminal_event_ids = :event_ids, input_tokens = COALESCE(:input_tokens, input_tokens), "
+            "output_tokens = COALESCE(:output_tokens, output_tokens), total_tokens = COALESCE("
+            ":total_tokens, total_tokens), updated_at = "
+            "clock_timestamp() WHERE workspace_id = :workspace_id AND run_id = :run_id"
+        ),
+        {
+            "status": status,
+            "occurred_at": event.occurred_at,
+            "conflict": conflict,
+            "event_ids": event_ids,
+            "workspace_id": event.workspace_id,
+            "run_id": event.run_id,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_tokens": total_tokens,
+        },
+    )
+    if conflict:
+        await conn.execute(
+            text(
+                "INSERT INTO projection_conflicts (workspace_id, subject_type, subject_id, "
+                "conflict_type, event_ids) VALUES (:workspace_id, 'run', :run_id, "
+                "'contradictory_terminal_state', :event_ids) ON CONFLICT (workspace_id, "
+                "subject_type, subject_id, conflict_type) DO UPDATE SET event_ids = EXCLUDED.event_ids, "
+                "detected_at = clock_timestamp(), resolved_at = NULL"
+            ),
+            {
+                "workspace_id": event.workspace_id,
+                "run_id": event.run_id,
+                "event_ids": event_ids,
+            },
+        )
+
+
+def _identity_params(event: EventEnvelope) -> dict[str, UUID | None]:
+    return {
+        "workspace_id": event.workspace_id,
+        "run_id": event.run_id,
+        "preparation_run_id": event.preparation_run_id,
+        "thread_id": event.thread_id,
+        "task_id": event.task_id,
+        "user_id": event.user_id,
+        "team_id": event.team_id,
+        "repository_id": event.repository_id,
+    }
+
+
+async def _mark_dirty(conn: AsyncConnection, event: EventEnvelope) -> None:
+    version = ENV.ANALYTICS_SUMMARY_VERSION.get_int(1)
+    families = {"additive", "distinct_membership"}
+    dates = {event.occurred_at.date()}
+    if event.pr_id is not None:
+        families.add("pr_open_cohort")
+        opened_at = await conn.scalar(
+            text(
+                "SELECT opened_at FROM pr_projection WHERE workspace_id = :workspace_id AND pr_id = :pr_id"
+            ),
+            {"workspace_id": event.workspace_id, "pr_id": event.pr_id},
+        )
+        if opened_at is not None:
+            dates.add(opened_at.date())
+    if event.finding_id is not None:
+        families.update({"finding_surfaced_cohort", "latency_histogram"})
+        surfaced_at = await conn.scalar(
+            text(
+                "SELECT surfaced_at FROM finding_projection WHERE workspace_id = :workspace_id "
+                "AND finding_id = :finding_id"
+            ),
+            {"workspace_id": event.workspace_id, "finding_id": event.finding_id},
+        )
+        if surfaced_at is not None:
+            dates.add(surfaced_at.date())
+    if event.event_name in {EventName.RUN_STARTED, EventName.RUN_COST_RECORDED}:
+        families.add("cost_completeness")
+    for family in families:
+        for partition_date in dates:
+            await conn.execute(
+                text(
+                    "INSERT INTO dirty_summary_partitions (workspace_id, summary_version, family, "
+                    "partition_date, reason_event_id) VALUES (:workspace_id, :version, :family, "
+                    ":partition_date, :event_id) ON CONFLICT (workspace_id, summary_version, "
+                    "family, partition_date, dimension_key) DO UPDATE SET dirty_since = "
+                    "LEAST(dirty_summary_partitions.dirty_since, clock_timestamp()), reason_event_id = "
+                    "EXCLUDED.reason_event_id"
+                ),
+                {
+                    "workspace_id": event.workspace_id,
+                    "version": version,
+                    "family": family,
+                    "partition_date": partition_date,
+                    "event_id": event.event_id,
+                },
+            )

--- a/agent/analytics/migrations/0001_analytics.sql
+++ b/agent/analytics/migrations/0001_analytics.sql
@@ -1,0 +1,295 @@
+CREATE SCHEMA IF NOT EXISTS open_swe_analytics;
+SET search_path TO open_swe_analytics, public;
+
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    version integer PRIMARY KEY,
+    applied_at timestamptz NOT NULL DEFAULT clock_timestamp()
+);
+
+CREATE TABLE IF NOT EXISTS event_ids (
+    event_id uuid PRIMARY KEY,
+    occurred_at timestamptz NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS events (
+    event_id uuid NOT NULL,
+    event_name text NOT NULL,
+    schema_version integer NOT NULL,
+    occurred_at timestamptz NOT NULL,
+    recorded_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+    workspace_id uuid NOT NULL,
+    environment text NOT NULL,
+    producer text NOT NULL,
+    producer_event_id text NOT NULL,
+    source_version bigint,
+    correlation_id uuid,
+    causation_id uuid,
+    run_id uuid,
+    preparation_run_id uuid,
+    thread_id uuid,
+    task_id uuid,
+    pr_id uuid,
+    review_id uuid,
+    finding_id uuid,
+    user_id uuid,
+    team_id uuid,
+    repository_id uuid,
+    model_id uuid,
+    entry_point text NOT NULL,
+    privacy_classification text NOT NULL CHECK (privacy_classification IN ('non_personal', 'pseudonymous')),
+    payload jsonb NOT NULL,
+    PRIMARY KEY (event_id, occurred_at),
+    UNIQUE (workspace_id, producer, producer_event_id, event_name, schema_version, occurred_at)
+) PARTITION BY RANGE (occurred_at);
+
+CREATE TABLE IF NOT EXISTS events_default PARTITION OF events DEFAULT;
+CREATE INDEX IF NOT EXISTS events_workspace_time_idx ON events (workspace_id, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS events_workspace_run_idx ON events (workspace_id, run_id, occurred_at);
+CREATE INDEX IF NOT EXISTS events_workspace_pr_idx ON events (workspace_id, pr_id, occurred_at);
+CREATE INDEX IF NOT EXISTS events_workspace_finding_idx ON events (workspace_id, finding_id, occurred_at);
+CREATE INDEX IF NOT EXISTS events_workspace_user_idx ON events (workspace_id, user_id, occurred_at);
+CREATE INDEX IF NOT EXISTS events_workspace_repo_idx ON events (workspace_id, repository_id, occurred_at);
+
+CREATE TABLE IF NOT EXISTS ingestion_receipts (
+    workspace_id uuid NOT NULL,
+    producer text NOT NULL,
+    producer_event_id text NOT NULL,
+    event_name text NOT NULL,
+    event_id uuid NOT NULL,
+    received_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+    expires_at timestamptz NOT NULL,
+    PRIMARY KEY (workspace_id, producer, producer_event_id, event_name)
+);
+CREATE INDEX IF NOT EXISTS ingestion_receipts_expiry_idx ON ingestion_receipts (expires_at);
+
+CREATE TABLE IF NOT EXISTS outbox (
+    event_id uuid PRIMARY KEY,
+    workspace_id uuid NOT NULL,
+    event_body jsonb NOT NULL,
+    state text NOT NULL DEFAULT 'pending' CHECK (state IN ('pending', 'delivering', 'acknowledged', 'dead_letter')),
+    attempts integer NOT NULL DEFAULT 0,
+    next_attempt_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+    locked_at timestamptz,
+    acknowledged_at timestamptz,
+    dead_lettered_at timestamptz,
+    last_error text,
+    created_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+    updated_at timestamptz NOT NULL DEFAULT clock_timestamp()
+);
+CREATE INDEX IF NOT EXISTS outbox_delivery_idx ON outbox (state, next_attempt_at, created_at);
+CREATE INDEX IF NOT EXISTS outbox_stale_idx ON outbox (state, created_at);
+
+CREATE TABLE IF NOT EXISTS run_projection (
+    workspace_id uuid NOT NULL,
+    run_id uuid NOT NULL,
+    preparation_run_id uuid,
+    thread_id uuid,
+    task_id uuid,
+    user_id uuid,
+    team_id uuid,
+    repository_id uuid,
+    configured_model_id uuid,
+    effective_model_id uuid,
+    model_attribution_quality text NOT NULL DEFAULT 'unavailable',
+    entry_point text NOT NULL DEFAULT 'unknown',
+    started_at timestamptz,
+    terminal_at timestamptz,
+    technical_status text NOT NULL DEFAULT 'pending' CHECK (technical_status IN ('pending', 'completed', 'failed', 'canceled', 'conflicted')),
+    terminal_conflict boolean NOT NULL DEFAULT false,
+    terminal_event_ids uuid[] NOT NULL DEFAULT '{}',
+    input_tokens bigint,
+    output_tokens bigint,
+    total_tokens bigint,
+    updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+    PRIMARY KEY (workspace_id, run_id)
+);
+CREATE INDEX IF NOT EXISTS run_projection_leaderboard_idx ON run_projection (workspace_id, started_at DESC, user_id);
+CREATE INDEX IF NOT EXISTS run_projection_dimensions_idx ON run_projection (workspace_id, team_id, entry_point, effective_model_id, repository_id, started_at);
+
+CREATE TABLE IF NOT EXISTS task_projection (
+    workspace_id uuid NOT NULL,
+    task_id uuid NOT NULL,
+    thread_id uuid,
+    user_id uuid,
+    marked_complete_at timestamptz,
+    accepted_at timestamptz,
+    major_rework_count integer NOT NULL DEFAULT 0,
+    minor_rework_count integer NOT NULL DEFAULT 0,
+    updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+    PRIMARY KEY (workspace_id, task_id)
+);
+
+CREATE TABLE IF NOT EXISTS pr_projection (
+    workspace_id uuid NOT NULL,
+    pr_id uuid NOT NULL,
+    repository_id uuid NOT NULL,
+    opening_run_id uuid NOT NULL,
+    originating_model_id uuid,
+    model_attribution_quality text NOT NULL,
+    opened_at timestamptz NOT NULL,
+    current_state text NOT NULL CHECK (current_state IN ('open', 'merged', 'closed_without_merge')),
+    outcome_at timestamptz,
+    source_version bigint,
+    repository_private boolean,
+    updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+    PRIMARY KEY (workspace_id, pr_id)
+);
+CREATE INDEX IF NOT EXISTS pr_projection_cohort_idx ON pr_projection (workspace_id, opened_at, originating_model_id, current_state);
+CREATE INDEX IF NOT EXISTS pr_projection_repo_idx ON pr_projection (workspace_id, repository_id, opened_at);
+
+CREATE TABLE IF NOT EXISTS pr_run_link_projection (
+    workspace_id uuid NOT NULL,
+    pr_id uuid NOT NULL,
+    run_id uuid NOT NULL,
+    link_role text NOT NULL,
+    linked_at timestamptz NOT NULL,
+    PRIMARY KEY (workspace_id, pr_id, run_id)
+);
+
+CREATE TABLE IF NOT EXISTS latest_cost_projection (
+    workspace_id uuid NOT NULL,
+    run_id uuid NOT NULL,
+    observation_revision integer NOT NULL,
+    observed_at timestamptz NOT NULL,
+    status text NOT NULL CHECK (status IN ('complete', 'partial', 'unavailable')),
+    cost_usd numeric(20, 8),
+    input_tokens bigint,
+    output_tokens bigint,
+    total_tokens bigint,
+    source text NOT NULL,
+    missing_reason text,
+    event_id uuid NOT NULL,
+    PRIMARY KEY (workspace_id, run_id)
+);
+
+CREATE TABLE IF NOT EXISTS review_projection (
+    workspace_id uuid NOT NULL,
+    review_id uuid NOT NULL,
+    pr_id uuid,
+    repository_id uuid,
+    published_at timestamptz NOT NULL,
+    finding_count integer NOT NULL,
+    PRIMARY KEY (workspace_id, review_id)
+);
+
+CREATE TABLE IF NOT EXISTS finding_projection (
+    workspace_id uuid NOT NULL,
+    finding_id uuid NOT NULL,
+    review_id uuid,
+    pr_id uuid,
+    repository_id uuid,
+    severity text,
+    category text,
+    surfaced_at timestamptz,
+    current_state text NOT NULL DEFAULT 'open' CHECK (current_state IN ('open', 'resolved', 'dismissed')),
+    resolved_at timestamptz,
+    dismissed_at timestamptz,
+    reopened_count integer NOT NULL DEFAULT 0,
+    source_version bigint,
+    latest_occurred_at timestamptz,
+    updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+    PRIMARY KEY (workspace_id, finding_id)
+);
+CREATE INDEX IF NOT EXISTS finding_projection_cohort_idx ON finding_projection (workspace_id, surfaced_at, current_state);
+
+CREATE TABLE IF NOT EXISTS feedback_projection (
+    workspace_id uuid NOT NULL,
+    feedback_id uuid NOT NULL,
+    run_id uuid,
+    task_id uuid,
+    user_id uuid,
+    sentiment text NOT NULL CHECK (sentiment IN ('positive', 'neutral', 'negative')),
+    rating integer,
+    submitted_at timestamptz NOT NULL,
+    withdrawn_at timestamptz,
+    PRIMARY KEY (workspace_id, feedback_id)
+);
+
+CREATE TABLE IF NOT EXISTS projection_conflicts (
+    workspace_id uuid NOT NULL,
+    subject_type text NOT NULL,
+    subject_id uuid NOT NULL,
+    conflict_type text NOT NULL,
+    event_ids uuid[] NOT NULL,
+    detected_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+    resolved_at timestamptz,
+    PRIMARY KEY (workspace_id, subject_type, subject_id, conflict_type)
+);
+
+CREATE TABLE IF NOT EXISTS dirty_summary_partitions (
+    workspace_id uuid NOT NULL,
+    summary_version integer NOT NULL,
+    family text NOT NULL,
+    partition_date date NOT NULL,
+    dimension_key text NOT NULL DEFAULT '',
+    dirty_since timestamptz NOT NULL DEFAULT clock_timestamp(),
+    reason_event_id uuid NOT NULL,
+    PRIMARY KEY (workspace_id, summary_version, family, partition_date, dimension_key)
+);
+
+CREATE TABLE IF NOT EXISTS daily_summaries (
+    workspace_id uuid NOT NULL,
+    summary_version integer NOT NULL,
+    family text NOT NULL,
+    partition_date date NOT NULL,
+    dimension_key text NOT NULL DEFAULT '',
+    counters jsonb NOT NULL DEFAULT '{}',
+    sums jsonb NOT NULL DEFAULT '{}',
+    exact_members uuid[] NOT NULL DEFAULT '{}',
+    histogram_bounds bigint[] NOT NULL DEFAULT '{}',
+    histogram_counts bigint[] NOT NULL DEFAULT '{}',
+    completeness jsonb NOT NULL DEFAULT '{}',
+    data_watermark timestamptz,
+    recomputed_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+    PRIMARY KEY (workspace_id, summary_version, family, partition_date, dimension_key)
+);
+CREATE INDEX IF NOT EXISTS daily_summaries_query_idx ON daily_summaries (workspace_id, summary_version, family, partition_date, dimension_key);
+
+CREATE TABLE IF NOT EXISTS identity_directory (
+    workspace_id uuid NOT NULL,
+    person_id uuid NOT NULL,
+    github_login text,
+    display_name text,
+    email text,
+    team_id uuid,
+    anonymize_after timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+    PRIMARY KEY (workspace_id, person_id)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS identity_directory_login_idx ON identity_directory (workspace_id, lower(github_login)) WHERE github_login IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS model_directory (
+    workspace_id uuid NOT NULL,
+    model_id uuid NOT NULL,
+    provider_model_id text NOT NULL,
+    updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+    PRIMARY KEY (workspace_id, model_id)
+);
+
+CREATE TABLE IF NOT EXISTS repository_directory (
+    workspace_id uuid NOT NULL,
+    repository_id uuid NOT NULL,
+    full_name text NOT NULL,
+    private boolean NOT NULL,
+    updated_at timestamptz NOT NULL DEFAULT clock_timestamp(),
+    PRIMARY KEY (workspace_id, repository_id)
+);
+
+CREATE TABLE IF NOT EXISTS named_export_audit (
+    audit_id uuid PRIMARY KEY,
+    workspace_id uuid NOT NULL,
+    actor_person_id uuid NOT NULL,
+    scope text NOT NULL,
+    exported_at timestamptz NOT NULL DEFAULT clock_timestamp()
+);
+
+CREATE OR REPLACE FUNCTION reject_event_mutation() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    RAISE EXCEPTION 'analytics events are immutable';
+END;
+$$;
+DROP TRIGGER IF EXISTS events_immutable ON events;
+CREATE TRIGGER events_immutable BEFORE UPDATE ON events
+FOR EACH ROW EXECUTE FUNCTION reject_event_mutation();
+
+INSERT INTO schema_migrations(version) VALUES (1) ON CONFLICT DO NOTHING;

--- a/agent/analytics/outbox.py
+++ b/agent/analytics/outbox.py
@@ -1,0 +1,208 @@
+"""Durable at-least-once analytics delivery."""
+
+import asyncio
+import logging
+import random
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import text
+
+from agent.analytics.database import configured, transaction
+from agent.analytics.events import EventEnvelope
+from agent.analytics.ingestion import ingest
+from agent.config import ENV
+
+logger = logging.getLogger(__name__)
+
+_STOP = asyncio.Event()
+_WORKER: asyncio.Task[None] | None = None
+
+
+async def enqueue(event: EventEnvelope) -> bool:
+    async with transaction() as conn:
+        result = await conn.execute(
+            text(
+                "INSERT INTO outbox (event_id, workspace_id, event_body) VALUES "
+                "(:event_id, :workspace_id, CAST(:event_body AS jsonb)) ON CONFLICT DO NOTHING "
+                "RETURNING event_id"
+            ),
+            {
+                "event_id": event.event_id,
+                "workspace_id": event.workspace_id,
+                "event_body": event.model_dump_json(),
+            },
+        )
+        return result.scalar_one_or_none() is not None
+
+
+async def _claim(limit: int = 50) -> list[dict[str, Any]]:
+    async with transaction() as conn:
+        result = await conn.execute(
+            text(
+                """
+                WITH candidates AS (
+                    SELECT event_id FROM outbox
+                    WHERE state IN ('pending', 'delivering')
+                      AND next_attempt_at <= clock_timestamp()
+                      AND (state = 'pending' OR locked_at < clock_timestamp() - interval '5 minutes')
+                    ORDER BY created_at
+                    FOR UPDATE SKIP LOCKED
+                    LIMIT :limit
+                )
+                UPDATE outbox AS target
+                SET state = 'delivering', locked_at = clock_timestamp(),
+                    attempts = attempts + 1, updated_at = clock_timestamp()
+                FROM candidates
+                WHERE target.event_id = candidates.event_id
+                RETURNING target.event_id, target.event_body, target.attempts
+                """
+            ),
+            {"limit": min(max(limit, 1), 100)},
+        )
+        return [dict(row) for row in result.mappings()]
+
+
+def _delay(attempt: int) -> float:
+    base = min(3600.0, 2.0 ** min(attempt, 12))
+    return base * random.uniform(0.5, 1.5)
+
+
+async def _ack(event_id: UUID) -> None:
+    async with transaction() as conn:
+        await conn.execute(
+            text(
+                "UPDATE outbox SET state = 'acknowledged', acknowledged_at = clock_timestamp(), "
+                "locked_at = NULL, last_error = NULL, updated_at = clock_timestamp() "
+                "WHERE event_id = :event_id"
+            ),
+            {"event_id": event_id},
+        )
+
+
+async def _fail(event_id: UUID, attempt: int, exc: Exception) -> None:
+    exhausted = attempt >= ENV.ANALYTICS_OUTBOX_MAX_ATTEMPTS.get_int(10)
+    message = type(exc).__name__
+    async with transaction() as conn:
+        await conn.execute(
+            text(
+                "UPDATE outbox SET state = :state, dead_lettered_at = CASE WHEN :exhausted "
+                "THEN clock_timestamp() ELSE NULL END, next_attempt_at = :next_attempt_at, "
+                "locked_at = NULL, last_error = :error, updated_at = clock_timestamp() "
+                "WHERE event_id = :event_id"
+            ),
+            {
+                "state": "dead_letter" if exhausted else "pending",
+                "exhausted": exhausted,
+                "next_attempt_at": datetime.now(UTC) + timedelta(seconds=_delay(attempt)),
+                "error": message,
+                "event_id": event_id,
+            },
+        )
+
+
+async def deliver_batch() -> int:
+    delivered = 0
+    for record in await _claim():
+        event_id = UUID(str(record["event_id"]))
+        try:
+            event = EventEnvelope.model_validate(record["event_body"])
+            await ingest(event)
+            await _ack(event_id)
+            delivered += 1
+        except Exception as exc:  # noqa: BLE001
+            await _fail(event_id, int(record["attempts"]), exc)
+            logger.warning(
+                "Analytics delivery failed",
+                extra={
+                    "analytics_event_id": str(event_id),
+                    "analytics_attempt": record["attempts"],
+                },
+                exc_info=True,
+            )
+    return delivered
+
+
+async def outbox_status(stale_minutes: int = 15) -> dict[str, int]:
+    async with transaction() as conn:
+        result = await conn.execute(
+            text(
+                "SELECT count(*) FILTER (WHERE state = 'pending') AS pending, count(*) FILTER "
+                "(WHERE state = 'dead_letter') AS dead_letters, count(*) FILTER (WHERE state IN "
+                "('pending', 'delivering') AND created_at < clock_timestamp() - "
+                "(:stale_minutes * interval '1 minute')) AS stale FROM outbox"
+            ),
+            {"stale_minutes": min(max(stale_minutes, 1), 1440)},
+        )
+        row = result.mappings().one()
+        return {key: int(row[key] or 0) for key in ("pending", "dead_letters", "stale")}
+
+
+async def run_worker() -> None:
+    while not _STOP.is_set():
+        try:
+            delivered = await deliver_batch()
+            from agent.analytics.summaries import recompute_dirty_partitions
+
+            await recompute_dirty_partitions(limit=20)
+            await enforce_retention()
+        except Exception:  # noqa: BLE001
+            delivered = 0
+            logger.warning("Analytics worker iteration failed", exc_info=True)
+        try:
+            await asyncio.wait_for(_STOP.wait(), timeout=0.25 if delivered else 5.0)
+        except TimeoutError:
+            pass
+
+
+def start_worker() -> None:
+    global _WORKER
+    if not configured() or (_WORKER is not None and not _WORKER.done()):
+        return
+    _STOP.clear()
+    _WORKER = asyncio.create_task(run_worker(), name="analytics-outbox-worker")
+
+
+async def stop_worker() -> None:
+    global _WORKER
+    _STOP.set()
+    if _WORKER is not None:
+        await _WORKER
+    _WORKER = None
+
+
+async def enforce_retention() -> None:
+    async with transaction() as conn:
+        await conn.execute(
+            text(
+                "DELETE FROM events WHERE occurred_at < clock_timestamp() - "
+                "(:months * interval '1 month')"
+            ),
+            {"months": ENV.ANALYTICS_RAW_EVENT_MONTHS.get_int(25)},
+        )
+        await conn.execute(
+            text("DELETE FROM ingestion_receipts WHERE expires_at < clock_timestamp()")
+        )
+        await conn.execute(
+            text(
+                "DELETE FROM outbox WHERE state = 'acknowledged' AND acknowledged_at < "
+                "clock_timestamp() - (:days * interval '1 day')"
+            ),
+            {"days": ENV.ANALYTICS_ACK_OUTBOX_DAYS.get_int(30)},
+        )
+        await conn.execute(
+            text(
+                "UPDATE identity_directory SET github_login = NULL, display_name = NULL, email = "
+                "NULL, team_id = NULL, updated_at = clock_timestamp() WHERE anonymize_after < "
+                "clock_timestamp() AND (github_login IS NOT NULL OR display_name IS NOT NULL OR "
+                "email IS NOT NULL OR team_id IS NOT NULL)"
+            )
+        )
+        await conn.execute(
+            text(
+                "DELETE FROM daily_summaries WHERE partition_date < current_date - "
+                "(:years * interval '1 year')"
+            ),
+            {"years": ENV.ANALYTICS_AGGREGATE_YEARS.get_int(7)},
+        )

--- a/agent/analytics/queries.py
+++ b/agent/analytics/queries.py
@@ -1,0 +1,253 @@
+"""Bounded indexed analytics queries for dashboard metrics."""
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from sqlalchemy import text
+
+from agent.analytics.database import connection
+from agent.analytics.emitter import opaque_person, workspace_id
+from agent.analytics.summaries import summary_metadata
+from agent.config import ENV
+
+
+def period_start(period: str | None) -> datetime:
+    days = 7 if period == "7d" else 30
+    if period == "all":
+        raw = ENV.ANALYTICS_EPOCH.require()
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    return datetime.now(UTC) - timedelta(days=days)
+
+
+async def usage_leaderboard(
+    *, period: str | None, limit: int, current_login: str | None, admin: bool
+) -> dict[str, Any]:
+    start = period_start(period)
+    max_rows = min(max(limit, 1), 100)
+    current_person = opaque_person("github", current_login)
+    sql = text(
+        """
+        WITH run_stats AS (
+            SELECT user_id, count(*) AS agent_runs,
+                   COALESCE(sum(total_tokens), 0) AS total_tokens,
+                   COALESCE(sum(EXTRACT(EPOCH FROM (terminal_at - started_at)))
+                       FILTER (WHERE terminal_at >= started_at), 0) AS duration_seconds,
+                   count(*) FILTER (WHERE terminal_at >= started_at) AS finished_runs,
+                   count(*) FILTER (WHERE technical_status = 'completed') AS completed_runs,
+                   count(*) FILTER (WHERE technical_status = 'failed') AS failed_runs,
+                   count(*) FILTER (WHERE technical_status = 'canceled') AS canceled_runs
+            FROM run_projection
+            WHERE workspace_id = :workspace_id AND started_at >= :start AND user_id IS NOT NULL
+            GROUP BY user_id
+        ), pr_stats AS (
+            SELECT r.user_id, count(DISTINCT p.pr_id) AS prs_opened,
+                   count(DISTINCT p.pr_id) FILTER (WHERE p.current_state = 'merged') AS merged_prs
+            FROM pr_projection p JOIN run_projection r
+              ON r.workspace_id = p.workspace_id AND r.run_id = p.opening_run_id
+            WHERE p.workspace_id = :workspace_id AND p.opened_at >= :start
+            GROUP BY r.user_id
+        ), cost_stats AS (
+            SELECT r.user_id, COALESCE(sum(c.cost_usd), 0) AS total_cost_usd,
+                   count(*) FILTER (WHERE c.status = 'complete') AS known_cost_runs,
+                   count(*) AS cost_run_count
+            FROM run_projection r LEFT JOIN latest_cost_projection c
+              ON c.workspace_id = r.workspace_id AND c.run_id = r.run_id
+            WHERE r.workspace_id = :workspace_id AND r.started_at >= :start AND r.user_id IS NOT NULL
+            GROUP BY r.user_id
+        ), combined AS (
+            SELECT r.*, COALESCE(p.prs_opened, 0) AS prs_opened,
+                   COALESCE(p.merged_prs, 0) AS merged_prs,
+                   COALESCE(c.total_cost_usd, 0) AS total_cost_usd,
+                   COALESCE(c.known_cost_runs, 0) AS known_cost_runs,
+                   COALESCE(c.cost_run_count, 0) AS cost_run_count,
+                   row_number() OVER (ORDER BY COALESCE(p.merged_prs, 0) DESC,
+                       COALESCE(p.prs_opened, 0) DESC, r.agent_runs DESC, r.user_id) AS rank
+            FROM run_stats r LEFT JOIN pr_stats p USING (user_id)
+            LEFT JOIN cost_stats c USING (user_id)
+        )
+        SELECT combined.*, d.github_login, d.display_name, d.email
+        FROM combined LEFT JOIN identity_directory d
+          ON d.workspace_id = :workspace_id AND d.person_id = combined.user_id
+        WHERE rank <= :limit OR user_id = :current_person
+        ORDER BY rank LIMIT :bounded_limit
+        """
+    )
+    async with connection() as conn:
+        result = await conn.execute(
+            sql,
+            {
+                "workspace_id": workspace_id(),
+                "start": start,
+                "limit": max_rows,
+                "bounded_limit": max_rows + 1,
+                "current_person": current_person,
+            },
+        )
+        rows = []
+        for row in result.mappings():
+            is_current = row["user_id"] == current_person
+            named = admin or is_current
+            finished = int(row["finished_runs"] or 0)
+            rows.append(
+                {
+                    "rank": int(row["rank"]),
+                    "user": {
+                        "name": (row["display_name"] or row["github_login"] or "Open SWE user")
+                        if named
+                        else "Open SWE user",
+                        "github_login": row["github_login"] if named else None,
+                        "email": row["email"] if is_current else None,
+                    },
+                    "is_current": is_current,
+                    "favorite_model": "unavailable",
+                    "agent_runs": int(row["agent_runs"]),
+                    "completed_runs": int(row["completed_runs"]),
+                    "failed_runs": int(row["failed_runs"]),
+                    "canceled_runs": int(row["canceled_runs"]),
+                    "prs_opened": int(row["prs_opened"]),
+                    "merged_prs": int(row["merged_prs"]),
+                    "agent_loc": 0,
+                    "additions": 0,
+                    "deletions": 0,
+                    "total_tokens": int(row["total_tokens"]),
+                    "total_cost_usd": float(row["total_cost_usd"]),
+                    "cost_completeness": "complete"
+                    if row["known_cost_runs"] == row["cost_run_count"]
+                    else "partial"
+                    if row["known_cost_runs"]
+                    else "unavailable",
+                    "avg_run_seconds": float(row["duration_seconds"]) / finished
+                    if finished
+                    else 0.0,
+                }
+            )
+        total_members = await conn.scalar(
+            text(
+                "SELECT count(DISTINCT user_id) FROM run_projection WHERE workspace_id = "
+                ":workspace_id AND started_at >= :start AND user_id IS NOT NULL"
+            ),
+            {"workspace_id": workspace_id(), "start": start},
+        )
+        watermark = await conn.scalar(
+            text("SELECT max(recorded_at) FROM events WHERE workspace_id = :workspace_id"),
+            {"workspace_id": workspace_id()},
+        )
+    current = next((row for row in rows if row.pop("is_current")), None)
+    return {
+        "period": period if period in {"7d", "30d", "all"} else "30d",
+        "rows": rows,
+        "total_members": int(total_members or 0),
+        "current_user_rank": current["rank"] if current else None,
+        "generated_at_ms": int(datetime.now(UTC).timestamp() * 1000),
+        "reviewer_stats": await reviewer_stats(start),
+        **summary_metadata(watermark=watermark, completeness="epoch_forward_only"),
+    }
+
+
+async def reviewer_stats(start: datetime) -> dict[str, Any]:
+    async with connection() as conn:
+        result = await conn.execute(
+            text(
+                """
+                SELECT count(DISTINCT review_id) AS reviewed_prs,
+                       count(*) AS surfaced_findings,
+                       count(*) FILTER (WHERE current_state = 'resolved') AS resolved,
+                       count(*) FILTER (WHERE current_state = 'dismissed') AS dismissed,
+                       count(*) FILTER (WHERE current_state = 'open') AS open,
+                       COALESCE(sum(reopened_count), 0) AS reopened
+                FROM finding_projection WHERE workspace_id = :workspace_id AND surfaced_at >= :start
+                """
+            ),
+            {"workspace_id": workspace_id(), "start": start},
+        )
+        row = result.mappings().one()
+    surfaced = int(row["surfaced_findings"] or 0)
+    resolved = int(row["resolved"] or 0)
+    return {
+        "period": "custom",
+        "reviewed_prs": int(row["reviewed_prs"] or 0),
+        "prs_with_findings": int(row["reviewed_prs"] or 0),
+        "findings_recorded": surfaced,
+        "surfaced_findings": surfaced,
+        "addressed_findings": resolved,
+        "resolved_after_update": resolved,
+        "dismissed_findings": int(row["dismissed"] or 0),
+        "unresolved_surfaced_findings": int(row["open"] or 0),
+        "reopened_findings": int(row["reopened"] or 0),
+        "resolution_rate": resolved / surfaced if surfaced else 0.0,
+        "human_replies": 0,
+        "severity_counts": {},
+        "top_categories": [],
+        "generated_at_ms": int(datetime.now(UTC).timestamp() * 1000),
+    }
+
+
+async def pr_merge_rate_by_model(
+    *, period: str | None, maturity_days: int | None = None, admin: bool = False
+) -> dict[str, Any]:
+    start = period_start(period)
+    days = maturity_days or ENV.ANALYTICS_PR_MATURITY_DAYS.get_int(14)
+    days = min(max(days, 1), 365)
+    minimum = 1 if admin else ENV.ANALYTICS_MIN_COHORT_SIZE.get_int(5)
+    async with connection() as conn:
+        result = await conn.execute(
+            text(
+                """
+                SELECT p.originating_model_id, p.model_attribution_quality, m.provider_model_id,
+                    count(*) FILTER (WHERE current_state = 'merged') AS merged,
+                    count(*) FILTER (WHERE current_state = 'closed_without_merge') AS closed,
+                    count(*) FILTER (WHERE current_state = 'open' AND opened_at <= :mature_before) AS mature_pending,
+                    count(*) FILTER (WHERE current_state = 'open' AND opened_at > :mature_before) AS waiting,
+                    count(*) AS cohort_size
+                FROM pr_projection p LEFT JOIN model_directory m
+                  ON m.workspace_id = p.workspace_id AND m.model_id = p.originating_model_id
+                WHERE p.workspace_id = :workspace_id AND opened_at >= :start AND opened_at <= :as_of
+                GROUP BY p.originating_model_id, p.model_attribution_quality, m.provider_model_id
+                HAVING count(*) >= :minimum
+                ORDER BY count(*) DESC, originating_model_id
+                LIMIT 100
+                """
+            ),
+            {
+                "workspace_id": workspace_id(),
+                "start": start,
+                "as_of": datetime.now(UTC),
+                "mature_before": datetime.now(UTC) - timedelta(days=days),
+                "minimum": minimum,
+            },
+        )
+        cohorts = []
+        for row in result.mappings():
+            merged = int(row["merged"] or 0)
+            closed = int(row["closed"] or 0)
+            pending = int(row["mature_pending"] or 0)
+            decided = merged + closed
+            mature = decided + pending
+            cohorts.append(
+                {
+                    "model_id": row["provider_model_id"],
+                    "model_attribution_quality": row["model_attribution_quality"],
+                    "merged": merged,
+                    "closed_without_merge": closed,
+                    "mature_pending": pending,
+                    "waiting": int(row["waiting"] or 0),
+                    "cohort_size": int(row["cohort_size"]),
+                    "decided_denominator": decided,
+                    "decided_merge_rate": merged / decided if decided else None,
+                    "mature_denominator": mature,
+                    "mature_cohort_merge_share": merged / mature if mature else None,
+                }
+            )
+        watermark = await conn.scalar(
+            text("SELECT max(recorded_at) FROM events WHERE workspace_id = :workspace_id"),
+            {"workspace_id": workspace_id()},
+        )
+    return {
+        "metric": "pr_merge_rate_by_originating_model",
+        "definition": "PR-open-date cohorts attributed to the opening run's effective primary model.",
+        "maturity_days": days,
+        "period": period if period in {"7d", "30d", "all"} else "30d",
+        "suppression_threshold": minimum,
+        "cohorts": cohorts,
+        **summary_metadata(watermark=watermark, completeness="epoch_forward_only"),
+    }

--- a/agent/analytics/summaries.py
+++ b/agent/analytics/summaries.py
@@ -1,0 +1,160 @@
+"""Correctable versioned daily summaries."""
+
+import json
+from datetime import UTC, datetime
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+from agent.analytics.database import transaction
+from agent.config import ENV
+
+_LATENCY_BOUNDS_MS = [60_000, 300_000, 900_000, 3_600_000, 14_400_000, 86_400_000, 604_800_000]
+
+
+async def recompute_dirty_partitions(limit: int = 20) -> int:
+    async with transaction() as conn:
+        claimed = await conn.execute(
+            text(
+                "SELECT workspace_id, summary_version, family, partition_date, dimension_key FROM "
+                "dirty_summary_partitions ORDER BY dirty_since FOR UPDATE SKIP LOCKED LIMIT :limit"
+            ),
+            {"limit": min(max(limit, 1), 100)},
+        )
+        partitions = [dict(row) for row in claimed.mappings()]
+        for partition in partitions:
+            payload = await _compute(conn, partition)
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO daily_summaries (
+                        workspace_id, summary_version, family, partition_date, dimension_key,
+                        counters, sums, exact_members, histogram_bounds, histogram_counts,
+                        completeness, data_watermark
+                    ) VALUES (
+                        :workspace_id, :summary_version, :family, :partition_date, :dimension_key,
+                        CAST(:counters AS jsonb), CAST(:sums AS jsonb), :exact_members,
+                        :histogram_bounds, :histogram_counts, CAST(:completeness AS jsonb),
+                        :data_watermark
+                    ) ON CONFLICT (workspace_id, summary_version, family, partition_date, dimension_key)
+                    DO UPDATE SET counters = EXCLUDED.counters, sums = EXCLUDED.sums,
+                        exact_members = EXCLUDED.exact_members,
+                        histogram_bounds = EXCLUDED.histogram_bounds,
+                        histogram_counts = EXCLUDED.histogram_counts,
+                        completeness = EXCLUDED.completeness,
+                        data_watermark = EXCLUDED.data_watermark,
+                        recomputed_at = clock_timestamp()
+                    """
+                ),
+                {**partition, **payload},
+            )
+            await conn.execute(
+                text(
+                    "DELETE FROM dirty_summary_partitions WHERE workspace_id = :workspace_id AND "
+                    "summary_version = :summary_version AND family = :family AND partition_date = "
+                    ":partition_date AND dimension_key = :dimension_key"
+                ),
+                partition,
+            )
+        return len(partitions)
+
+
+async def _compute(conn: AsyncConnection, partition: dict[str, object]) -> dict[str, object]:
+    family = partition["family"]
+    workspace_id = partition["workspace_id"]
+    partition_date = partition["partition_date"]
+    counters: dict[str, int] = {}
+    sums: dict[str, float] = {}
+    members: list[object] = []
+    histogram_counts = [0] * (len(_LATENCY_BOUNDS_MS) + 1)
+    if family == "pr_open_cohort":
+        result = await conn.execute(
+            text(
+                "SELECT current_state, count(*) AS count FROM pr_projection WHERE workspace_id = "
+                ":workspace_id AND opened_at >= :day AND opened_at < :day + interval '1 day' "
+                "GROUP BY current_state"
+            ),
+            {"workspace_id": workspace_id, "day": partition_date},
+        )
+        counters = {row["current_state"]: int(row["count"]) for row in result.mappings()}
+    elif family == "finding_surfaced_cohort":
+        result = await conn.execute(
+            text(
+                "SELECT current_state, count(*) AS count FROM finding_projection WHERE workspace_id "
+                "= :workspace_id AND surfaced_at >= :day AND surfaced_at < :day + interval '1 day' "
+                "GROUP BY current_state"
+            ),
+            {"workspace_id": workspace_id, "day": partition_date},
+        )
+        counters = {row["current_state"]: int(row["count"]) for row in result.mappings()}
+    elif family == "cost_completeness":
+        result = await conn.execute(
+            text(
+                "SELECT count(*) AS runs, count(cost_usd) AS known, COALESCE(sum(cost_usd), 0) AS "
+                "cost FROM run_projection r LEFT JOIN latest_cost_projection c USING "
+                "(workspace_id, run_id) WHERE r.workspace_id = :workspace_id AND r.started_at >= "
+                ":day AND r.started_at < :day + interval '1 day'"
+            ),
+            {"workspace_id": workspace_id, "day": partition_date},
+        )
+        row = result.mappings().one()
+        counters = {"runs": int(row["runs"]), "known_cost_runs": int(row["known"])}
+        sums = {"cost_usd": float(row["cost"])}
+    elif family == "distinct_membership":
+        result = await conn.execute(
+            text(
+                "SELECT DISTINCT user_id FROM run_projection WHERE workspace_id = :workspace_id AND "
+                "started_at >= :day AND started_at < :day + interval '1 day' AND user_id IS NOT NULL"
+            ),
+            {"workspace_id": workspace_id, "day": partition_date},
+        )
+        members = [row[0] for row in result]
+    elif family == "latency_histogram":
+        result = await conn.execute(
+            text(
+                "SELECT EXTRACT(EPOCH FROM (resolved_at - surfaced_at)) * 1000 AS latency FROM "
+                "finding_projection WHERE workspace_id = :workspace_id AND surfaced_at >= :day "
+                "AND surfaced_at < :day + interval '1 day' AND resolved_at >= surfaced_at"
+            ),
+            {"workspace_id": workspace_id, "day": partition_date},
+        )
+        for row in result:
+            latency = float(row[0])
+            bucket = next(
+                (index for index, bound in enumerate(_LATENCY_BOUNDS_MS) if latency <= bound),
+                len(_LATENCY_BOUNDS_MS),
+            )
+            histogram_counts[bucket] += 1
+    else:
+        result = await conn.execute(
+            text(
+                "SELECT event_name, count(*) AS count FROM events WHERE workspace_id = :workspace_id "
+                "AND occurred_at >= :day AND occurred_at < :day + interval '1 day' GROUP BY event_name"
+            ),
+            {"workspace_id": workspace_id, "day": partition_date},
+        )
+        counters = {row["event_name"]: int(row["count"]) for row in result.mappings()}
+    watermark = await conn.scalar(
+        text("SELECT max(recorded_at) FROM events WHERE workspace_id = :workspace_id"),
+        {"workspace_id": workspace_id},
+    )
+    return {
+        "counters": json.dumps(counters),
+        "sums": json.dumps(sums),
+        "exact_members": members,
+        "histogram_bounds": _LATENCY_BOUNDS_MS,
+        "histogram_counts": histogram_counts,
+        "completeness": json.dumps({"status": "complete"}),
+        "data_watermark": watermark,
+    }
+
+
+def summary_metadata(*, watermark: datetime | None, completeness: str) -> dict[str, object]:
+    return {
+        "analytics_epoch": ENV.ANALYTICS_EPOCH.optional(),
+        "summary_version": ENV.ANALYTICS_SUMMARY_VERSION.get_int(1),
+        "freshness": "live_current_utc_day_plus_completed_day_summaries",
+        "completeness": completeness,
+        "data_watermark": watermark.isoformat() if watermark else None,
+        "as_of": datetime.now(UTC).isoformat(),
+    }

--- a/agent/api/app.py
+++ b/agent/api/app.py
@@ -1,5 +1,6 @@
 """FastAPI application composition."""
 
+import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
@@ -17,6 +18,8 @@ from agent.slack.routes import router as slack_webhook_router
 from agent.utils.dashboard_ui import mount_dashboard_ui
 from agent.utils.event_loop import pin_single_event_loop
 
+logger = logging.getLogger(__name__)
+
 # Before the queue starts: it reads this when it builds its workers, and Open SWE
 # cannot survive them landing on different loops.
 pin_single_event_loop()
@@ -24,6 +27,9 @@ pin_single_event_loop()
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    from agent.analytics.database import close as close_analytics
+    from agent.analytics.database import migrate as migrate_analytics
+    from agent.analytics.outbox import start_worker, stop_worker
     from agent.sandboxes.providers.registry import validate_sandbox_startup_config
     from agent.utils.model import close_cached_models, validate_local_dev_llm_config
 
@@ -31,8 +37,15 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     validate_sandbox_startup_config()
     validate_local_dev_llm_config()
     try:
+        await migrate_analytics()
+        start_worker()
+    except Exception:  # noqa: BLE001
+        logger.warning("Analytics startup failed", exc_info=True)
+    try:
         yield
     finally:
+        await stop_worker()
+        await close_analytics()
         await close_cached_models()
 
 

--- a/agent/api/health.py
+++ b/agent/api/health.py
@@ -14,6 +14,13 @@ async def health_check() -> dict[str, str]:
     return {"status": "healthy"}
 
 
+@router.get("/health/analytics")
+async def analytics_health_check() -> dict[str, Any]:
+    from agent.analytics.database import readiness
+
+    return await readiness()
+
+
 @router.post("/webhooks/run-complete")
 async def run_complete_webhook(request: Request) -> dict[str, Any]:
     if not verify_run_complete_token(request.query_params.get("token")):

--- a/agent/completion.py
+++ b/agent/completion.py
@@ -284,6 +284,7 @@ async def _finalize_agent_usage_telemetry(
         run_id=prepare_run_id,
         thread_id=thread_id,
         state=state,
+        status=str(status),
     )
 
 

--- a/agent/config.py
+++ b/agent/config.py
@@ -320,6 +320,30 @@ ENV.var(
 ENV.var("RUN_COMPLETE_WEBHOOK_SECRET", "Token authenticating /webhooks/run-complete.", secret=True)
 ENV.var("COMPLETION_WEBHOOK_URL", "Where LangGraph posts run-completion webhooks.")
 
+# --- Analytics -------------------------------------------------------------------------------
+ENV.var(
+    "ANALYTICS_POSTGRES_URI",
+    "Dedicated managed PostgreSQL analytics datastore; falls back to POSTGRES_URI when unset.",
+    secret=True,
+)
+ENV.var("POSTGRES_URI", "LangGraph deployment PostgreSQL URI available to custom code.", secret=True)
+ENV.var("ANALYTICS_WORKSPACE_ID", "Immutable UUID identifying the analytics workspace.")
+ENV.var("ANALYTICS_EPOCH", "UTC timestamp before which analytics events are rejected.")
+ENV.var("ANALYTICS_ENVIRONMENT", "Analytics producer environment.", default="production")
+ENV.var("ANALYTICS_SUMMARY_VERSION", "Active metric semantics version.", default="1")
+ENV.var("ANALYTICS_PR_MATURITY_DAYS", "PR cohort maturity period.", default="14")
+ENV.var("ANALYTICS_MIN_COHORT_SIZE", "Minimum aggregate cohort size.", default="5")
+ENV.var("ANALYTICS_POOL_SIZE", "Analytics PostgreSQL connection pool size.", default="5")
+ENV.var("ANALYTICS_POOL_OVERFLOW", "Analytics PostgreSQL pool overflow.", default="5")
+ENV.var("ANALYTICS_POOL_TIMEOUT_SECONDS", "Analytics pool checkout timeout.", default="5")
+ENV.var("ANALYTICS_HEALTH_TIMEOUT_SECONDS", "Analytics readiness timeout.", default="3")
+ENV.var("ANALYTICS_OUTBOX_MAX_ATTEMPTS", "Delivery attempts before dead-lettering.", default="10")
+ENV.var("ANALYTICS_RAW_EVENT_MONTHS", "Online raw-event retention.", default="25")
+ENV.var("ANALYTICS_AGGREGATE_YEARS", "Aggregate summary retention.", default="7")
+ENV.var("ANALYTICS_PERSON_MONTHS", "Named identity and summary retention.", default="13")
+ENV.var("ANALYTICS_ACK_OUTBOX_DAYS", "Acknowledged outbox retention.", default="30")
+ENV.var("ANALYTICS_RECEIPT_DAYS", "Ingestion-receipt retention.", default="90")
+
 # --- Models and tools ------------------------------------------------------------------------
 ENV.var("ANTHROPIC_API_KEY", "Anthropic API key.", secret=True)
 ENV.var("OPENAI_API_KEY", "OpenAI API key (models and voice dictation).", secret=True)

--- a/agent/dashboard/agent_usage.py
+++ b/agent/dashboard/agent_usage.py
@@ -1,340 +1,44 @@
-"""Open SWE Agent and Review usage telemetry."""
+"""PostgreSQL-backed Open SWE usage analytics."""
 
-import asyncio
-import hashlib
-import json
-import logging
-import math
-import time
-import weakref
-from collections import Counter
-from collections.abc import Callable, Mapping, Sequence
-from datetime import UTC, datetime, timedelta
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
 from typing import Any, Literal
 
-from langgraph_sdk import get_client
-from langgraph_sdk.errors import APIStatusError
-
-from agent.review.findings import coerce_finding, is_surfaced
-from agent.utils.json_types import as_json_object, thread_metadata
+from agent.analytics.emitter import (
+    finding_transition,
+    pr_opened,
+    pr_state,
+    review_published,
+    run_cost,
+    run_started,
+    run_terminal,
+)
+from agent.analytics.queries import usage_leaderboard
+from agent.config import ENV
+from agent.utils.json_types import as_json_object
 from agent.utils.run_usage import RunUsageSummary
 
-AGENT_RUN_NAMESPACE = ["usage", "v2", "agent_runs"]
-AGENT_PR_NAMESPACE = ["usage", "v2", "agent_prs"]
-REVIEW_NAMESPACE = ["usage", "v2", "reviews"]
-REVIEW_FINDING_NAMESPACE = ["usage", "v2", "review_findings"]
 
-Period = Literal["7d", "30d", "all"]
-_PAGE_SIZE = 1000
-_AGENT_SOURCES = frozenset({"dashboard", "github", "slack", "linear", "schedule"})
-_WRITE_LOCKS: weakref.WeakValueDictionary[tuple[tuple[str, ...], str, int], asyncio.Lock] = (
-    weakref.WeakValueDictionary()
-)
-_USAGE_CACHE: dict[tuple[str, str], tuple[int, dict[str, Any], dict[str, Any] | None]] = {}
-_USAGE_CACHE_TTL_MS = 60_000
-
-LEGACY_THREAD_NAMESPACE = ["agent_usage", "threads"]
-LEGACY_PR_NAMESPACE = ["agent_usage", "prs"]
-BACKFILL_NAMESPACE = ["usage", "v2", "backfill"]
-_BACKFILL_KEY = "legacy_v1"
-
-logger = logging.getLogger(__name__)
-
-
-def _client():
-    return get_client()
-
-
-def _now_ms() -> int:
-    return int(datetime.now(UTC).timestamp() * 1000)
-
-
-def _timestamp_ms(value: object) -> int:
-    if isinstance(value, bool):
-        return 0
-    if isinstance(value, int | float):
-        raw = int(value)
-        return raw if raw > 10_000_000_000 else raw * 1000
-    if isinstance(value, str) and value.strip():
-        raw = value.strip()
-        if raw.isdigit():
-            return _timestamp_ms(int(raw))
+def _timestamp(value: object) -> datetime:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
+    if isinstance(value, int | float) and not isinstance(value, bool):
+        raw = float(value) / 1000 if value > 10_000_000_000 else float(value)
+        return datetime.fromtimestamp(raw, UTC)
+    if isinstance(value, str) and value:
         try:
-            parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
         except ValueError:
-            return 0
-        if parsed.tzinfo is None:
-            parsed = parsed.replace(tzinfo=UTC)
-        return int(parsed.timestamp() * 1000)
-    return 0
+            pass
+    return datetime.now(UTC)
 
 
-def _normalize_period(period: str | None) -> Period:
-    if period == "7d" or period == "all":
-        return period
-    return "30d"
-
-
-def _period_cutoff_ms(period: Period) -> int:
-    days = 7 if period == "7d" else 30 if period == "30d" else 0
-    return int((datetime.now(UTC) - timedelta(days=days)).timestamp() * 1000) if days else 0
-
-
-def _store_key(*parts: object) -> str:
-    encoded = json.dumps(parts, separators=(",", ":"), ensure_ascii=True).encode()
-    return hashlib.sha256(encoded).hexdigest()
-
-
-def _record(item: Any) -> dict[str, Any] | None:
-    value = item.get("value") if isinstance(item, dict) else getattr(item, "value", None)
-    return value if isinstance(value, dict) else None
-
-
-def _write_lock(namespace: list[str], key: str) -> asyncio.Lock:
-    lock_key = (tuple(namespace), key, id(asyncio.get_running_loop()))
-    lock = _WRITE_LOCKS.get(lock_key)
-    if lock is None:
-        lock = asyncio.Lock()
-        _WRITE_LOCKS[lock_key] = lock
-    return lock
-
-
-async def _get(namespace: list[str], key: str) -> dict[str, Any] | None:
-    try:
-        return _record(await _client().store.get_item(namespace, key))
-    except APIStatusError as exc:
-        if exc.response.status_code == 404:
-            return None
-        raise
-
-
-async def _mutate(
-    namespace: list[str], key: str, update: Callable[[dict[str, Any] | None], dict[str, Any]]
-) -> None:
-    async with _write_lock(namespace, key):
-        # An empty result means the callback found nothing to update; writing it
-        # would insert a record with no identity that every reader must skip.
-        value = update(await _get(namespace, key))
-        if not value:
-            return
-        await _client().store.put_item(namespace, key, value)
-
-
-async def _all(namespace: list[str]) -> list[dict[str, Any]]:
-    started_at = time.monotonic()
-    values: list[dict[str, Any]] = []
-    offset = 0
-    pages = 0
-    try:
-        while True:
-            result = await _client().store.search_items(namespace, limit=_PAGE_SIZE, offset=offset)
-            items = (
-                result.get("items") if isinstance(result, dict) else getattr(result, "items", [])
-            )
-            page = list(items or [])
-            pages += 1
-            values.extend(value for item in page if (value := _record(item)) is not None)
-            if len(page) < _PAGE_SIZE:
-                logger.info(
-                    "Usage telemetry scan completed",
-                    extra={
-                        "usage_namespace": "/".join(namespace),
-                        "usage_pages": pages,
-                        "usage_records": len(values),
-                        "usage_elapsed_ms": round((time.monotonic() - started_at) * 1000),
-                    },
-                )
-                return values
-            offset += len(page)
-    except Exception:
-        logger.exception(
-            "Usage telemetry scan failed",
-            extra={
-                "usage_namespace": "/".join(namespace),
-                "usage_pages": pages,
-                "usage_records": len(values),
-                "usage_offset": offset,
-                "usage_elapsed_ms": round((time.monotonic() - started_at) * 1000),
-            },
-        )
-        raise
-
-
-def _login(value: object) -> str:
-    return value.strip().lower() if isinstance(value, str) else ""
-
-
-def _email(value: object) -> str:
-    return value.strip().lower() if isinstance(value, str) else ""
-
-
-def _int(value: object, fallback: object = 0) -> int:
-    return value if isinstance(value, int) else fallback if isinstance(fallback, int) else 0
-
-
-async def _backfill_legacy_agent_records() -> None:
-    legacy_threads, legacy_prs = await asyncio.gather(
-        _all(LEGACY_THREAD_NAMESPACE), _all(LEGACY_PR_NAMESPACE)
-    )
-    for record in legacy_threads:
-        thread_id = record.get("thread_id")
-        if not isinstance(thread_id, str) or not thread_id:
-            continue
-        if record.get("source") not in _AGENT_SOURCES:
-            continue
-        key = _store_key("run", f"legacy:{thread_id}")
-        if await _get(AGENT_RUN_NAMESPACE, key):
-            continue
-        await _client().store.put_item(
-            AGENT_RUN_NAMESPACE,
-            key,
-            {
-                "run_id": f"legacy:{thread_id}",
-                "thread_id": thread_id,
-                "github_login": _login(record.get("github_login")),
-                "user_email": _email(record.get("user_email")),
-                "model_id": record.get("model_id") or "",
-                "effort": record.get("effort") or "",
-                "source": record.get("source"),
-                "created_at_ms": _timestamp_ms(record.get("created_at_ms"))
-                or _timestamp_ms(record.get("updated_at_ms")),
-            },
-        )
-    for record in legacy_prs:
-        owner = record.get("owner")
-        repo = record.get("repo")
-        number = record.get("pr_number")
-        if not isinstance(owner, str) or not isinstance(repo, str) or not isinstance(number, int):
-            continue
-        key = _store_key("pr", owner.lower(), repo.lower(), number)
-        if await _get(AGENT_PR_NAMESPACE, key):
-            continue
-        await _client().store.put_item(
-            AGENT_PR_NAMESPACE,
-            key,
-            {
-                **record,
-                "github_login": _login(record.get("github_login")),
-                "user_email": _email(record.get("user_email")),
-                "created_at_ms": _timestamp_ms(record.get("created_at_ms"))
-                or _timestamp_ms(record.get("updated_at_ms")),
-                "merged_at_ms": 0,
-            },
-        )
-
-
-async def _backfill_legacy_reviews() -> None:
-    from agent.review.findings import REVIEWER_THREAD_KIND
-
-    offset = 0
-    while True:
-        page = await _client().threads.search(
-            metadata={"kind": REVIEWER_THREAD_KIND}, limit=_PAGE_SIZE, offset=offset
-        )
-        threads = list(page or [])
-        for thread in threads:
-            metadata = thread_metadata(thread)
-            thread_id = thread.get("thread_id") if isinstance(thread, Mapping) else None
-            if not isinstance(thread_id, str) or not thread_id:
-                continue
-            findings = [item for item in metadata.get("findings") or [] if isinstance(item, dict)]
-            head_sha = metadata.get("last_reviewed_sha") or metadata.get("head_sha") or ""
-            reviewed_at_ms = _timestamp_ms(
-                metadata.get("created_at")
-                or (thread.get("created_at") if isinstance(thread, Mapping) else None)
-            )
-            await _backfill_legacy_review(
-                thread_id=thread_id,
-                metadata=metadata,
-                findings=findings,
-                head_sha=str(head_sha),
-                reviewed_at_ms=reviewed_at_ms,
-            )
-        if len(threads) < _PAGE_SIZE:
-            return
-        offset += len(threads)
-
-
-async def _backfill_legacy_review(
-    *,
-    thread_id: str,
-    metadata: dict[str, Any],
-    findings: list[dict[str, Any]],
-    head_sha: str,
-    reviewed_at_ms: int,
-) -> None:
-    pr_meta = as_json_object(metadata.get("pr"))
-    owner = str(pr_meta.get("owner") or "")
-    repo = str(pr_meta.get("name") or "")
-    pr_number = pr_meta.get("number")
-    if not owner or not repo or not isinstance(pr_number, int):
-        return
-    review_key = _store_key("review", thread_id, head_sha)
-    if not await _get(REVIEW_NAMESPACE, review_key):
-        await _client().store.put_item(
-            REVIEW_NAMESPACE,
-            review_key,
-            {
-                "thread_id": thread_id,
-                "owner": owner,
-                "repo": repo,
-                "pr_number": pr_number,
-                "head_sha": head_sha,
-                "findings_recorded": len(findings),
-                "published_at_ms": reviewed_at_ms,
-            },
-        )
-    for finding in findings:
-        finding_id = finding.get("id")
-        if not isinstance(finding_id, str) or not finding_id:
-            continue
-        key = _store_key("finding", thread_id, finding_id)
-        if await _get(REVIEW_FINDING_NAMESPACE, key):
-            continue
-        status = finding.get("status") or "open"
-        surfaced = _finding_surfaced(finding)
-        await _client().store.put_item(
-            REVIEW_FINDING_NAMESPACE,
-            key,
-            {
-                "thread_id": thread_id,
-                "finding_id": finding_id,
-                "owner": owner,
-                "repo": repo,
-                "pr_number": pr_number,
-                "severity": finding.get("severity") or "",
-                "category": finding.get("category") or "",
-                "status": status,
-                "first_seen_sha": finding.get("first_seen_sha") or "",
-                "last_confirmed_sha": finding.get("last_confirmed_sha") or "",
-                "surfaced_at_ms": reviewed_at_ms if surfaced else 0,
-                "human_replies": _human_reply_count(finding),
-                "recorded_at_ms": reviewed_at_ms,
-                "updated_at_ms": reviewed_at_ms,
-                "resolved_at_ms": reviewed_at_ms if status == "resolved" else 0,
-                "resolved_sha": finding.get("last_confirmed_sha") or ""
-                if status == "resolved"
-                else "",
-            },
-        )
-
-
-async def _backfill_legacy_usage() -> None:
-    """Migrate pre-v2 usage records into the event namespaces exactly once."""
-    if await _get(BACKFILL_NAMESPACE, _BACKFILL_KEY):
-        return
-    async with _write_lock(BACKFILL_NAMESPACE, _BACKFILL_KEY):
-        if await _get(BACKFILL_NAMESPACE, _BACKFILL_KEY):
-            return
-        try:
-            await _backfill_legacy_agent_records()
-            await _backfill_legacy_reviews()
-        except Exception:  # noqa: BLE001
-            logger.warning("Legacy usage backfill failed; retrying next read", exc_info=True)
-            return
-        await _client().store.put_item(
-            BACKFILL_NAMESPACE, _BACKFILL_KEY, {"completed_at_ms": _now_ms()}
-        )
+def _severity(value: object) -> Literal["low", "medium", "high", "critical"]:
+    severity = str(value or "low").lower()
+    if severity in {"low", "medium", "high", "critical"}:
+        return severity
+    return "low"
 
 
 async def record_agent_run_usage(
@@ -346,92 +50,54 @@ async def record_agent_run_usage(
     model_id: str,
     effort: str | None,
     source: str | None,
+    github_user_id: str | int | None = None,
+    repository: str | None = None,
 ) -> None:
-    """Record one actual Agent run, idempotently."""
-    if not run_id or not thread_id:
-        return
-    key = _store_key("run", run_id)
-    now_ms = _now_ms()
+    del effort
+    from agent.analytics.directory import upsert_model, upsert_person
 
-    def update(existing: dict[str, Any] | None) -> dict[str, Any]:
-        return existing or {
-            "run_id": run_id,
-            "thread_id": thread_id,
-            "github_login": _login(github_login),
-            "user_email": _email(user_email),
-            "model_id": model_id,
-            "effort": effort or "",
-            "source": source if source in _AGENT_SOURCES else "dashboard",
-            "created_at_ms": now_ms,
-            "input_tokens": 0,
-            "output_tokens": 0,
-            "total_tokens": 0,
-            "cost_usd": None,
-            "cost_refresh_scheduled_at_ms": 0,
-            "finished_at_ms": 0,
-        }
-
-    await _mutate(AGENT_RUN_NAMESPACE, key, update)
+    await upsert_person(
+        provider="github",
+        immutable_person_key=github_user_id or github_login,
+        github_login=github_login,
+        email=user_email,
+    )
+    await upsert_model(model_id)
+    await run_started(
+        run_key=run_id,
+        thread_key=thread_id,
+        model=model_id,
+        source=source,
+        immutable_person_key=github_user_id or github_login,
+        repository_key=repository,
+    )
 
 
-async def record_agent_run_completion(*, run_id: str, usage: RunUsageSummary | None) -> bool:
-    """Complete an existing run record idempotently."""
-    if not run_id:
-        return False
-    key = _store_key("run", run_id)
-    async with _write_lock(AGENT_RUN_NAMESPACE, key):
-        existing = await _get(AGENT_RUN_NAMESPACE, key)
-        if not existing or existing.get("finished_at_ms"):
-            return False
-        value = {**existing, "finished_at_ms": _now_ms()}
-        if usage is not None:
-            counts = {
-                "input_tokens": usage.input_tokens,
-                "output_tokens": usage.output_tokens,
-                "total_tokens": usage.total_tokens,
-            }
-            value.update({field: count for field, count in counts.items() if count is not None})
-        await _client().store.put_item(AGENT_RUN_NAMESPACE, key, value)
+async def record_agent_run_completion(
+    *, run_id: str, usage: RunUsageSummary | None, status: str = "success", thread_id: str = ""
+) -> bool:
+    await run_terminal(
+        run_key=run_id,
+        thread_key=thread_id or run_id,
+        status=status,
+        input_tokens=usage.input_tokens if usage else None,
+        output_tokens=usage.output_tokens if usage else None,
+        total_tokens=usage.total_tokens if usage else None,
+        producer_suffix="middleware",
+    )
     return True
 
 
 async def agent_run_needs_cost_refresh(*, run_id: str) -> bool:
-    """Return whether a completed run still needs cost enrichment scheduled."""
-    if not run_id:
-        return False
-    existing = await _get(AGENT_RUN_NAMESPACE, _store_key("run", run_id))
-    return bool(
-        existing
-        and existing.get("finished_at_ms")
-        and existing.get("cost_usd") is None
-        and not existing.get("cost_refresh_scheduled_at_ms")
-    )
+    return bool(run_id and ENV.ANALYTICS_WORKSPACE_ID.optional())
 
 
 async def mark_agent_cost_refresh_scheduled(*, run_id: str) -> None:
-    """Persist that deferred cost enrichment was successfully scheduled."""
-    if not run_id:
-        return
-    key = _store_key("run", run_id)
-
-    def update(existing: dict[str, Any] | None) -> dict[str, Any]:
-        if not existing or existing.get("cost_refresh_scheduled_at_ms"):
-            return existing or {}
-        return {**existing, "cost_refresh_scheduled_at_ms": _now_ms()}
-
-    await _mutate(AGENT_RUN_NAMESPACE, key, update)
+    del run_id
 
 
 async def record_agent_run_cost(*, run_id: str, cost_usd: float) -> None:
-    """Store the LangSmith cost for an existing run."""
-    if not run_id or not math.isfinite(cost_usd) or cost_usd < 0:
-        return
-    key = _store_key("run", run_id)
-
-    def update(existing: dict[str, Any] | None) -> dict[str, Any]:
-        return {**existing, "cost_usd": cost_usd} if existing else {}
-
-    await _mutate(AGENT_RUN_NAMESPACE, key, update)
+    await run_cost(run_key=run_id, cost_usd=cost_usd)
 
 
 async def record_agent_pr_usage(
@@ -452,82 +118,64 @@ async def record_agent_pr_usage(
     merged: bool = False,
     created_at: object = None,
     merged_at: object = None,
+    run_id: str | None = None,
+    model_id: str | None = None,
+    source: str | None = None,
+    repository_private: bool | None = None,
 ) -> None:
-    """Record an Agent-authored PR while preserving its original attribution."""
-    if not owner or not repo or not pr_number:
+    del github_login, user_email, pr_url, head, base, additions, deletions, changed_files
+    opening_run = run_id or thread_id
+    if not opening_run:
         return
-    key = _store_key("pr", owner.lower(), repo.lower(), pr_number)
-    now_ms = _now_ms()
-
-    def update(existing: dict[str, Any] | None) -> dict[str, Any]:
-        was_merged = bool((existing or {}).get("merged"))
-        value = {
-            **(existing or {}),
-            "owner": owner,
-            "repo": repo,
-            "pr_number": pr_number,
-            "pr_url": pr_url or (existing or {}).get("pr_url", ""),
-            "head": head,
-            "base": base,
-            "additions": max(0, additions),
-            "deletions": max(0, deletions),
-            "changed_files": max(0, changed_files),
-            "state": "closed" if was_merged else state or "open",
-            "merged": was_merged or bool(merged),
-            "merged_at_ms": _timestamp_ms(merged_at) or (existing or {}).get("merged_at_ms", 0),
-            "updated_at_ms": now_ms,
-        }
-        if not existing:
-            value.update(
-                thread_id=thread_id or "",
-                github_login=_login(github_login),
-                user_email=_email(user_email),
-                created_at_ms=_timestamp_ms(created_at) or now_ms,
-            )
-        return value
-
-    await _mutate(AGENT_PR_NAMESPACE, key, update)
+    await pr_opened(
+        owner=owner,
+        repo=repo,
+        number=pr_number,
+        run_key=opening_run,
+        model=model_id,
+        source=source,
+        repository_private=repository_private,
+        occurred_at=_timestamp(created_at),
+    )
+    if merged or state == "closed":
+        await pr_state(
+            owner=owner,
+            repo=repo,
+            number=pr_number,
+            action="closed",
+            merged=merged,
+            source_version=None,
+            occurred_at=_timestamp(merged_at),
+        )
 
 
 async def update_agent_pr_usage_from_webhook(payload: dict[str, Any]) -> None:
-    """Update a known Agent PR from a verified GitHub webhook payload."""
     pr = payload.get("pull_request")
-    repo_payload = payload.get("repository")
-    if not isinstance(pr, dict) or not isinstance(repo_payload, dict):
+    repository = payload.get("repository")
+    if not isinstance(pr, dict) or not isinstance(repository, dict):
         return
-    owner_payload = repo_payload.get("owner")
+    owner_payload = repository.get("owner")
     owner = owner_payload.get("login") if isinstance(owner_payload, dict) else None
-    repo = repo_payload.get("name")
-    number = pr.get("number")
-    if not isinstance(owner, str) or not isinstance(repo, str) or not isinstance(number, int):
+    repo = repository.get("name")
+    number = pr.get("number") or payload.get("number")
+    action = payload.get("action")
+    if (
+        not isinstance(owner, str)
+        or not isinstance(repo, str)
+        or not isinstance(number, int)
+        or action not in {"closed", "reopened"}
+    ):
         return
-    key = _store_key("pr", owner.lower(), repo.lower(), number)
-    existing = await _get(AGENT_PR_NAMESPACE, key)
-    if not existing:
-        return
-    await record_agent_pr_usage(
-        thread_id=existing.get("thread_id") if isinstance(existing.get("thread_id"), str) else None,
-        github_login=existing.get("github_login"),
-        user_email=existing.get("user_email"),
+    updated_at = _timestamp(pr.get("updated_at") or pr.get("closed_at"))
+    await pr_state(
         owner=owner,
         repo=repo,
-        pr_number=number,
-        pr_url=pr.get("html_url"),
-        head=as_json_object(pr.get("head")).get("ref") or existing.get("head", ""),
-        base=as_json_object(pr.get("base")).get("ref") or existing.get("base", ""),
-        additions=_int(pr.get("additions"), existing.get("additions")),
-        deletions=_int(pr.get("deletions"), existing.get("deletions")),
-        changed_files=_int(pr.get("changed_files"), existing.get("changed_files")),
-        state=pr.get("state") if isinstance(pr.get("state"), str) else existing.get("state"),
+        number=number,
+        action=action,
         merged=bool(pr.get("merged")),
-        created_at=pr.get("created_at"),
-        merged_at=pr.get("merged_at"),
+        source_version=int(updated_at.timestamp() * 1_000_000),
+        occurred_at=updated_at,
     )
-
-
-def _finding_surfaced(finding: Mapping[str, Any]) -> bool:
-    record = coerce_finding(dict(finding))
-    return record is not None and is_surfaced(record)
 
 
 async def record_reviewer_publication(
@@ -539,160 +187,49 @@ async def record_reviewer_publication(
     head_sha: str,
     findings: Sequence[Mapping[str, Any]],
 ) -> None:
-    """Record a completed review and its finding cohort."""
-    now_ms = _now_ms()
-
-    def update_review(existing: dict[str, Any] | None) -> dict[str, Any]:
-        return {
-            **(existing or {}),
-            "thread_id": thread_id,
-            "owner": owner,
-            "repo": repo,
-            "pr_number": pr_number,
-            "head_sha": head_sha,
-            "findings_recorded": sum(
-                1 for finding in findings if finding.get("first_seen_sha") == head_sha
-            ),
-            "published_at_ms": (existing or {}).get("published_at_ms") or now_ms,
-        }
-
-    await _mutate(REVIEW_NAMESPACE, _store_key("review", thread_id, head_sha), update_review)
+    await review_published(
+        thread_key=thread_id,
+        owner=owner,
+        repo=repo,
+        number=pr_number,
+        head_sha=head_sha,
+        finding_count=len(findings),
+    )
     for finding in findings:
-        finding_id = finding.get("id")
-        if not isinstance(finding_id, str) or not finding_id:
-            continue
-        key = _store_key("finding", thread_id, finding_id)
-        surfaced = _finding_surfaced(finding)
-
-        def update(
-            existing: dict[str, Any] | None,
-            finding: Mapping[str, Any] = finding,
-            finding_id: str = finding_id,
-            surfaced: bool = surfaced,
-        ) -> dict[str, Any]:
-            value = {
-                **(existing or {}),
-                "thread_id": thread_id,
-                "finding_id": finding_id,
-                "owner": owner,
-                "repo": repo,
-                "pr_number": pr_number,
-                "severity": finding.get("severity") or "",
-                "category": finding.get("category") or "",
-                "status": finding.get("status") or "open",
-                "first_seen_sha": finding.get("first_seen_sha") or "",
-                "last_confirmed_sha": finding.get("last_confirmed_sha") or "",
-                "surfaced_at_ms": (existing or {}).get("surfaced_at_ms")
-                or (now_ms if surfaced else 0),
-                "human_replies": _human_reply_count(finding),
-                "updated_at_ms": now_ms,
-            }
-            if not existing:
-                value["recorded_at_ms"] = now_ms
-            if value["status"] == "resolved" and not value.get("resolved_at_ms"):
-                value["resolved_at_ms"] = now_ms
-                value["resolved_sha"] = value["last_confirmed_sha"]
-            return value
-
-        await _mutate(REVIEW_FINDING_NAMESPACE, key, update)
-
-
-def _human_reply_count(finding: Mapping[str, Any]) -> int:
-    interactions = finding.get("interactions")
-    if isinstance(interactions, list):
-        return sum(
-            1
-            for interaction in interactions
-            if isinstance(interaction, dict) and interaction.get("kind") == "human_reply"
-        )
-    return int(bool(finding.get("last_human_reply_at")))
+        if finding.get("surface_state") == "surfaced":
+            await finding_transition(
+                thread_key=thread_id,
+                finding_key=str(finding.get("id") or ""),
+                owner=owner,
+                repo=repo,
+                number=pr_number,
+                state="surfaced",
+                severity=_severity(finding.get("severity")),
+                category=str(finding.get("category") or "unknown"),
+                version=str(finding.get("last_confirmed_sha") or head_sha),
+            )
 
 
 async def record_reviewer_finding_state(thread_id: str, finding: Mapping[str, Any]) -> None:
-    """Update an already-published finding's outcome state."""
-    finding_id = finding.get("id")
-    if not isinstance(finding_id, str) or not finding_id:
+    pr = as_json_object(finding.get("pr"))
+    owner = str(pr.get("owner") or finding.get("owner") or "")
+    repo = str(pr.get("name") or finding.get("repo") or "")
+    number = pr.get("number") or finding.get("pr_number")
+    if not owner or not repo or not isinstance(number, int):
         return
-    key = _store_key("finding", thread_id, finding_id)
-    now_ms = _now_ms()
-
-    def update(existing: dict[str, Any] | None) -> dict[str, Any]:
-        if not existing:
-            return {}
-        status = finding.get("status") or "open"
-        value = {
-            **existing,
-            "status": status,
-            "severity": finding.get("severity") or existing.get("severity", ""),
-            "category": finding.get("category") or existing.get("category", ""),
-            "last_confirmed_sha": finding.get("last_confirmed_sha") or "",
-            "human_replies": _human_reply_count(finding),
-            "updated_at_ms": now_ms,
-        }
-        if _finding_surfaced(finding) and not value.get("surfaced_at_ms"):
-            value["surfaced_at_ms"] = now_ms
-        if status == "resolved" and not value.get("resolved_at_ms"):
-            value["resolved_at_ms"] = now_ms
-            value["resolved_sha"] = value["last_confirmed_sha"]
-        return value
-
-    async with _write_lock(REVIEW_FINDING_NAMESPACE, key):
-        existing = await _get(REVIEW_FINDING_NAMESPACE, key)
-        if existing:
-            await _client().store.put_item(REVIEW_FINDING_NAMESPACE, key, update(existing))
-
-
-def _aliases(records: list[dict[str, Any]]) -> dict[str, str]:
-    return {
-        email: login
-        for record in records
-        if (email := _email(record.get("user_email")))
-        and (login := _login(record.get("github_login")))
-    }
-
-
-def _user_key(record: dict[str, Any], aliases: dict[str, str]) -> str | None:
-    login = _login(record.get("github_login")) or aliases.get(_email(record.get("user_email")), "")
-    if login:
-        return f"github:{login}"
-    email = _email(record.get("user_email"))
-    return f"email:{email}" if email else None
-
-
-def _new_user(key: str, record: dict[str, Any], aliases: dict[str, str]) -> dict[str, Any]:
-    login = _login(record.get("github_login")) or aliases.get(_email(record.get("user_email")), "")
-    email = _email(record.get("user_email"))
-    return {
-        "key": key,
-        "github_login": login,
-        "email": email,
-        "name": login or email.split("@", 1)[0],
-        "agent_runs": 0,
-        "prs_opened": 0,
-        "merged_prs": 0,
-        "agent_loc": 0,
-        "additions": 0,
-        "deletions": 0,
-        "total_tokens": 0,
-        "total_cost_usd": 0.0,
-        "run_duration_ms": 0,
-        "finished_runs": 0,
-        "models": Counter(),
-    }
-
-
-def _limited_rows(
-    rows: list[dict[str, Any]], current_row: dict[str, Any] | None, limit: int
-) -> list[dict[str, Any]]:
-    limited = rows[: min(max(limit, 1), 100)]
-    if current_row and all(row["rank"] != current_row["rank"] for row in limited):
-        return [*limited, current_row]
-    return limited
-
-
-def _in_period(record: dict[str, Any], field: str, cutoff_ms: int) -> bool:
-    timestamp = _timestamp_ms(record.get(field))
-    return timestamp > 0 and timestamp >= cutoff_ms
+    status = str(finding.get("status") or "open")
+    state = status if status in {"resolved", "dismissed"} else "reopened"
+    await finding_transition(
+        thread_key=thread_id,
+        finding_key=str(finding.get("id") or ""),
+        owner=owner,
+        repo=repo,
+        number=number,
+        state=state,
+        severity=_severity(finding.get("severity")),
+        category=str(finding.get("category") or "unknown"),
+        version=str(finding.get("last_confirmed_sha") or datetime.now(UTC).isoformat()),
+    )
 
 
 async def list_agent_usage_leaderboard(
@@ -701,199 +238,9 @@ async def list_agent_usage_leaderboard(
     limit: int,
     current_login: str | None,
     current_email: str | None,
+    admin: bool = False,
 ) -> dict[str, Any]:
-    """Aggregate current usage from complete, paginated telemetry."""
-    started_at = time.monotonic()
-    normalized = _normalize_period(period)
-    logger.info(
-        "Usage leaderboard aggregation started",
-        extra={"usage_period": normalized, "usage_limit": limit},
+    del current_email
+    return await usage_leaderboard(
+        period=period, limit=limit, current_login=current_login, admin=admin
     )
-    cache_key = (normalized, _login(current_login) or _email(current_email))
-    cached = _USAGE_CACHE.get(cache_key)
-    if cached and _now_ms() - cached[0] < _USAGE_CACHE_TTL_MS:
-        payload = dict(cached[1])
-        payload["rows"] = _limited_rows(payload["rows"], cached[2], limit)
-        logger.info(
-            "Usage leaderboard cache hit",
-            extra={
-                "usage_period": normalized,
-                "usage_rows": len(payload["rows"]),
-                "usage_elapsed_ms": round((time.monotonic() - started_at) * 1000),
-            },
-        )
-        return payload
-    await _backfill_legacy_usage()
-    cutoff_ms = _period_cutoff_ms(normalized)
-    runs, prs, review_records, finding_records = await asyncio.gather(
-        _all(AGENT_RUN_NAMESPACE),
-        _all(AGENT_PR_NAMESPACE),
-        _all(REVIEW_NAMESPACE),
-        _all(REVIEW_FINDING_NAMESPACE),
-    )
-    aliases = _aliases(runs + prs)
-    users: dict[str, dict[str, Any]] = {}
-
-    for record in runs:
-        if not _in_period(record, "created_at_ms", cutoff_ms):
-            continue
-        key = _user_key(record, aliases)
-        if not key:
-            continue
-        user = users.setdefault(key, _new_user(key, record, aliases))
-        user["agent_runs"] += 1
-        user["total_tokens"] += _int(record.get("total_tokens"))
-        cost_usd = record.get("cost_usd")
-        if (
-            isinstance(cost_usd, int | float)
-            and not isinstance(cost_usd, bool)
-            and math.isfinite(cost_usd)
-            and cost_usd >= 0
-        ):
-            user["total_cost_usd"] += float(cost_usd)
-        created_at_ms = _timestamp_ms(record.get("created_at_ms"))
-        finished_at_ms = _timestamp_ms(record.get("finished_at_ms"))
-        if created_at_ms and finished_at_ms >= created_at_ms:
-            user["run_duration_ms"] += finished_at_ms - created_at_ms
-            user["finished_runs"] += 1
-        model = record.get("model_id")
-        if isinstance(model, str) and model:
-            user["models"][model] += 1
-
-    for record in prs:
-        if not _in_period(record, "created_at_ms", cutoff_ms):
-            continue
-        key = _user_key(record, aliases)
-        if not key:
-            continue
-        user = users.setdefault(key, _new_user(key, record, aliases))
-        additions = int(record.get("additions") or 0)
-        deletions = int(record.get("deletions") or 0)
-        user["prs_opened"] += 1
-        user["merged_prs"] += int(bool(record.get("merged")))
-        user["additions"] += additions
-        user["deletions"] += deletions
-        user["agent_loc"] += additions + deletions
-
-    ordered = sorted(
-        users.values(),
-        key=lambda user: (
-            -user["merged_prs"],
-            -user["agent_loc"],
-            -user["prs_opened"],
-            -user["agent_runs"],
-            user["name"],
-        ),
-    )
-    current_keys = {
-        f"github:{_login(current_login)}" if _login(current_login) else "",
-        f"email:{_email(current_email)}" if _email(current_email) else "",
-    }
-    rows: list[dict[str, Any]] = []
-    current_row: dict[str, Any] | None = None
-    for rank, user in enumerate(ordered, 1):
-        models: Counter[str] = user["models"]
-        is_current = user["key"] in current_keys
-        row = {
-            "rank": rank,
-            "user": {
-                "name": user["name"] if is_current or user["github_login"] else "Open SWE user",
-                "github_login": user["github_login"] or None,
-                "email": (user["email"] or None) if is_current else None,
-            },
-            "favorite_model": models.most_common(1)[0][0] if models else "default",
-            "avg_run_seconds": (
-                user["run_duration_ms"] / user["finished_runs"] / 1000
-                if user["finished_runs"]
-                else 0.0
-            ),
-            **{
-                key: user[key]
-                for key in (
-                    "agent_runs",
-                    "prs_opened",
-                    "merged_prs",
-                    "agent_loc",
-                    "additions",
-                    "deletions",
-                    "total_tokens",
-                    "total_cost_usd",
-                )
-            },
-        }
-        if is_current:
-            current_row = row
-        if len(rows) < 100:
-            rows.append(row)
-
-    reviews = [
-        record for record in review_records if _in_period(record, "published_at_ms", cutoff_ms)
-    ]
-    findings = [
-        record for record in finding_records if _in_period(record, "recorded_at_ms", cutoff_ms)
-    ]
-    surfaced = [
-        record for record in finding_records if _in_period(record, "surfaced_at_ms", cutoff_ms)
-    ]
-    reviewed_prs = {(r.get("owner"), r.get("repo"), r.get("pr_number")) for r in reviews}
-    prs_with_findings = {
-        (r.get("owner"), r.get("repo"), r.get("pr_number"))
-        for r in reviews
-        if int(r.get("findings_recorded") or 0) > 0
-    }
-    addressed = [record for record in surfaced if record.get("status") == "resolved"]
-    dismissed = [record for record in surfaced if record.get("status") == "dismissed"]
-    unresolved = [record for record in surfaced if record.get("status") == "open"]
-    severity = Counter(str(record.get("severity")) for record in findings if record.get("severity"))
-    categories = Counter(
-        str(record.get("category")) for record in findings if record.get("category")
-    )
-    now_ms = _now_ms()
-    reviewer_stats = {
-        "period": normalized,
-        "reviewed_prs": len(reviewed_prs),
-        "prs_with_findings": len(prs_with_findings),
-        "findings_recorded": len(findings),
-        "surfaced_findings": len(surfaced),
-        "addressed_findings": len(addressed),
-        "resolved_after_update": sum(
-            1
-            for record in addressed
-            if record.get("resolved_sha")
-            and record.get("resolved_sha") != record.get("first_seen_sha")
-        ),
-        "dismissed_findings": len(dismissed),
-        "unresolved_surfaced_findings": len(unresolved),
-        "resolution_rate": len(addressed) / len(surfaced) if surfaced else 0.0,
-        "human_replies": sum(int(record.get("human_replies") or 0) for record in surfaced),
-        "severity_counts": dict(severity),
-        "top_categories": [
-            {"name": name, "count": count} for name, count in categories.most_common(5)
-        ],
-        "generated_at_ms": now_ms,
-    }
-    payload = {
-        "period": normalized,
-        "rows": rows,
-        "total_members": len(ordered),
-        "current_user_rank": current_row["rank"] if current_row else None,
-        "generated_at_ms": now_ms,
-        "reviewer_stats": reviewer_stats,
-    }
-    _USAGE_CACHE[cache_key] = (now_ms, payload, current_row)
-    result = dict(payload)
-    result["rows"] = _limited_rows(rows, current_row, limit)
-    logger.info(
-        "Usage leaderboard aggregation completed",
-        extra={
-            "usage_period": normalized,
-            "usage_runs": len(runs),
-            "usage_prs": len(prs),
-            "usage_reviews": len(review_records),
-            "usage_findings": len(finding_records),
-            "usage_members": len(ordered),
-            "usage_rows": len(result["rows"]),
-            "usage_elapsed_ms": round((time.monotonic() - started_at) * 1000),
-        },
-    )
-    return result

--- a/agent/dashboard/plan_api.py
+++ b/agent/dashboard/plan_api.py
@@ -312,6 +312,11 @@ async def reject_plan(
         ):
             raise HTTPException(409, "plan is no longer ready for review")
         await set_plan_status(thread_id, PLAN_STATUS_REVISING, plan_mode=True)
+        from agent.analytics.emitter import task_rework
+
+        await task_rework(
+            thread_id, source="dashboard", scope="major", reason="plan_review"
+        )
     if rejection is not None and not rejection.dispatch:
         return {"status": PLAN_STATUS_REVISING}
     feedback = format_plan_comments(await list_plan_comments(thread_id, raise_on_error=True))

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -1940,7 +1940,32 @@ async def api_agent_usage_leaderboard(
         limit=limit,
         current_login=session["sub"],
         current_email=session.get("email"),
+        admin=_session_is_admin(session),
     )
+
+
+@router.get("/analytics/pr-merge-rate-by-model")
+async def api_pr_merge_rate_by_model(
+    period: str | None = "30d",
+    maturity_days: int | None = Query(default=None, ge=1, le=365),
+    session: dict[str, Any] = _SESSION_DEP,
+) -> dict[str, Any]:
+    from agent.analytics.queries import pr_merge_rate_by_model
+
+    return await pr_merge_rate_by_model(
+        period=period,
+        maturity_days=maturity_days,
+        admin=_session_is_admin(session),
+    )
+
+
+@router.get("/analytics/outbox-status")
+async def api_analytics_outbox_status(
+    _admin: dict[str, Any] = _ADMIN_DEP,
+) -> dict[str, Any]:
+    from agent.analytics.outbox import outbox_status
+
+    return await outbox_status()
 
 
 @router.get("/schedules")

--- a/agent/dashboard/threads/api.py
+++ b/agent/dashboard/threads/api.py
@@ -446,6 +446,11 @@ async def resolve_dashboard_thread(
                 "attention_reason": None,
             }
             await client.threads.update(thread_id=thread_id, metadata=metadata_update)
+            if resolved:
+                from agent.analytics.emitter import task_accepted, task_marked_complete
+
+                await task_marked_complete(thread_id, source="dashboard")
+                await task_accepted(thread_id, source="dashboard", actor_key=login)
     except HTTPException:
         raise
     except Exception as exc:  # noqa: BLE001

--- a/agent/review/findings.py
+++ b/agent/review/findings.py
@@ -508,8 +508,22 @@ async def _replace_findings_unlocked(thread_id: str, findings: list[Finding]) ->
         raise ReviewerThreadMissingError(thread_id, exc) from exc
     from agent.dashboard.agent_usage import record_reviewer_finding_state
 
+    metadata = await get_thread_metadata(thread_id)
+    pr: dict[str, Any] = metadata["pr"] if isinstance(metadata.get("pr"), dict) else {}
     results = await asyncio.gather(
-        *(record_reviewer_finding_state(thread_id, finding) for finding in findings),
+        *(
+            record_reviewer_finding_state(
+                thread_id,
+                {
+                    **finding,
+                    "pr": pr,
+                    "owner": pr.get("owner"),
+                    "repo": pr.get("name"),
+                    "pr_number": pr.get("number"),
+                },
+            )
+            for finding in findings
+        ),
         return_exceptions=True,
     )
     failures = [result for result in results if isinstance(result, Exception)]

--- a/agent/server.py
+++ b/agent/server.py
@@ -875,10 +875,12 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
                         run_id=cfg.prepare_run_id,
                         thread_id=self._thread_id,
                         github_login=self._profile_login,
+                        github_user_id=cfg.github_user_id,
                         user_email=self._user_email,
                         model_id=self._model_id,
                         effort=self._effort,
                         source=self._source,
+                        repository=cfg.repo_full_name or None,
                     )
         except Exception:
             logger.debug(

--- a/agent/slack/thread_feedback.py
+++ b/agent/slack/thread_feedback.py
@@ -323,6 +323,14 @@ async def _process_rating(payload: dict[str, Any]) -> None:
             record.rating = int(suffix)
             record.last_rating_ts = action_ts
             await _store(channel_id).put(run_id, record)
+            from agent.analytics.emitter import feedback_submitted
+
+            await feedback_submitted(
+                run_key=run_id,
+                person_key=user_id,
+                rating=record.rating,
+                producer_version=str(action_ts),
+            )
     except Exception:
         logger.warning(
             "Could not save Slack rating", extra={"feedback_run_id": run_id}, exc_info=True

--- a/agent/tools/open_pull_request.py
+++ b/agent/tools/open_pull_request.py
@@ -591,6 +591,14 @@ async def _record_pr_telemetry(
             merged=merged,
             created_at=details.get("created_at") or pr.get("created_at"),
             merged_at=details.get("merged_at") or pr.get("merged_at"),
+            run_id=cfg.prepare_run_id,
+            model_id=cfg.agent_model_id,
+            source=cfg.source,
+            repository_private=(
+                details.get("base", {}).get("repo", {}).get("private")
+                if isinstance(details.get("base"), dict)
+                else None
+            ),
         )
         if isinstance(thread_id, str) and thread_id:
             repo_private = None

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -1491,7 +1491,16 @@ async def update_agent_thread_pr_state(payload: dict[str, Any]) -> None:
             logger.debug("Failed to update pr_state for thread %s", thread_id, exc_info=True)
             continue
         if new_state == "merged":
+            from agent.analytics.emitter import task_marked_complete
+
+            await task_marked_complete(thread_id, source="github", auto=True)
             await _record_pr_merge_feedback(thread_id, pr_url=pr_url)
+        elif new_state == "open" and previous_state in _TERMINAL_PR_STATES:
+            from agent.analytics.emitter import task_rework
+
+            await task_rework(
+                thread_id, source="github", scope="major", reason="pr_reopened"
+            )
             from agent.slack.thread_feedback import post_slack_pr_feedback_prompt
 
             await post_slack_pr_feedback_prompt(thread_id, metadata, pr_url)

--- a/docs/ANALYTICS.md
+++ b/docs/ANALYTICS.md
@@ -1,0 +1,49 @@
+# Durable analytics
+
+Open SWE analytics uses an append-only lifecycle event log and derived projections in a dedicated PostgreSQL service boundary. The LangGraph Store remains operational storage and is not queried for reports.
+
+## Deployment contract
+
+Set:
+
+- `ANALYTICS_POSTGRES_URI`: managed PostgreSQL URI. If omitted, custom code reads LangGraph's `POSTGRES_URI` as the deployment-provided database connection. Production operators should provision a separately governed database or schema and prefer the dedicated variable.
+- `ANALYTICS_WORKSPACE_ID`: immutable UUID for the workspace.
+- `ANALYTICS_EPOCH`: timezone-aware UTC timestamp at which trustworthy collection begins. Events before it are rejected; existing mutable records are not backfilled into a fabricated history.
+- `ANALYTICS_ENVIRONMENT`: producer environment, default `production`.
+- `ANALYTICS_SUMMARY_VERSION`: one version for metric semantics, attribution, maturity, and histogram buckets. Queries never mix versions.
+- `ANALYTICS_PR_MATURITY_DAYS`: default `14`.
+- `ANALYTICS_MIN_COHORT_SIZE`: aggregate privacy threshold, default `5`.
+
+The application runs idempotent migrations at startup and exposes `/health/analytics`. The service is product-fail-soft after startup: lifecycle capture catches analytics errors and the product side effect remains successful. PostgreSQL must be provisioned outside this repository with encrypted connections, backups, point-in-time recovery, least-privilege credentials, monitoring, and capacity appropriate to the event volume.
+
+## Delivery and atomicity
+
+Event intents enter the PostgreSQL outbox and are delivered at least once. Workers claim bounded batches with `FOR UPDATE SKIP LOCKED`, retry with bounded exponential backoff and jitter, acknowledge only after the event and projection transaction commits, and retain exhausted rows in `dead_letter`. Admins can inspect stale and dead-letter counts at `/dashboard/api/analytics/outbox-status`.
+
+Most operational state lives in LangGraph Store, GitHub, Slack, or LangGraph runs while analytics lives in PostgreSQL. Those systems cannot participate in one transaction. Therefore an operational side effect may succeed while its outbox insert fails. Capture points are fail-soft and never roll back product work. Deterministic event IDs, provider delivery versions, webhook redelivery, and reconciliation limit loss, but the system does not claim exactly-once side effects across systems.
+
+## Event and privacy contract
+
+The Pydantic envelope rejects unknown fields and validates a specific payload schema for every event name. IDs are deterministic UUIDv5 values. Duplicate ingestion is prevented by database constraints. Corrections are new events with a higher source version or observation revision.
+
+Events contain only opaque workspace-scoped person and subject UUIDs. Prompts, responses, feedback comments, source code, diffs, branch names, raw paths, emails, and display names are prohibited from the event schema. Names live in `identity_directory`, a separately protected join table. Named leaderboard rows are visible only to the person or workspace administrators. Aggregate model cohorts smaller than five are suppressed for non-admins. Repository names live in a protected directory so unauthorized callers can receive redacted dimensions. Named exports must write `named_export_audit` before returning data.
+
+Team-manager authorization is schema-ready through `team_id`, but Open SWE does not currently have an authoritative manager-membership signal. No manager access is granted until such a directory is connected. Effective model is currently captured as configured attribution where provider execution does not return an authoritative effective model.
+
+## Metrics and summaries
+
+Completed UTC days are materialized as versioned summaries; the current UTC day is queried live from the same projections and definitions. Dirty partitions include the event occurrence day plus original PR-open and finding-surfaced cohort days. Recompute atomically replaces one partition.
+
+Summary families include additive counters/sums, PR-open cohorts, finding-surfaced cohorts, cost completeness, exact distinct-member UUID sets, and fixed latency histograms. Distinct counts are computed from set unions, never summed. Range percentiles derive from merged histograms, never averaged daily percentile values.
+
+PR merge rate uses PR-open-date cohorts and snapshots the opening run/model attribution. Outcomes are mutually exclusive: merged, closed without merge, mature pending, and waiting. Decided merge rate excludes pending PRs; mature cohort merge share includes mature pending PRs in the denominator.
+
+Cost observations are per-run and revisioned. `null` is unknown and zero is a valid observed cost. Cost per PR can use the opening run separately and all distinct `pr_run_link_projection` members without duplicate links.
+
+## Signal gaps
+
+Open SWE now captures explicit dashboard task resolution/acceptance, plan rework, PR reopening, run terminals, PR lifecycle, Slack rating sentiment, review publication, and finding lifecycle where those transitions are available. It does not infer acceptance, team identity, major use, effective provider model, or cost when no authoritative signal exists. Feedback text remains only in the operational feedback system and is never copied to analytics.
+
+## Retention and deletion
+
+Defaults are configurable: raw events 25 months, aggregate summaries 7 years, named identities 13 months, acknowledged outbox 30 days, ingestion receipts 90 days, and unresolved dead letters until resolved. Compact event-ID tombstones are retained so an expired raw event cannot be reintroduced by a very late replay. The worker deletes expired online facts and anonymizes identity directory fields in place after their deadline. Cold archives are not created by Open SWE; finance or security may provision an encrypted archive under a separate policy.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ dependencies = [
     "langchain-mcp-adapters>=0.3.2",
     "stagehand>=3.23.0,<4.0.0",
     "websockets>=16.1.1",
+    "sqlalchemy==2.0.52",
+    "asyncpg==0.31.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_analytics_events.py
+++ b/tests/test_analytics_events.py
@@ -1,0 +1,43 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from agent.analytics.events import (
+    EventEnvelope,
+    EventName,
+    RunStartedPayload,
+    _reject_forbidden_fields,
+    deterministic_event_id,
+)
+
+
+def test_event_id_is_deterministic_and_versioned() -> None:
+    workspace = uuid4()
+    first = deterministic_event_id(workspace, EventName.RUN_STARTED, "run-1", "1")
+    assert first == deterministic_event_id(workspace, EventName.RUN_STARTED, "run-1", "1")
+    assert first != deterministic_event_id(workspace, EventName.RUN_STARTED, "run-1", "2")
+
+
+def test_event_rejects_forbidden_nested_fields() -> None:
+    with pytest.raises(ValueError, match="forbidden analytics field"):
+        _reject_forbidden_fields({"safe": [{"prompt": {"text": "secret"}}]})
+
+
+def test_event_requires_timezone() -> None:
+    workspace = uuid4()
+    occurred_at = datetime(2026, 1, 1)
+    with pytest.raises(ValidationError, match="timezone-aware"):
+        EventEnvelope(
+            event_id=deterministic_event_id(workspace, EventName.RUN_STARTED, "run-1", "1"),
+            event_name=EventName.RUN_STARTED,
+            workspace_id=workspace,
+            environment="test",
+            producer="open-swe",
+            producer_event_id="run-1:1",
+            occurred_at=occurred_at,
+            recorded_at=datetime.now(UTC),
+            privacy_classification="non_personal",
+            payload=RunStartedPayload(model_attribution_quality="unavailable"),
+        )

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -277,6 +277,15 @@ export interface UserMappingsPage {
 
 export type UsageLeaderboardPeriod = "7d" | "30d" | "all"
 
+export interface AnalyticsMetadata {
+  analytics_epoch: string | null
+  summary_version: number
+  freshness: string
+  completeness: string
+  data_watermark: string | null
+  as_of: string
+}
+
 export interface UsageLeaderboardRow {
   rank: number
   user: {
@@ -311,6 +320,7 @@ export interface ReviewerStatsPayload {
   resolved_after_update: number
   dismissed_findings: number
   unresolved_surfaced_findings: number
+  reopened_findings: number
   resolution_rate: number
   human_replies: number
   severity_counts: Record<string, number>
@@ -318,13 +328,36 @@ export interface ReviewerStatsPayload {
   generated_at_ms: number | null
 }
 
-export interface UsageLeaderboardPayload {
+export interface UsageLeaderboardPayload extends AnalyticsMetadata {
   period: UsageLeaderboardPeriod
   rows: Array<UsageLeaderboardRow>
   total_members: number
   current_user_rank: number | null
   generated_at_ms: number | null
   reviewer_stats: ReviewerStatsPayload
+}
+
+export interface PRMergeRateCohort {
+  model_id: string | null
+  model_attribution_quality: "effective" | "configured" | "unavailable"
+  merged: number
+  closed_without_merge: number
+  mature_pending: number
+  waiting: number
+  cohort_size: number
+  decided_denominator: number
+  decided_merge_rate: number | null
+  mature_denominator: number
+  mature_cohort_merge_share: number | null
+}
+
+export interface PRMergeRatePayload extends AnalyticsMetadata {
+  metric: "pr_merge_rate_by_originating_model"
+  definition: string
+  maturity_days: number
+  period: UsageLeaderboardPeriod
+  suppression_threshold: number
+  cohorts: PRMergeRateCohort[]
 }
 
 export interface Repository {
@@ -859,6 +892,13 @@ export const api = {
   usageLeaderboard: (period: UsageLeaderboardPeriod = "30d", limit = 10) =>
     request<UsageLeaderboardPayload>(
       `/agent-usage-leaderboard?period=${encodeURIComponent(period)}&limit=${limit}`
+    ),
+  prMergeRateByModel: (
+    period: UsageLeaderboardPeriod = "30d",
+    maturityDays = 14
+  ) =>
+    request<PRMergeRatePayload>(
+      `/analytics/pr-merge-rate-by-model?period=${encodeURIComponent(period)}&maturity_days=${maturityDays}`
     ),
   myMapping: () => request<Partial<UserMapping>>("/my-mapping"),
   adminListUserMappings: (page = 1, pageSize = 20) =>

--- a/ui/src/routes/usage.tsx
+++ b/ui/src/routes/usage.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router"
 import { useQuery } from "@tanstack/react-query"
 
 import type {
+  PRMergeRateCohort,
   ReviewerStatsPayload,
   UsageLeaderboardPeriod,
   UsageLeaderboardRow,
@@ -48,8 +49,11 @@ function UsagePage() {
     queryKey: ["usageLeaderboard", activePeriod],
     queryFn: () => api.usageLeaderboard(activePeriod, 10),
     enabled: !!session.data,
-    staleTime: 60 * 1000,
-    refetchInterval: 60 * 1000,
+  })
+  const mergeRate = useQuery({
+    queryKey: ["prMergeRateByModel", activePeriod],
+    queryFn: () => api.prMergeRateByModel(activePeriod, 14),
+    enabled: !!session.data,
   })
 
   if (session.isLoading) {
@@ -64,8 +68,40 @@ function UsagePage() {
   return (
     <AppShell user={session.data} title="Usage" className="max-w-5xl">
       <SettingsSection
+        title="PR merge rate by originating model"
+        description="PRs are grouped by open date and the opening run's effective model. Open PRs wait 14 days before becoming mature pending; pending is never failure."
+      >
+        {mergeRate.isLoading ? (
+          <div className="space-y-2 p-4">
+            <Skeleton className="h-16 w-full" />
+            <Skeleton className="h-16 w-full" />
+          </div>
+        ) : mergeRate.isError ? (
+          <p className="p-4 text-xs text-destructive">
+            Failed to load PR merge rate: {mergeRate.error.message}
+          </p>
+        ) : mergeRate.data?.cohorts.length ? (
+          <PRMergeRateTable cohorts={mergeRate.data.cohorts} />
+        ) : (
+          <p className="p-6 text-center text-xs text-muted-foreground">
+            No cohort meets the privacy threshold for this period yet.
+          </p>
+        )}
+        {mergeRate.data ? (
+          <div className="border-t border-border px-4 py-3 text-xs text-muted-foreground">
+            Decided rate excludes pending PRs. Mature share includes mature
+            pending PRs. Cohorts smaller than{" "}
+            {mergeRate.data.suppression_threshold} are suppressed. Data is
+            trustworthy from{" "}
+            {mergeRate.data.analytics_epoch ?? "the configured epoch"};
+            completeness: {mergeRate.data.completeness}.
+          </div>
+        ) : null}
+      </SettingsSection>
+
+      <SettingsSection
         title="Agent leaderboard"
-        description="Ranked by merged PRs, then agent lines of code, PRs opened, and agent runs."
+        description="Ranked by merged PRs, then PRs opened and agent runs from indexed analytics projections."
         action={
           <Select
             value={activePeriod}
@@ -114,7 +150,7 @@ function UsagePage() {
 
       <SettingsSection
         title="Reviewer stats"
-        description="Issues surfaced by Open SWE Review and how often users addressed them."
+        description="Surfaced, resolved, dismissed, open, and reopened findings are tracked separately."
       >
         {leaderboard.isLoading ? (
           <div className="grid gap-3 p-4 sm:grid-cols-2">
@@ -142,6 +178,64 @@ function UsagePage() {
         </p>
       ) : null}
     </AppShell>
+  )
+}
+
+function PRMergeRateTable({ cohorts }: { cohorts: PRMergeRateCohort[] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full min-w-[760px] text-xs">
+        <thead className="border-b border-border text-muted-foreground">
+          <tr>
+            <th className="px-4 py-3 text-left font-normal">
+              Originating model
+            </th>
+            <th className="px-2 py-3 text-right font-normal">Merged</th>
+            <th className="px-2 py-3 text-right font-normal">Closed</th>
+            <th className="px-2 py-3 text-right font-normal">Mature pending</th>
+            <th className="px-2 py-3 text-right font-normal">Waiting</th>
+            <th className="px-2 py-3 text-right font-normal">Decided rate</th>
+            <th className="px-4 py-3 text-right font-normal">Mature share</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          {cohorts.map((cohort) => (
+            <tr key={`${cohort.model_id}-${cohort.model_attribution_quality}`}>
+              <td className="px-4 py-3">
+                <div className="font-medium">
+                  {cohort.model_id ?? "Unavailable"}
+                </div>
+                <div className="text-muted-foreground">
+                  {cohort.model_attribution_quality} attribution
+                </div>
+              </td>
+              <td className="px-2 py-3 text-right tabular-nums">
+                {cohort.merged}
+              </td>
+              <td className="px-2 py-3 text-right tabular-nums">
+                {cohort.closed_without_merge}
+              </td>
+              <td className="px-2 py-3 text-right tabular-nums">
+                {cohort.mature_pending}
+              </td>
+              <td className="px-2 py-3 text-right tabular-nums">
+                {cohort.waiting}
+              </td>
+              <td className="px-2 py-3 text-right tabular-nums">
+                {cohort.decided_merge_rate == null
+                  ? "—"
+                  : formatPercent(cohort.decided_merge_rate)}
+              </td>
+              <td className="px-4 py-3 text-right tabular-nums">
+                {cohort.mature_cohort_merge_share == null
+                  ? "—"
+                  : formatPercent(cohort.mature_cohort_merge_share)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   )
 }
 
@@ -247,7 +341,12 @@ function ReviewerStats({ stats }: { stats: ReviewerStatsPayload }) {
     {
       label: "Dismissed",
       value: stats.dismissed_findings,
-      helper: `${formatNumber(stats.human_replies)} human replies tracked`,
+      helper: "Dismissal is separate from resolution",
+    },
+    {
+      label: "Reopened",
+      value: stats.reopened_findings,
+      helper: "Findings reopened after a terminal state",
     },
   ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -159,6 +159,30 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncpg"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/36/e9450d62e84a13aea6580c83a47a437f26c7ca6fa0f0fd40b6670793ea30/asyncpg-0.31.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f6b56b91bb0ffc328c4e3ed113136cddd9deefdf5f79ab448598b9772831df44", size = 660867, upload-time = "2025-11-24T23:26:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/82/4b/1d0a2b33b3102d210439338e1beea616a6122267c0df459ff0265cd5807a/asyncpg-0.31.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:334dec28cf20d7f5bb9e45b39546ddf247f8042a690bff9b9573d00086e69cb5", size = 638349, upload-time = "2025-11-24T23:26:19.689Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/e7f7ac9a7974f08eff9183e392b2d62516f90412686532d27e196c0f0eeb/asyncpg-0.31.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98cc158c53f46de7bb677fd20c417e264fc02b36d901cc2a43bd6cb0dc6dbfd2", size = 3410428, upload-time = "2025-11-24T23:26:21.275Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/de/bf1b60de3dede5c2731e6788617a512bc0ebd9693eac297ee74086f101d7/asyncpg-0.31.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9322b563e2661a52e3cdbc93eed3be7748b289f792e0011cb2720d278b366ce2", size = 3471678, upload-time = "2025-11-24T23:26:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/fc3ade003e22d8bd53aaf8f75f4be48f0b460fa73738f0391b9c856a9147/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19857a358fc811d82227449b7ca40afb46e75b33eb8897240c3839dd8b744218", size = 3313505, upload-time = "2025-11-24T23:26:25.235Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e9/73eb8a6789e927816f4705291be21f2225687bfa97321e40cd23055e903a/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba5f8886e850882ff2c2ace5732300e99193823e8107e2c53ef01c1ebfa1e85d", size = 3434744, upload-time = "2025-11-24T23:26:26.944Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4b/f10b880534413c65c5b5862f79b8e81553a8f364e5238832ad4c0af71b7f/asyncpg-0.31.0-cp314-cp314-win32.whl", hash = "sha256:cea3a0b2a14f95834cee29432e4ddc399b95700eb1d51bbc5bfee8f31fa07b2b", size = 532251, upload-time = "2025-11-24T23:26:28.404Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2d/7aa40750b7a19efa5d66e67fc06008ca0f27ba1bd082e457ad82f59aba49/asyncpg-0.31.0-cp314-cp314-win_amd64.whl", hash = "sha256:04d19392716af6b029411a0264d92093b6e5e8285ae97a39957b9a9c14ea72be", size = 604901, upload-time = "2025-11-24T23:26:30.34Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fe/b9dfe349b83b9dee28cc42360d2c86b2cdce4cb551a2c2d27e156bcac84d/asyncpg-0.31.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bdb957706da132e982cc6856bb2f7b740603472b54c3ebc77fe60ea3e57e1bd2", size = 702280, upload-time = "2025-11-24T23:26:32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/81/e6be6e37e560bd91e6c23ea8a6138a04fd057b08cf63d3c5055c98e81c1d/asyncpg-0.31.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6d11b198111a72f47154fa03b85799f9be63701e068b43f84ac25da0bda9cb31", size = 682931, upload-time = "2025-11-24T23:26:33.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/45/6009040da85a1648dd5bc75b3b0a062081c483e75a1a29041ae63a0bf0dc/asyncpg-0.31.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18c83b03bc0d1b23e6230f5bf8d4f217dc9bc08644ce0502a9d91dc9e634a9c7", size = 3581608, upload-time = "2025-11-24T23:26:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/06/2e3d4d7608b0b2b3adbee0d0bd6a2d29ca0fc4d8a78f8277df04e2d1fd7b/asyncpg-0.31.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e009abc333464ff18b8f6fd146addffd9aaf63e79aa3bb40ab7a4c332d0c5e9e", size = 3498738, upload-time = "2025-11-24T23:26:37.275Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/aa/7d75ede780033141c51d83577ea23236ba7d3a23593929b32b49db8ed36e/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3b1fbcb0e396a5ca435a8826a87e5c2c2cc0c8c68eb6fadf82168056b0e53a8c", size = 3401026, upload-time = "2025-11-24T23:26:39.423Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7a/15e37d45e7f7c94facc1e9148c0e455e8f33c08f0b8a0b1deb2c5171771b/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8df714dba348efcc162d2adf02d213e5fab1bd9f557e1305633e851a61814a7a", size = 3429426, upload-time = "2025-11-24T23:26:41.032Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d5/71437c5f6ae5f307828710efbe62163974e71237d5d46ebd2869ea052d10/asyncpg-0.31.0-cp314-cp314t-win32.whl", hash = "sha256:1b41f1afb1033f2b44f3234993b15096ddc9cd71b21a42dbd87fc6a57b43d65d", size = 614495, upload-time = "2025-11-24T23:26:42.659Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d7/8fb3044eaef08a310acfe23dae9a8e2e07d305edc29a53497e52bc76eca7/asyncpg-0.31.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bd4107bb7cdd0e9e65fae66a62afd3a249663b844fa34d479f6d5b3bef9c04c3", size = 706062, upload-time = "2025-11-24T23:26:44.086Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -771,6 +795,45 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/20/18/a746c8344152d368a5aac738d4c857012f2c5d1fd2eac7e17b647a7861bd/googleapis_common_protos-1.74.0.tar.gz", hash = "sha256:57971e4eeeba6aad1163c1f0fc88543f965bb49129b8bb55b2b7b26ecab084f1", size = 151254, upload-time = "2026-04-02T21:23:26.679Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/b0/be5d3329badb9230b765de6eea66b73abd5944bdeb5afb3562ddcd80ae84/googleapis_common_protos-1.74.0-py3-none-any.whl", hash = "sha256:702216f78610bb510e3f12ac3cafd281b7ac45cc5d86e90ad87e4d301a3426b5", size = 300743, upload-time = "2026-04-02T21:22:49.108Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/d8/7cc97c142388aef03f622e001c572c4f84e9252a439549d483f555771970/greenlet-3.5.5.tar.gz", hash = "sha256:adb4bae02e91a8e863e48b177e4014bdcac8a6b5e047ea1df687a61534b85e6c", size = 207585, upload-time = "2026-08-10T15:09:36.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/8c/080e881fa2be95ff1ddbd6994b2bab3b1a78df3b3fcab39306011764fcc7/greenlet-3.5.5-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d4a389a852e392a6366058651a20fa5ba40d979865aa81bea2ccbdc44805070d", size = 295309, upload-time = "2026-08-10T13:26:03.032Z" },
+    { url = "https://files.pythonhosted.org/packages/25/cc/0ac614e6586c0e42d4cc281a5819150f4f43685744a4c5ff77139286409d/greenlet-3.5.5-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:70b157cd319873e8b544ddc2de158f55bbd0a9b0218c8ce9332039801518e328", size = 661185, upload-time = "2026-08-10T14:14:37.867Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b9/6808725354be8ad305dfe5172377664fc9642d4fc043be246b3314cf4482/greenlet-3.5.5-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8bdfd1424abcf26832961e766570cae79efdb9599d709088c9cb6ef82b194926", size = 673419, upload-time = "2026-08-10T14:27:28.652Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2e/40c509967da7f254680826a2fa0dd22138ec79946c70b97542d74cde8b43/greenlet-3.5.5-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:182de51c6b572a705f2fafaab2e783bcf7d2760940229dfe73086cbae037af3e", size = 670822, upload-time = "2026-08-10T13:40:51.833Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/22/c3c2eee4a8fe191d6d1d183086c56133d646024e3d70bfd414829f64560b/greenlet-3.5.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8fec3f165dfe332e490c3247c0f6c23b0bfc45f06496ad7f00ddb00e3d35e4dc", size = 1628469, upload-time = "2026-08-10T14:15:08.11Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/87/25babd09b94cb1f03e71db815fde463f0262e40cfbd953d58a8d77311351/greenlet-3.5.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c6ce25fee6cabc8bf22cb8b52e642cbb821be5b9aec8094d07ff03378141b8e9", size = 1691952, upload-time = "2026-08-10T13:40:33.502Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/3d/5cc9701117ea4dc0eb7bf1f4f9b7888a6e2e5277ddfae095805ace50f2b6/greenlet-3.5.5-cp314-cp314-win_amd64.whl", hash = "sha256:7dffc5c859fe6059974df1e37d7923d654a83e2ae18fdd616994270e001115e1", size = 327458, upload-time = "2026-08-10T13:27:02.868Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6b/594fa2de7fae7629168a404a4305d7d7e31a5742c50a801b1839543cb93d/greenlet-3.5.5-cp314-cp314-win_arm64.whl", hash = "sha256:5e2afcfc4d4305dd715809b03da5cbe437c8984f61d8917751eb5fe4aefa3e07", size = 311146, upload-time = "2026-08-10T13:27:25.046Z" },
+    { url = "https://files.pythonhosted.org/packages/24/e0/50cd600b469e5734c72709b6b1838b6bc63f307b573c772c3132d6ecfe92/greenlet-3.5.5-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:0e5a7de979d764aea1f5b6e95cf92b5b37741b9823702041f34b126e7f690277", size = 305471, upload-time = "2026-08-10T13:26:20.568Z" },
+    { url = "https://files.pythonhosted.org/packages/75/a3/77acd66dfc6387b5219b2080806c0cabb73c10eb1bb44b413c40a62015ba/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fef01bd457f11fc158b130ca0027a3c365693280e8e231b65bdaf57999f39f5b", size = 672470, upload-time = "2026-08-10T14:14:39.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/71/0d178142dca3ec19f46fb2212ae73d30ad53b9d548dc64804086033a7089/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5173a72310725a74afc82c164f0e52cb8ad0de62f2bb623f24f6c0cc07d80272", size = 679973, upload-time = "2026-08-10T14:27:30.072Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/31/46eb8567302eaf787abf88d09df014e14ae3baf460af1b8b0efdbd3efcd5/greenlet-3.5.5-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44f08341873200ba8a60a8bc14ace3d91f1754f7fa7bc66157714a8cd420a476", size = 676634, upload-time = "2026-08-10T13:40:53.004Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/e9/b88bbf5b29970cb84172dc2c32aa3e5e579ceb94c808e81c826454138850/greenlet-3.5.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d246c0db9a2513cd45f019ba178ea4d4d4705bd210ee465e2c15d76a1ab13874", size = 1637320, upload-time = "2026-08-10T14:15:09.317Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/8c/7631ed29cc6f0392f11830076e172ce4885e70b0bc2c1bce1731176d4b4e/greenlet-3.5.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:72507285b5caa1d17904a3f7c322ca780823a54170a0e04ec3f37bcc60d4db71", size = 1697412, upload-time = "2026-08-10T13:40:34.924Z" },
+    { url = "https://files.pythonhosted.org/packages/da/0f/f7dd935f9c4cb1be49098770587f54d8a78518e55c89bce86c4fb4109057/greenlet-3.5.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7805655781fb8f28a55d05fe57ed61f5f10f1892fb587673e3bb5264f28041f0", size = 331514, upload-time = "2026-08-10T13:29:20.611Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e5/681b01f8fbc1b55232822f99e8f8afeb78a55a7c76a7bf9dbdc7ccb03a6d/greenlet-3.5.5-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:c0db80fcd5b8aece93f66c64f78a786bbb6b96c5fe63ef5a5a4581ecf8bab206", size = 295975, upload-time = "2026-08-10T13:28:45.985Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f2/69b488cd9e7267bf4b0fe8cdebf25d8d6df680d21bdf41150d23e23d6652/greenlet-3.5.5-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b241c32f912ada659808d68e308c568baf577eebf757d15471472de0c18cfad", size = 666823, upload-time = "2026-08-10T14:14:40.222Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d4/d5bc2fdebbdda0c94555925ba79948b8395d75a7f6a36cc85dce5bab9f11/greenlet-3.5.5-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ef6a08349401d8eaf3cb12688ac8557de95788556b8631ef17555a4a173022c0", size = 677613, upload-time = "2026-08-10T14:27:31.543Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/93/542d8a3a90f3b35c6ad8bf7e56a03010287f2cafa289a5b7985b5207db39/greenlet-3.5.5-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f2e3d061b8e13aec2f0441689b3c71b244a20e5d274a52cb0f7e31bd1d139552", size = 675930, upload-time = "2026-08-10T13:40:54.205Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b5/89c9f2e8460d71101037d47a1feed11928615a5edd42370be290e0657eeb/greenlet-3.5.5-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:9ab5f5b93655e77fe0d6c2dfd22b5eac751bb1f876d8ec21761b7c1fb9266007", size = 1633878, upload-time = "2026-08-10T14:15:10.693Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/60/297de93f3b02ac78a5e04d32bb8bbe3080f4a73d8ed95016561463b70618/greenlet-3.5.5-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:f0e5a21bd4452a88cf032fc43c4a5b307ab1380eacb63b5988f9c0317885e773", size = 1696597, upload-time = "2026-08-10T13:40:36.252Z" },
+    { url = "https://files.pythonhosted.org/packages/18/25/54c6eaff4f337fb670215e89eb2d00d9499487b658e709d4b477be4a342e/greenlet-3.5.5-cp315-cp315-win_amd64.whl", hash = "sha256:469dbb0a78625642f4a626cfd0c6e8bccc0385b5e49189b6308bbe849ec88a8e", size = 327700, upload-time = "2026-08-10T13:28:06.752Z" },
+    { url = "https://files.pythonhosted.org/packages/67/67/857e88a36301caa0e029870132c2478bd55d896630321432afab03a3115f/greenlet-3.5.5-cp315-cp315-win_arm64.whl", hash = "sha256:2d57406c3efd32d7a81e17a674314e8bd00792cdab49ea3228a49aa1bfb2e769", size = 311750, upload-time = "2026-08-10T13:34:08.815Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e2/3144c0a116067ac1e30457b0139a94d60d1d36a86e015de68e9ac87cb3bc/greenlet-3.5.5-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:68184dfcf50ccaa8e864770fe0633a7e27250ea9329f8192ef47ee9ecfd78e1c", size = 306387, upload-time = "2026-08-10T13:27:00.897Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/a1/cb4223a7e9b9f43b8807e8eb212358bfe2dfaa174a9ea2889eb1714dcba2/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9ec0dc0e59dc9c61af5c47348365ccbbd7addfafe0a93b00336ff3da2907bdc6", size = 676472, upload-time = "2026-08-10T14:14:41.417Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/cd/a154b4498e5d8f12ada291cfb3b8d596eadde2177f5bf09a9be699d2a446/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e604f58e35833fc46ef20302bcb314dddbfd3fcf33a4f936216d51dd678d63ae", size = 684238, upload-time = "2026-08-10T14:27:32.946Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/bb/b0031d260c2968a3c87deebc51d80c64e499377f993aafe06ee3b7488cc2/greenlet-3.5.5-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:40239b5384f96da3963585cc6d7eaa9b56f8ae67e8d92cc82dd9e202fc847de3", size = 681246, upload-time = "2026-08-10T13:40:55.402Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/07/da554b71ab88e649da146e1065d86a48a5c5d92e50ab74ef41b504aa7f56/greenlet-3.5.5-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:a1eaccf5c3a1d3e46dead602c72e6836731e8e245c9de6a27764567b6b62d4c0", size = 1642735, upload-time = "2026-08-10T14:15:11.92Z" },
+    { url = "https://files.pythonhosted.org/packages/78/76/26a3782a051677668af9d92beaa47cd87ba9dd5072f762961144a03dd4c6/greenlet-3.5.5-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:19e4e026fe20691f333b8eb1a3bc9625eceba8c3f9d62ec5a6f8581afbc6b5a5", size = 1700925, upload-time = "2026-08-10T13:40:37.656Z" },
+    { url = "https://files.pythonhosted.org/packages/28/d9/fe7baf4190c2ae71f267efb9de21b3172bb35bc0ed1ef53dd6027d658e33/greenlet-3.5.5-cp315-cp315t-win_amd64.whl", hash = "sha256:712aee154f648bde84634654bb38bb78c69ac640c37a45c9effed800735049d8", size = 331829, upload-time = "2026-08-10T13:26:48.851Z" },
+    { url = "https://files.pythonhosted.org/packages/df/af/419a4e383bd600858a9b67e9b280a60fdc383ee3f2fe5b6c0c1ef04e74d1/greenlet-3.5.5-cp315-cp315t-win_arm64.whl", hash = "sha256:7f049911ee81a16a03c33d5450d8d5867d27f596ca5fb201b86f4524e874468b", size = 315093, upload-time = "2026-08-10T13:29:34.949Z" },
 ]
 
 [[package]]
@@ -1634,6 +1697,7 @@ name = "open-swe-agent"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "asyncpg" },
     { name = "cryptography" },
     { name = "deepagents" },
     { name = "exa-py" },
@@ -1657,6 +1721,7 @@ dependencies = [
     { name = "markdownify" },
     { name = "openai" },
     { name = "pyjwt" },
+    { name = "sqlalchemy" },
     { name = "stagehand" },
     { name = "uvicorn" },
     { name = "websockets" },
@@ -1673,6 +1738,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "asyncpg", specifier = "==0.31.0" },
     { name = "cryptography", specifier = ">=50.0.0" },
     { name = "deepagents", specifier = "==0.7.13" },
     { name = "exa-py", specifier = ">=2.18.1" },
@@ -1700,6 +1766,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.1.1" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.4.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.16.4" },
+    { name = "sqlalchemy", specifier = "==2.0.52" },
     { name = "stagehand", specifier = ">=3.23.0,<4.0.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = "==0.0.78" },
     { name = "uvicorn", specifier = ">=0.52.4" },
@@ -2502,6 +2569,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/21/77b4c147963073040dc3c3a5cb7a8c3001a1893c0209432cb77f9df836aa/sqlalchemy-2.0.52.tar.gz", hash = "sha256:5e2d46356ac2ccb7d268ab6c2319ac6a2b42f1b8d5fd8bd3d46855cd82abee97", size = 9945637, upload-time = "2026-08-11T19:07:09.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/f5/71cb30af58c9b80a4e1fac0b73bb48f86d497a774a6a2eb6d2f1e657bb73/sqlalchemy-2.0.52-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:410d52be41d17f1a236d19520fbe776257dc16516ed06bd16d433311842aefd9", size = 2169537, upload-time = "2026-08-11T20:58:13.855Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/93/d07ebd645d1b07b6b5ed63450a70f063a346a7e0f2c8810daf2e532400cb/sqlalchemy-2.0.52-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dfe9ce533dbe4d0a2ae1486546619bd30b76bcd670539a44d910361376175f5e", size = 3319606, upload-time = "2026-08-11T21:02:45.829Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/5c/290c84c7c2566ecd3b65baaae0fddec9bc33b033b398a06123bb86fbfc6e/sqlalchemy-2.0.52-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:812bae5138bfc0aa46fb0686da0fc7f581f68e2bbb05bc24c3713bebaedd1437", size = 3323642, upload-time = "2026-08-11T21:17:05.675Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f5/2cc160590ca49173359557880b92a0572293ccb899e8f6cedf150c5a3ddf/sqlalchemy-2.0.52-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:50bff43b632a56fbf5ed9afdd76307e1512b62051bcd5afb341ae67205bbb6c8", size = 3268125, upload-time = "2026-08-11T21:02:47.649Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f3/ea8933fc9f7d1353e9c2ff9965eae687c4cef181120574591ed2fa0633e1/sqlalchemy-2.0.52-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:49565daf5af554f538e23aef1fc81a95a4e49658f152285e45c02f5fc44f04cd", size = 3289516, upload-time = "2026-08-11T21:17:07.267Z" },
+    { url = "https://files.pythonhosted.org/packages/45/67/05cf86541c1e1716fca1e4a996954a439cd74501707cda607fb7cb02ef50/sqlalchemy-2.0.52-cp314-cp314-win32.whl", hash = "sha256:ab9da41e61b9979b910499d633b241df20c51ee5037e5405b11c2faac3cbe1a2", size = 2130249, upload-time = "2026-08-11T21:14:57.273Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d7/8ac6ffa1e36169e762ef65bd835046abb2251b1bc17f8f6708e14ed8d31f/sqlalchemy-2.0.52-cp314-cp314-win_amd64.whl", hash = "sha256:a593db51b3bae75db17a5738ad5f992244b3a03863f83c28117ee482c6a3f76d", size = 2156718, upload-time = "2026-08-11T21:14:58.667Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/4b/e01a737eef378e734cc6394a82248a6ce13b167dfa36c731075ce9fc9c64/sqlalchemy-2.0.52-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1e61d08bdf4ee2f41024569e3400de7d6734ba498144766b11260936ccfa582", size = 2190344, upload-time = "2026-08-11T19:53:21.393Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/3f/3582293d1e185e71d19d7c731c3e2ee20ba21981c4a1115c0806c1f62120/sqlalchemy-2.0.52-py3-none-any.whl", hash = "sha256:3b81b8363a919ce53453591cdb93702e6bd54ade6c4fa2f468fc053baee5ed89", size = 1950700, upload-time = "2026-08-11T20:47:21.603Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Summary

- replace LangGraph Store full scans and the 60-second process cache with bounded SQLAlchemy queries over PostgreSQL projections
- add strict immutable lifecycle events, deterministic IDs, a durable at-least-once outbox, dead letters, conflict tracking, versioned summaries, retention, and analytics readiness
- capture run, cost, task, PR, review, finding, and feedback transitions without storing prompts, responses, feedback text, code, diffs, branch names, paths, emails, or display names in events
- add a PR-open cohort metric by originating model with 14-day maturity, separate merged/closed/mature-pending/waiting outcomes, privacy suppression, watermark, completeness, epoch, and summary metadata
- document provisioning, deployment fallback, signal gaps, privacy boundaries, retention, and the unavoidable cross-system atomicity gap

### Architecture

```mermaid
flowchart LR
    A[Product lifecycle transitions] -->|fail-soft capture| B[PostgreSQL outbox]
    B -->|FOR UPDATE SKIP LOCKED| C[Immutable event log]
    C --> D[Current projections]
    C --> E[Dirty UTC partitions]
    E --> F[Versioned daily summaries]
    D --> G[Live current day]
    F --> H[Dashboard queries]
    G --> H
    I[Protected identity/model/repository directories] -. authorized join .-> H
```

### Dependencies

- `SQLAlchemy==2.0.52` for the required bound-parameter async service boundary and migration/query layer; MIT licensed and actively maintained
- `asyncpg==0.31.0` as SQLAlchemy's Python 3.14-capable PostgreSQL async driver; Apache-2.0 licensed and actively maintained
- standard-library or already-declared alternatives do not provide an async PostgreSQL implementation; direct raw-driver SQL was rejected in favor of SQLAlchemy Core

### UI

The usage page now explains the two denominators explicitly: decided merge rate excludes pending PRs, while mature cohort merge share includes mature pending PRs. Pending is never presented as failure, and cohorts below the configured privacy threshold are suppressed for ordinary users.

Made by [Open SWE](https://openswe.vercel.app/agents/03880036-3b58-557c-b29b-e9bffc576c24) · openai:gpt-5.6-sol (high)