### PR TITLE
feat(ui): link settings sections

### DIFF
--- a/ui/src/components/AppShell.test.tsx
+++ b/ui/src/components/AppShell.test.tsx
@@ -1,0 +1,39 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { SettingsSection } from "./AppShell"
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children }: { children: React.ReactNode }) => <a>{children}</a>,
+}))
+vi.mock("@/components/AppSidebar", () => ({ AppSidebar: () => null }))
+
+afterEach(() => {
+  cleanup()
+  window.history.replaceState(null, "", "/")
+  vi.restoreAllMocks()
+})
+
+describe("SettingsSection", () => {
+  it("links its heading and scrolls to an initial hash", () => {
+    window.history.replaceState(null, "", "/my-settings#pull-requests")
+    const scrollIntoView = vi.fn()
+    HTMLElement.prototype.scrollIntoView = scrollIntoView
+
+    render(
+      <SettingsSection title="Pull Requests">
+        <div>Settings</div>
+      </SettingsSection>
+    )
+
+    const heading = screen.getByRole("heading", { name: "Pull Requests" })
+    const section = heading.closest("section")
+    expect(section?.id).toBe("pull-requests")
+    expect(
+      screen.getByRole("link", { name: "Pull Requests" }).getAttribute("href")
+    ).toBe("#pull-requests")
+    expect(scrollIntoView).toHaveBeenCalledOnce()
+  })
+})

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -1,6 +1,10 @@
 import { Link } from "@tanstack/react-router"
-import { ArrowLeftIcon, CaretRightIcon } from "@phosphor-icons/react"
-import type { ReactNode } from "react"
+import {
+  ArrowLeftIcon,
+  CaretRightIcon,
+  LinkSimpleIcon,
+} from "@phosphor-icons/react"
+import { useEffect, type ReactNode } from "react"
 
 import type { SessionUser } from "@/lib/api"
 import { AppSidebar } from "@/components/AppSidebar"
@@ -64,6 +68,15 @@ interface SettingsSectionProps {
   description?: string
   action?: ReactNode
   children: ReactNode
+  id?: string
+}
+
+function sectionId(title: string): string {
+  return title
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "")
 }
 
 /** A titled group of rows rendered as a single card. */
@@ -72,12 +85,27 @@ export function SettingsSection({
   description,
   action,
   children,
+  id = sectionId(title),
 }: SettingsSectionProps) {
+  useEffect(() => {
+    if (window.location.hash === `#${id}`) {
+      document.getElementById(id)?.scrollIntoView()
+    }
+  }, [id])
+
   return (
-    <section className="space-y-3">
+    <section id={id} className="scroll-mt-4 space-y-3">
       <div className="flex items-start justify-between gap-4">
         <div>
-          <h2 className="text-sm font-medium text-foreground">{title}</h2>
+          <h2 className="text-sm font-medium text-foreground">
+            <a
+              href={`#${id}`}
+              className="group flex w-fit items-center gap-1.5"
+            >
+              {title}
+              <LinkSimpleIcon className="size-3.5 opacity-30 transition-opacity group-hover:opacity-60 group-focus-visible:opacity-60" />
+            </a>
+          </h2>
           {description && (
             <p className="mt-1 max-w-2xl text-xs text-muted-foreground">
               {description}


### PR DESCRIPTION
Settings section headings now expose stable hash links derived from their titles. Opening a settings page with a section hash scrolls the nested page container to that section after the authenticated content renders.

![Settings section hash links](https://01a08804-300c-7a70-aa59-fc98c79b41a0--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGc1T0Rrd01ERXNJbXAwYVNJNklqQXhZVEE0T0RCa0xXTm1NMk10TnpjNE5DMDVabVF4TFRsbE0ySXhNekZtWWpCak5DSXNJbk5wWkNJNklqQXhZVEE0T0RBMExUTXdNR010TjJFM01DMWhZVFU1TFdaak9UaGpOemxpTkRGaE1DSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMeTV2Y0dWdUxYTjNaUzloY25ScFptRmpkSE12YzJWMGRHbHVaM010YzJWamRHbHZiaTFvWVhOb0xXeHBibXR6TG5CdVp5SXNJbU4wSWpvaWFXMWhaMlU2Y0c1bklpd2lZMlFpT2lKcGJteHBibVVpZlEuN3hUUGVuNDFIcmdPSHpxb1RlWENFWGR6aWZKWmZZS1hscnlxQXFWV3d1SEFNV3JoZC1sNDVmSEkyc0pqLVF2WjRkUWVaX0ZISW1kQVBUN1NDWmFYRFE)

Made by [Open SWE](https://openswe.vercel.app/agents/75864376-8bf8-5887-b5db-d7f85843b769) · openai:gpt-5.6-sol (high)