### PR TITLE
feat(desktop): enable Datadog RUM in releases

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -127,8 +127,8 @@ jobs:
           VITE_DATADOG_CLIENT_TOKEN: ${{ secrets.VITE_DATADOG_CLIENT_TOKEN }}
           VITE_DATADOG_SERVICE: open-swe-desktop
           VITE_DATADOG_VERSION: ${{ steps.release.outputs.version }}
-          VITE_DATADOG_SESSION_SAMPLE_RATE: "20"
-          VITE_DATADOG_SESSION_REPLAY_SAMPLE_RATE: "0"
+          VITE_DATADOG_SESSION_SAMPLE_RATE: "100"
+          VITE_DATADOG_SESSION_REPLAY_SAMPLE_RATE: "20"
         run: |
           pnpm run build
           pnpm --filter open-swe-desktop run build:local-backend

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -127,6 +127,7 @@ jobs:
           VITE_DATADOG_CLIENT_TOKEN: ${{ secrets.VITE_DATADOG_CLIENT_TOKEN }}
           VITE_DATADOG_SERVICE: open-swe-desktop
           VITE_DATADOG_VERSION: ${{ steps.release.outputs.version }}
+          VITE_DATADOG_SESSION_SAMPLE_RATE: "20"
           VITE_DATADOG_SESSION_REPLAY_SAMPLE_RATE: "0"
         run: |
           pnpm run build

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -123,6 +123,11 @@ jobs:
           APPLE_API_KEY: ${{ env.APPLE_API_KEY_PATH }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          VITE_DATADOG_APPLICATION_ID: ${{ secrets.VITE_DATADOG_APPLICATION_ID }}
+          VITE_DATADOG_CLIENT_TOKEN: ${{ secrets.VITE_DATADOG_CLIENT_TOKEN }}
+          VITE_DATADOG_SERVICE: open-swe-desktop
+          VITE_DATADOG_VERSION: ${{ steps.release.outputs.version }}
+          VITE_DATADOG_SESSION_REPLAY_SAMPLE_RATE: "0"
         run: |
           pnpm run build
           pnpm --filter open-swe-desktop run build:local-backend


### PR DESCRIPTION
Inject the existing Datadog RUM configuration into desktop release builds, including the release version and desktop service name. Capture ordinary RUM for all sessions and Session Replay for 20%.

Requires the `VITE_DATADOG_APPLICATION_ID` and `VITE_DATADOG_CLIENT_TOKEN` Actions secrets.

Made by [Open SWE](https://openswe.vercel.app/agents/22ee5a9c-daeb-5a0a-ab38-fc9bbfcdd967) · openai:gpt-5.6-sol (medium)