### PR TITLE
fix(ui): return from settings to active thread

### DIFF
--- a/tests/e2e/tests/settings_back_navigation.spec.ts
+++ b/tests/e2e/tests/settings_back_navigation.spec.ts
@@ -12,11 +12,17 @@ test("Back to app returns to the thread that opened settings", async ({
   await loginAs(page, SAME_USER);
   await openThreadViaSlackLink(page);
   const threadUrl = page.url();
+  const threadHref = new URL(threadUrl);
 
   await page.getByRole("button", { name: SAME_USER.login }).click();
   await page.getByRole("menuitem", { name: "Settings" }).click();
   await expect(page).toHaveURL(/\/my-settings$/);
 
-  await page.getByRole("link", { name: "Back to app" }).click();
+  const backLink = page.getByRole("link", { name: "Back to app" });
+  await expect(backLink).toHaveAttribute(
+    "href",
+    `${threadHref.pathname}${threadHref.search}${threadHref.hash}`,
+  );
+  await backLink.click();
   await expect(page).toHaveURL(threadUrl);
 });

--- a/tests/e2e/tests/settings_back_navigation.spec.ts
+++ b/tests/e2e/tests/settings_back_navigation.spec.ts
@@ -19,8 +19,4 @@ test("Back to app returns to the thread that opened settings", async ({
 
   await page.getByRole("link", { name: "Back to app" }).click();
   await expect(page).toHaveURL(threadUrl);
-  await page.screenshot({
-    path: ".open-swe/artifacts/settings-back-to-thread.png",
-    fullPage: true,
-  });
 });

--- a/tests/e2e/tests/settings_back_navigation.spec.ts
+++ b/tests/e2e/tests/settings_back_navigation.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  loginAs,
+  openThreadViaSlackLink,
+  SAME_USER,
+} from "./helpers/dashboard";
+
+test("Back to app returns to the thread that opened settings", async ({
+  page,
+}) => {
+  await loginAs(page, SAME_USER);
+  await openThreadViaSlackLink(page);
+  const threadUrl = page.url();
+
+  await page.getByRole("button", { name: SAME_USER.login }).click();
+  await page.getByRole("menuitem", { name: "Settings" }).click();
+  await expect(page).toHaveURL(/\/my-settings$/);
+
+  await page.getByRole("link", { name: "Back to app" }).click();
+  await expect(page).toHaveURL(threadUrl);
+  await page.screenshot({
+    path: ".open-swe/artifacts/settings-back-to-thread.png",
+    fullPage: true,
+  });
+});

--- a/ui/src/components/AppSidebar.tsx
+++ b/ui/src/components/AppSidebar.tsx
@@ -1,4 +1,4 @@
-import { Link } from "@tanstack/react-router"
+import { Link, useNavigate } from "@tanstack/react-router"
 import {
   IoArrowBackOutline,
   IoCloudOutline,
@@ -17,6 +17,7 @@ import {
   useSidebarLayout,
 } from "@/components/sidebar-layout"
 import { cn } from "@/lib/utils"
+import { getLastAppLocation } from "@/lib/appLocation"
 
 type IconType = ComponentType<SVGProps<SVGSVGElement>>
 
@@ -59,6 +60,7 @@ const LINK_CLASS =
 
 export function AppSidebar({ user }: { user: SessionUser }) {
   const layout = useSidebarLayout()
+  const navigate = useNavigate()
   const isDesktop =
     typeof window !== "undefined" && Boolean(window.openSweDesktop)
 
@@ -76,7 +78,11 @@ export function AppSidebar({ user }: { user: SessionUser }) {
         <Link
           to="/agents"
           className={cn(LINK_CLASS, "-mx-2.5 font-medium")}
-          onClick={layout.closeOnMobile}
+          onClick={(event) => {
+            event.preventDefault()
+            layout.closeOnMobile()
+            void navigate({ href: getLastAppLocation() })
+          }}
         >
           <IoArrowBackOutline className="size-4" />
           <span>Back to app</span>

--- a/ui/src/components/AppSidebar.tsx
+++ b/ui/src/components/AppSidebar.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate } from "@tanstack/react-router"
+import { Link } from "@tanstack/react-router"
 import {
   IoArrowBackOutline,
   IoCloudOutline,
@@ -60,7 +60,6 @@ const LINK_CLASS =
 
 export function AppSidebar({ user }: { user: SessionUser }) {
   const layout = useSidebarLayout()
-  const navigate = useNavigate()
   const isDesktop =
     typeof window !== "undefined" && Boolean(window.openSweDesktop)
 
@@ -76,13 +75,9 @@ export function AppSidebar({ user }: { user: SessionUser }) {
         )}
       >
         <Link
-          to="/agents"
+          to={getLastAppLocation()}
           className={cn(LINK_CLASS, "-mx-2.5 font-medium")}
-          onClick={(event) => {
-            event.preventDefault()
-            layout.closeOnMobile()
-            void navigate({ href: getLastAppLocation() })
-          }}
+          onClick={layout.closeOnMobile}
         >
           <IoArrowBackOutline className="size-4" />
           <span>Back to app</span>

--- a/ui/src/lib/appLocation.test.ts
+++ b/ui/src/lib/appLocation.test.ts
@@ -1,0 +1,28 @@
+/** @vitest-environment jsdom */
+
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { getLastAppLocation, rememberAppLocation } from "./appLocation"
+
+beforeEach(() => {
+  window.sessionStorage.clear()
+})
+
+describe("app location", () => {
+  it("restores the last thread location", () => {
+    rememberAppLocation("/agents/thread-1?view=diff#latest")
+
+    expect(getLastAppLocation()).toBe("/agents/thread-1?view=diff#latest")
+  })
+
+  it("ignores locations outside the app", () => {
+    rememberAppLocation("/agents/thread-1")
+    rememberAppLocation("/my-settings")
+
+    expect(getLastAppLocation()).toBe("/agents/thread-1")
+  })
+
+  it("defaults to the app home", () => {
+    expect(getLastAppLocation()).toBe("/agents")
+  })
+})

--- a/ui/src/lib/appLocation.ts
+++ b/ui/src/lib/appLocation.ts
@@ -1,0 +1,19 @@
+const STORAGE_KEY = "open-swe:last-app-location"
+const FALLBACK_LOCATION = "/agents"
+
+function isAppLocation(value: string): boolean {
+  return (
+    value === FALLBACK_LOCATION || value.startsWith(`${FALLBACK_LOCATION}/`)
+  )
+}
+
+export function rememberAppLocation(href: string): void {
+  if (typeof window === "undefined" || !isAppLocation(href)) return
+  window.sessionStorage.setItem(STORAGE_KEY, href)
+}
+
+export function getLastAppLocation(): string {
+  if (typeof window === "undefined") return FALLBACK_LOCATION
+  const href = window.sessionStorage.getItem(STORAGE_KEY)
+  return href && isAppLocation(href) ? href : FALLBACK_LOCATION
+}

--- a/ui/src/routes/agents.tsx
+++ b/ui/src/routes/agents.tsx
@@ -12,6 +12,7 @@ import { AgentStreamProvider } from "@/features/agents/lib/stream/AgentStreamPro
 import { RequireLogin } from "@/lib/auth-redirect"
 import { useSession } from "@/lib/session"
 import { isDesktopLocalModeEnabled } from "@/lib/desktop-local-mode"
+import { rememberAppLocation } from "@/lib/appLocation"
 
 export const Route = createFileRoute("/agents")({
   component: AgentsLayout,
@@ -45,14 +46,19 @@ function AgentsLayout() {
   })
   const activeThreadId = threadMatch?.params.threadId
   const activeLocalSessionId = localMatch?.params.sessionId
-  const pathname = useRouterState({
-    select: (state) => state.location.pathname,
+  const location = useRouterState({
+    select: (state) => state.location,
   })
+  const pathname = location.pathname
   const localOnly = !session.data && isDesktopLocalModeEnabled()
   const isLocalRoute =
     pathname === "/agents" ||
     pathname === "/agents/" ||
     Boolean(activeLocalSessionId)
+
+  useEffect(() => {
+    rememberAppLocation(location.href)
+  }, [location.href])
 
   if (session.isLoading) {
     return (


### PR DESCRIPTION
### Summary
- remember the most recent `/agents` location for the browser session
- make **Back to app** restore that thread instead of opening a blank composer
- cover the navigation with unit and browser regression tests

Made by [Open SWE](https://openswe.vercel.app/agents/b3cbec76-5343-5bb3-99f2-db4803610f39) · openai:gpt-5.6-sol (high)