### PR TITLE
fix(desktop): keep the top strip draggable and the sidebar toggle clickable

### DIFF
--- a/desktop/src/preload.cts
+++ b/desktop/src/preload.cts
@@ -118,9 +118,6 @@ contextBridge.exposeInMainWorld("openSweDesktop", {
   },
 });
 
-const DRAG_REGION_ID = "open-swe-desktop-drag-region";
-const DRAG_REGION_HEIGHT = 44;
-
 ipcRenderer.on("desktop:fullscreen-change", (_event, fullscreen) => {
   document.documentElement.classList.toggle("desktop-fullscreen", fullscreen);
 });
@@ -130,19 +127,18 @@ window.addEventListener("DOMContentLoaded", () => {
 
   const style = document.createElement("style");
   style.textContent = `
-    #${DRAG_REGION_ID} {
+    [data-desktop-drag-strip] {
       -webkit-app-region: drag;
       pointer-events: none;
       position: fixed;
       top: 0;
       left: 118px;
       right: 0;
-      height: ${DRAG_REGION_HEIGHT}px;
-      z-index: 2147483647;
+      height: 44px;
       user-select: none;
     }
 
-    .desktop-fullscreen #${DRAG_REGION_ID} {
+    .desktop-fullscreen [data-desktop-drag-strip] {
       left: 0;
     }
 
@@ -168,9 +164,4 @@ window.addEventListener("DOMContentLoaded", () => {
     }
   `;
   document.head.append(style);
-
-  const dragRegion = document.createElement("div");
-  dragRegion.id = DRAG_REGION_ID;
-  dragRegion.setAttribute("aria-hidden", "true");
-  document.body.prepend(dragRegion);
 });

--- a/ui/src/components/sidebar-layout.tsx
+++ b/ui/src/components/sidebar-layout.tsx
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
 } from "react"
+import { createPortal } from "react-dom"
 import { SidebarSimpleIcon } from "@phosphor-icons/react"
 
 import { cn } from "@/lib/utils"
@@ -118,7 +119,10 @@ export function SidebarFrame({
     typeof window !== "undefined" && Boolean(window.openSweDesktop)
 
   if (collapsed) {
-    return (
+    // Electron resolves window drag regions in DOM order, ignoring z-index, so
+    // a page header marked draggable would swallow clicks on this floating
+    // toggle if it came earlier. Portal it after all content to keep it last.
+    return createPortal(
       <button
         type="button"
         aria-label="Expand sidebar"
@@ -130,7 +134,8 @@ export function SidebarFrame({
         )}
       >
         <SidebarSimpleIcon className="size-4" />
-      </button>
+      </button>,
+      document.body
     )
   }
 

--- a/ui/src/features/agents/components/AgentThreadHeader.tsx
+++ b/ui/src/features/agents/components/AgentThreadHeader.tsx
@@ -192,10 +192,7 @@ export function AgentThreadHeader({
   )
 
   const header = (
-    <header
-      data-desktop-drag-region=""
-      className="relative z-10 h-11 shrink-0 border-b border-border/60 bg-background/80 after:pointer-events-none after:absolute after:inset-x-0 after:top-full after:h-4 after:bg-linear-to-b after:from-background/60 after:to-transparent"
-    >
+    <header className="relative z-10 h-11 shrink-0 border-b border-border/60 bg-background/80 after:pointer-events-none after:absolute after:inset-x-0 after:top-full after:h-4 after:bg-linear-to-b after:from-background/60 after:to-transparent">
       <div
         className={cn(
           "flex h-full w-full items-center gap-3 px-4",

--- a/ui/src/features/agents/components/AgentThreadHeader.tsx
+++ b/ui/src/features/agents/components/AgentThreadHeader.tsx
@@ -192,7 +192,10 @@ export function AgentThreadHeader({
   )
 
   const header = (
-    <header className="relative z-10 h-11 shrink-0 border-b border-border/60 bg-background/80 after:pointer-events-none after:absolute after:inset-x-0 after:top-full after:h-4 after:bg-linear-to-b after:from-background/60 after:to-transparent">
+    <header
+      data-desktop-drag-region=""
+      className="relative z-10 h-11 shrink-0 border-b border-border/60 bg-background/80 after:pointer-events-none after:absolute after:inset-x-0 after:top-full after:h-4 after:bg-linear-to-b after:from-background/60 after:to-transparent"
+    >
       <div
         className={cn(
           "flex h-full w-full items-center gap-3 px-4",

--- a/ui/src/routes/__root.tsx
+++ b/ui/src/routes/__root.tsx
@@ -78,6 +78,13 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         <HeadContent />
       </head>
       <body>
+        {typeof window !== "undefined" &&
+          window.openSweDesktop && (
+            // Rendered first so later no-drag elements carve out of it; the
+            // desktop preload styles it. Preload-injected DOM would be cleared
+            // when React takes over the document, so it lives here instead.
+            <div aria-hidden data-desktop-drag-strip="" />
+          )}
         <ThemeSync />
         <QueryClientProvider client={queryClient}>
           <AppCommandProvider>{children ?? <Outlet />}</AppCommandProvider>


### PR DESCRIPTION
Two desktop window-drag problems on macOS, both rooted in how Electron builds the draggable region: it applies every `-webkit-app-region` rect in DOM order and ignores z-index, so the last rect containing a point wins.

**Collapsed sidebar toggle was unclickable on thread pages.** The fixed "Expand sidebar" button rendered before the thread header, whose draggable rect re-covered the button's `no-drag` rect. Following t3code, which renders its floating sidebar toggle after all page content, `SidebarFrame` now portals the collapsed toggle to `document.body` so it is always last. The header keeps its `data-desktop-drag-region`.

**Pages without a draggable header (e.g. the new thread page) were not draggable at all.** The preload prepended a fixed drag strip to `document.body` on `DOMContentLoaded`, but on desktop the UI does `createRoot(document)`, and React clears body children it does not own when it mounts. The strip never survived, so only headers marked draggable worked. The strip is now rendered as the first body child in `RootDocument` (`data-desktop-drag-strip`), with its styling still supplied by the preload.

Made by [Open SWE](https://openswe.vercel.app/agents/01a0880e-03a2-727c-bb54-b9befc22efc4) · openai:gpt-6-astra (low), taken over by hand.