### PR TITLE
fix: keep RunConfig.dump from raising on non-JSON extras

### DIFF
--- a/agent/run_config.py
+++ b/agent/run_config.py
@@ -42,6 +42,8 @@ def _reject_bool(value: Any) -> Any:
 
 Int = Annotated[int, BeforeValidator(_reject_bool)]
 
+_UNSERIALIZABLE = "__run_config_unserializable__"
+
 
 class Repo(BaseModel):
     """A GitHub repository as ``configurable["repo"]`` carries it."""
@@ -221,8 +223,15 @@ class RunConfig(BaseModel):
         return cls.from_config(get_config())
 
     def dump(self) -> dict[str, Any]:
-        """The JSON value to store, preserving exactly the keys that were set."""
-        return self.model_dump(mode="json", exclude_unset=True)
+        """The JSON value to store, preserving exactly the keys that were set.
+
+        LangGraph Platform puts a ``ProxyUser`` in ``langgraph_auth_user``, so an
+        extra can be any object; dropping it beats raising and losing the rest.
+        """
+        dumped = self.model_dump(
+            mode="json", exclude_unset=True, fallback=lambda _: _UNSERIALIZABLE
+        )
+        return {key: value for key, value in dumped.items() if value != _UNSERIALIZABLE}
 
     def get(self, key: str) -> Any:
         """Value for ``key``, whether it is a declared field or an extra."""

--- a/agent/run_config.py
+++ b/agent/run_config.py
@@ -27,6 +27,7 @@ from typing import Annotated, Any, Self
 
 from langgraph.config import get_config
 from pydantic import BaseModel, BeforeValidator, ConfigDict, ValidationError
+from pydantic_core import PydanticSerializationError, to_jsonable_python
 
 from agent.source_context import GitHubIssueRef, LinearIssueRef, SlackThreadRef
 
@@ -41,8 +42,6 @@ def _reject_bool(value: Any) -> Any:
 
 
 Int = Annotated[int, BeforeValidator(_reject_bool)]
-
-_UNSERIALIZABLE = "__run_config_unserializable__"
 
 
 class Repo(BaseModel):
@@ -228,10 +227,17 @@ class RunConfig(BaseModel):
         LangGraph Platform puts a ``ProxyUser`` in ``langgraph_auth_user``, so an
         extra can be any object; dropping it beats raising and losing the rest.
         """
-        dumped = self.model_dump(
-            mode="json", exclude_unset=True, fallback=lambda _: _UNSERIALIZABLE
-        )
-        return {key: value for key, value in dumped.items() if value != _UNSERIALIZABLE}
+        try:
+            return self.model_dump(mode="json", exclude_unset=True)
+        except PydanticSerializationError:
+            logger.warning("Dropping unserializable configurable keys", exc_info=True)
+        encoded: dict[str, Any] = {}
+        for key, value in self.model_dump(exclude_unset=True).items():
+            try:
+                encoded[key] = to_jsonable_python(value)
+            except PydanticSerializationError:
+                continue
+        return encoded
 
     def get(self, key: str) -> Any:
         """Value for ``key``, whether it is a declared field or an extra."""

--- a/tests/agent/test_run_config.py
+++ b/tests/agent/test_run_config.py
@@ -92,6 +92,16 @@ def test_dump_drops_extras_that_cannot_be_json_encoded():
         pass
 
     cfg = RunConfig.parse(
-        {"thread_id": "t1", "github_login": "octocat", "langgraph_auth_user": ProxyUser()}
+        {
+            "thread_id": "t1",
+            "github_login": "octocat",
+            "langgraph_auth_user": ProxyUser(),
+            "nested": {"user": ProxyUser()},
+            "custom": {"a": 1},
+        }
     )
-    assert cfg.dump() == {"thread_id": "t1", "github_login": "octocat"}
+    assert cfg.dump() == {
+        "thread_id": "t1",
+        "github_login": "octocat",
+        "custom": {"a": 1},
+    }

--- a/tests/agent/test_run_config.py
+++ b/tests/agent/test_run_config.py
@@ -85,3 +85,13 @@ def test_bools_are_not_accepted_as_integers():
 
 def test_numeric_strings_still_coerce_to_int():
     assert RunConfig.parse({"pr_number": "7"}).pr_number == 7
+
+
+def test_dump_drops_extras_that_cannot_be_json_encoded():
+    class ProxyUser:
+        pass
+
+    cfg = RunConfig.parse(
+        {"thread_id": "t1", "github_login": "octocat", "langgraph_auth_user": ProxyUser()}
+    )
+    assert cfg.dump() == {"thread_id": "t1", "github_login": "octocat"}


### PR DESCRIPTION
## What

`RunConfig.dump()` called `model_dump(mode="json", exclude_unset=True)`. `RunConfig` is `extra="allow"`, so any non-JSON value in `configurable` made that raise `PydanticSerializationError`.

LangGraph Platform injects `configurable["langgraph_auth_user"]` — a `langgraph_api.auth.custom.ProxyUser` — on authenticated runs, so on those threads `dump()` always raised:

```
Unable to serialize unknown type: langgraph_api.auth.custom.ProxyUser
```

## Impact

Four tools call `cfg.dump()` early, before doing any work, only to pluck a handful of keys back out:

- `agent/tools/recreate_sandbox.py` and `agent/tools/sandbox_reset.py` — both dump the whole configurable just to feed `resolve_github_login`, which reads `github_login` / `user_email`. Both sandbox rebind paths returned `success: false` on dashboard-triggered threads and never reached the provider.
- `agent/tools/manage_baby_sit.py` and `agent/tools/schedule_thread_wakeup.py` — same latent break.

Nothing in the repo reads `langgraph_auth_user`.

## Fix

`dump()` now passes a `fallback` and drops extras that cannot be JSON encoded, keeping the rest — matching the module contract that one malformed value must not cost the run its `thread_id`.