### PR TITLE
feat(admin): control model availability

### DIFF
--- a/agent/analyzer.py
+++ b/agent/analyzer.py
@@ -31,7 +31,11 @@ from langchain.agents.middleware import ModelCallLimitMiddleware
 from langchain.agents.middleware.types import AgentMiddleware
 from langchain_core.language_models import BaseChatModel
 
-from agent.dashboard.team_settings import get_effective_gateway_enabled
+from agent.dashboard.team_settings import (
+    gate_model_availability,
+    get_effective_gateway_enabled,
+    get_team_allowed_models,
+)
 from agent.github.app import get_github_app_installation_token
 from agent.middleware import (
     BasePrepareRunMiddleware,
@@ -172,11 +176,15 @@ async def get_analyzer(config: RunnableConfig) -> Pregel:
     default_backend = get_cached_sandbox_backend(thread_id, reconnect=reconnect_backend)
     backend = CompositeBackend(default=default_backend, routes={SKILLS_ROUTE: StateBackend()})
 
-    model_id = DEFAULT_LLM_MODEL_ID
+    model_id, effort = gate_model_availability(
+        DEFAULT_LLM_MODEL_ID,
+        None,
+        allowed_models=await get_team_allowed_models(),
+    )
     use_gateway = await _cached_gateway_enabled()
     model_kwargs = provider_model_kwargs(
         model_id,
-        None,
+        effort,
         max_tokens=DEFAULT_LLM_MAX_TOKENS,
         openai_reasoning_default=DEFAULT_LLM_REASONING,
     )

--- a/agent/chat.py
+++ b/agent/chat.py
@@ -39,7 +39,9 @@ from agent.dashboard.options import (
     model_supports_effort,
 )
 from agent.dashboard.team_settings import (
+    gate_model_availability,
     get_effective_gateway_enabled,
+    get_team_allowed_models,
     get_team_default_model,
     get_team_fable_enabled,
 )
@@ -218,6 +220,9 @@ async def get_chat_agent(config: RunnableConfig) -> Pregel:
     model_id, effort = await _resolve_chat_model(cfg)
     model_id, effort = gate_fable_model(
         model_id, effort, fable_enabled=await get_team_fable_enabled()
+    )
+    model_id, effort = gate_model_availability(
+        model_id, effort, allowed_models=await get_team_allowed_models()
     )
     use_gateway = await _cached_gateway_enabled()
     model_kwargs = provider_model_kwargs(

--- a/agent/dashboard/options.py
+++ b/agent/dashboard/options.py
@@ -1,6 +1,6 @@
 """Supported models and reasoning efforts surfaced in the profile editor."""
 
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Collection, Mapping, Sequence
 from functools import cache, lru_cache
 from importlib import import_module
 from typing import NotRequired, TypedDict, cast
@@ -16,7 +16,16 @@ class ModelOption(TypedDict):
     supports_images: bool
     can_be_default: NotRequired[bool]
     context_window: NotRequired[int | None]
+    family: NotRequired[str]
+    family_label: NotRequired[str]
 
+
+MODEL_FAMILIES: dict[str, str] = {
+    "anthropic": "Anthropic",
+    "openai": "OpenAI",
+    "google_genai": "Google Gemini",
+    "fireworks": "Fireworks",
+}
 
 SUPPORTED_MODELS: list[ModelOption] = [
     {
@@ -117,6 +126,7 @@ SUPPORTED_MODELS: list[ModelOption] = [
 ]
 
 SUPPORTED_MODEL_IDS: frozenset[str] = frozenset(m["id"] for m in SUPPORTED_MODELS)
+SUPPORTED_MODEL_FAMILIES: frozenset[str] = frozenset(MODEL_FAMILIES)
 
 FABLE_MODEL_IDS: frozenset[str] = frozenset(
     m["id"] for m in SUPPORTED_MODELS if m["id"].startswith("anthropic:claude-fable")
@@ -207,15 +217,28 @@ def model_profile_context_window(model_id: str) -> int | None:
     return _PROFILE_CONTEXT_WINDOW_FALLBACKS.get(model_id)
 
 
+def model_family(model_id: str) -> str:
+    return model_id.partition(":")[0]
+
+
+def model_is_allowed(model_id: str, allowed_models: Collection[str] | None) -> bool:
+    if allowed_models is None:
+        return True
+    return model_id in allowed_models or f"{model_family(model_id)}:*" in allowed_models
+
+
 def models_with_profile_context_windows(models: Sequence[ModelOption]) -> list[ModelOption]:
     enriched: list[ModelOption] = []
     for model in models:
+        family = model_family(model["id"])
         option: ModelOption = {
             "id": model["id"],
             "label": model["label"],
             "efforts": model["efforts"],
             "default_effort": model["default_effort"],
             "supports_images": model["supports_images"],
+            "family": family,
+            "family_label": MODEL_FAMILIES.get(family, family),
         }
         if "can_be_default" in model:
             option["can_be_default"] = model["can_be_default"]
@@ -363,16 +386,18 @@ def default_model_pair() -> tuple[str, str]:
     raise ValueError(f"Unsupported default LLM_MODEL_ID: {model_id!r}")
 
 
-def default_vision_model_pair() -> tuple[str, str]:
-    """Default OpenAI/Anthropic model pair to use when image input is required."""
+def default_vision_model_pair(
+    allowed_models: list[str] | None = None,
+) -> tuple[str, str]:
+    """Default allowed model pair to use when image input is required."""
     if (
         DEFAULT_MODEL_ID in SUPPORTED_MODEL_IDS
         and model_supports_images(DEFAULT_MODEL_ID)
         and model_supports_effort(DEFAULT_MODEL_ID, DEFAULT_MODEL_EFFORT)
-        and DEFAULT_MODEL_ID.startswith(("openai:", "anthropic:"))
+        and model_is_allowed(DEFAULT_MODEL_ID, allowed_models)
     ):
         return DEFAULT_MODEL_ID, DEFAULT_MODEL_EFFORT
     for model in SUPPORTED_MODELS:
-        if model["id"].startswith(("openai:", "anthropic:")) and model["supports_images"]:
+        if model["supports_images"] and model_is_allowed(model["id"], allowed_models):
             return model["id"], model["default_effort"]
-    return default_model_pair()
+    raise ValueError("model allowlist has no image-capable model")

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -85,6 +85,7 @@ from agent.dashboard.options import (
     FABLE_MODEL_IDS,
     SUPPORTED_MODELS,
     gate_fable_model,
+    model_is_allowed,
     models_with_profile_context_windows,
 )
 from agent.dashboard.profiles import (
@@ -162,6 +163,7 @@ from agent.dashboard.team_credentials import (
 from agent.dashboard.team_settings import (
     TeamSettingsUpdate,
     TranscriptionSettingsUpdate,
+    get_team_allowed_models,
     get_team_default_model,
     get_team_default_subagent_model,
     get_team_fable_enabled,
@@ -638,25 +640,32 @@ async def api_delete_my_instructions(
 
 @router.get("/options")
 async def options() -> dict[str, Any]:
-    agent_model, agent_effort = await get_team_default_model("agent")
-    subagent_model, subagent_effort = await get_team_default_subagent_model("agent")
-    fable_enabled = await get_team_fable_enabled()
-    # Never advertise a default that isn't in the selectable list: when Fable is
-    # off, gate a stale Fable default down to its non-Fable fallback so the Cloud
-    # Agents page (and the PUT /profile it drives) don't choke on it.
+    (
+        (agent_model, agent_effort),
+        (subagent_model, subagent_effort),
+        fable_enabled,
+        allowed_models,
+    ) = await asyncio.gather(
+        get_team_default_model("agent"),
+        get_team_default_subagent_model("agent"),
+        get_team_fable_enabled(),
+        get_team_allowed_models(),
+    )
     agent_model, agent_effort = gate_fable_model(
         agent_model, agent_effort, fable_enabled=fable_enabled
     )
     subagent_model, subagent_effort = gate_fable_model(
         subagent_model, subagent_effort, fable_enabled=fable_enabled
     )
-    models = (
-        SUPPORTED_MODELS
-        if fable_enabled
-        else [m for m in SUPPORTED_MODELS if m["id"] not in FABLE_MODEL_IDS]
-    )
+    models = [
+        model
+        for model in SUPPORTED_MODELS
+        if (fable_enabled or model["id"] not in FABLE_MODEL_IDS)
+        and model_is_allowed(model["id"], allowed_models)
+    ]
     return {
         "models": models_with_profile_context_windows(models),
+        "model_catalog": models_with_profile_context_windows(SUPPORTED_MODELS),
         "default_agent_model": agent_model,
         "default_agent_reasoning_effort": agent_effort,
         "default_agent_subagent_model": subagent_model,

--- a/agent/dashboard/schedules.py
+++ b/agent/dashboard/schedules.py
@@ -13,7 +13,11 @@ from agent.dashboard.admin import is_admin
 from agent.dashboard.options import gate_fable_model, normalize_model_choice
 from agent.dashboard.profiles import get_profile, get_valid_access_token
 from agent.dashboard.repo_access import repo_config_for_user, require_repo_access_for_user
-from agent.dashboard.team_settings import get_team_fable_enabled
+from agent.dashboard.team_settings import (
+    gate_model_availability,
+    get_team_allowed_models,
+    get_team_fable_enabled,
+)
 from agent.dashboard.threads.access import agent_version_metadata, resolve_run_email
 from agent.dashboard.user_mappings import slack_id_for_login
 from agent.dispatch import create_durable_run
@@ -544,6 +548,9 @@ async def _agent_run_config(
     if model and effort:
         model, effort = gate_fable_model(
             model, effort, fable_enabled=await get_team_fable_enabled()
+        )
+        model, effort = gate_model_availability(
+            model, effort, allowed_models=await get_team_allowed_models()
         )
         configurable["agent_model_id"] = model
         configurable["agent_effort"] = effort

--- a/agent/dashboard/team_settings.py
+++ b/agent/dashboard/team_settings.py
@@ -16,14 +16,18 @@ from agent.dashboard.options import (
     DEPRECATED_MODEL_IDS,
     FABLE_MODEL_IDS,
     NON_DEFAULT_MODEL_IDS,
+    SUPPORTED_MODEL_FAMILIES,
     SUPPORTED_MODEL_IDS,
+    SUPPORTED_MODELS,
     canonical_model_pair,
     default_model_pair,
     gate_fable_model,
+    model_is_allowed,
     model_supports_effort,
     provider_fallback_pair,
 )
 from agent.store import get_value, now_iso, put_value
+from agent.utils import ttl_cache
 from agent.utils.gateway import gateway_overrides, resolve_gateway_enabled
 
 logger = logging.getLogger(__name__)
@@ -65,6 +69,7 @@ class TeamSettingsUpdate(TranscriptionSettingsUpdate):
     gateway_enabled: bool | None = None
     transcription_model: str = DEFAULT_TRANSCRIPTION_MODEL
     fable_enabled: bool = False
+    allowed_models: list[str] | None = None
     review_tracing_project: str | None = None
     org_guidelines: str | None = None
     default_agent_model: str | None = None
@@ -88,6 +93,23 @@ class TeamSettingsUpdate(TranscriptionSettingsUpdate):
     default_chat_reasoning_effort: str | None = None
     default_thread_title_model: str | None = None
     default_thread_title_reasoning_effort: str | None = None
+
+    @field_validator("allowed_models")
+    @classmethod
+    def _validate_allowed_models(cls, value: list[str] | None) -> list[str] | None:
+        if value is None:
+            return None
+        allowed = SUPPORTED_MODEL_IDS | {f"{family}:*" for family in SUPPORTED_MODEL_FAMILIES}
+        invalid = set(value) - allowed
+        if invalid:
+            raise ValueError(f"unsupported allowed models: {', '.join(sorted(invalid))}")
+        normalized = list(dict.fromkeys(value))
+        if not any(
+            option.get("can_be_default", True) and model_is_allowed(option["id"], normalized)
+            for option in SUPPORTED_MODELS
+        ):
+            raise ValueError("allowed_models must include a default-capable model")
+        return normalized
 
     @field_validator("org_guidelines", mode="before")
     @classmethod
@@ -326,6 +348,7 @@ def _default_settings() -> dict[str, Any]:
         "gateway_enabled": None,
         "transcription_model": DEFAULT_TRANSCRIPTION_MODEL,
         "fable_enabled": False,
+        "allowed_models": None,
         "review_tracing_project": None,
         "org_guidelines": None,
         "default_agent_model": fallback_model,
@@ -394,6 +417,7 @@ async def upsert_team_settings(update: TeamSettingsUpdate) -> dict[str, Any]:
         "gateway_enabled": update.gateway_enabled,
         "transcription_model": update.transcription_model,
         "fable_enabled": update.fable_enabled,
+        "allowed_models": update.allowed_models,
         "review_tracing_project": update.review_tracing_project,
         "org_guidelines": update.org_guidelines,
         "default_agent_model": update.default_agent_model,
@@ -420,6 +444,16 @@ async def upsert_team_settings(update: TeamSettingsUpdate) -> dict[str, Any]:
         "updated_at": now_iso(),
     }
     await put_value(TEAM_SETTINGS_NAMESPACE, TEAM_SETTINGS_KEY, value)
+    for key in (
+        "team-default-model-pair:agent",
+        "team-default-model-pair:reviewer",
+        "team-default-model:chat",
+        "team:agent-routing-models",
+        "team:thread-title-model",
+        "team:fable-enabled",
+        "team:allowed-models",
+    ):
+        ttl_cache.invalidate(key)
     return value
 
 
@@ -452,7 +486,7 @@ async def get_team_default_model(
             and model in SUPPORTED_MODEL_IDS
             and model_supports_effort(model, effort)
         ):
-            return _resolve_default_pair(model, effort)
+            return _resolve_default_pair(model, effort, settings.get("allowed_models"))
         # Inherit the Agent default when no chat-specific model is configured.
         model = settings.get("default_agent_model")
         effort = settings.get("default_agent_reasoning_effort")
@@ -462,7 +496,7 @@ async def get_team_default_model(
     else:
         model = settings.get("default_reviewer_model")
         effort = settings.get("default_reviewer_reasoning_effort")
-    return _resolve_default_pair(model, effort)
+    return _resolve_default_pair(model, effort, settings.get("allowed_models"))
 
 
 async def get_team_default_model_pair(
@@ -474,19 +508,23 @@ async def get_team_default_model_pair(
         main = _resolve_default_pair(
             settings.get("default_agent_model"),
             settings.get("default_agent_reasoning_effort"),
+            settings.get("allowed_models"),
         )
         subagent = _resolve_default_pair(
             settings.get("default_agent_subagent_model"),
             settings.get("default_agent_subagent_reasoning_effort"),
+            settings.get("allowed_models"),
         )
     else:
         main = _resolve_default_pair(
             settings.get("default_reviewer_model"),
             settings.get("default_reviewer_reasoning_effort"),
+            settings.get("allowed_models"),
         )
         subagent = _resolve_default_pair(
             settings.get("default_reviewer_subagent_model"),
             settings.get("default_reviewer_subagent_reasoning_effort"),
+            settings.get("allowed_models"),
         )
     return main, subagent
 
@@ -497,6 +535,7 @@ async def get_team_agent_routing_models() -> dict[str, tuple[str, str]]:
         tier: _resolve_default_pair(
             settings.get(f"default_agent_routing_{tier}_model"),
             settings.get(f"default_agent_routing_{tier}_reasoning_effort"),
+            settings.get("allowed_models"),
         )
         for tier in ("fast", "balanced", "performance")
     }
@@ -521,10 +560,11 @@ async def get_team_default_grouping_model() -> tuple[str, str]:
         and model not in NON_DEFAULT_MODEL_IDS
         and model_supports_effort(model, effort)
     ):
-        return _resolve_default_pair(model, effort)
+        return _resolve_default_pair(model, effort, settings.get("allowed_models"))
     return _resolve_default_pair(
         settings.get("default_reviewer_subagent_model"),
         settings.get("default_reviewer_subagent_reasoning_effort"),
+        settings.get("allowed_models"),
     )
 
 
@@ -561,9 +601,13 @@ async def get_team_default_thread_title_model() -> tuple[str, str]:
         and model not in NON_DEFAULT_MODEL_IDS
         and model_supports_effort(model, effort)
     ):
-        pair = _resolve_default_pair(model, effort)
+        pair = _resolve_default_pair(model, effort, settings.get("allowed_models"))
     else:
-        pair = DEFAULT_THREAD_TITLE_MODEL, DEFAULT_THREAD_TITLE_REASONING_EFFORT
+        pair = _resolve_default_pair(
+            DEFAULT_THREAD_TITLE_MODEL,
+            DEFAULT_THREAD_TITLE_REASONING_EFFORT,
+            settings.get("allowed_models"),
+        )
     return _gate_openai_title_model(
         pair, gateway_enabled=resolve_gateway_enabled(settings.get("gateway_enabled"))
     )
@@ -607,6 +651,20 @@ async def get_team_fable_enabled() -> bool:
     return bool(value) if isinstance(value, bool) else False
 
 
+async def get_team_allowed_models() -> list[str] | None:
+    record = await get_value(TEAM_SETTINGS_NAMESPACE, TEAM_SETTINGS_KEY)
+    if record is None or record.get("allowed_models") is None:
+        return None
+    value = record["allowed_models"]
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError("stored allowed_models must be a list of strings")
+    allowed = SUPPORTED_MODEL_IDS | {f"{family}:*" for family in SUPPORTED_MODEL_FAMILIES}
+    invalid = set(value) - allowed
+    if invalid:
+        raise ValueError(f"stored allowed_models contains unsupported entries: {invalid}")
+    return value
+
+
 async def get_effective_gateway_enabled() -> bool:
     """Resolve whether LLM Gateway routing is on: team setting, else env default."""
     return resolve_gateway_enabled(await get_team_gateway_enabled())
@@ -641,20 +699,44 @@ async def get_team_default_subagent_model(
     else:
         model = settings.get("default_reviewer_subagent_model")
         effort = settings.get("default_reviewer_subagent_reasoning_effort")
-    return _resolve_default_pair(model, effort)
+    return _resolve_default_pair(model, effort, settings.get("allowed_models"))
 
 
-def _resolve_default_pair(model: object, effort: object) -> tuple[str, str]:
-    """Supported pair if valid, else same-provider fallback, else global default."""
+def _resolve_default_pair(
+    model: object,
+    effort: object,
+    allowed_models: list[str] | None = None,
+) -> tuple[str, str]:
     if (
         isinstance(model, str)
         and isinstance(effort, str)
         and model in SUPPORTED_MODEL_IDS
         and model not in NON_DEFAULT_MODEL_IDS
         and model_supports_effort(model, effort)
+        and model_is_allowed(model, allowed_models)
     ):
         return model, effort
     provider_pair = provider_fallback_pair(model, effort)
-    if provider_pair is not None:
+    if provider_pair is not None and model_is_allowed(provider_pair[0], allowed_models):
         return provider_pair
-    return default_model_pair()
+    fallback = default_model_pair()
+    if model_is_allowed(fallback[0], allowed_models):
+        return fallback
+    for option in SUPPORTED_MODELS:
+        if option.get("can_be_default", True) and model_is_allowed(option["id"], allowed_models):
+            fallback_effort = effort if isinstance(effort, str) else None
+            if fallback_effort not in option["efforts"]:
+                fallback_effort = option["default_effort"]
+            return option["id"], fallback_effort
+    raise ValueError("models.allowed permits no default-capable models")
+
+
+def gate_model_availability(
+    model: str,
+    effort: str | None,
+    *,
+    allowed_models: list[str] | None,
+) -> tuple[str, str]:
+    if model_is_allowed(model, allowed_models) and isinstance(effort, str):
+        return model, effort
+    return _resolve_default_pair(model, effort, allowed_models)

--- a/agent/dashboard/threads/runs.py
+++ b/agent/dashboard/threads/runs.py
@@ -22,7 +22,12 @@ from agent.dashboard.options import (
     normalize_model_choice,
 )
 from agent.dashboard.profiles import get_profile
-from agent.dashboard.team_settings import get_team_default_model, get_team_fable_enabled
+from agent.dashboard.team_settings import (
+    gate_model_availability,
+    get_team_allowed_models,
+    get_team_default_model,
+    get_team_fable_enabled,
+)
 from agent.dashboard.threads.access import (
     _ensure_dashboard_github_token,
     agent_version_metadata,
@@ -120,15 +125,23 @@ async def _resolve_agent_model_choice(
     resolved_model, resolved_effort = gate_fable_model(
         resolved_model, resolved_effort, fable_enabled=await get_team_fable_enabled()
     )
+    resolved_model, resolved_effort = gate_model_availability(
+        resolved_model, resolved_effort, allowed_models=await get_team_allowed_models()
+    )
     if not isinstance(resolved_effort, str):
         raise ValueError("team default model must include a reasoning effort")
     return resolved_model, resolved_effort
 
 
-def _with_vision_fallback(model_id: str, effort: str, *, has_images: bool) -> tuple[str, str]:
+async def _with_vision_fallback(model_id: str, effort: str, *, has_images: bool) -> tuple[str, str]:
     if not has_images or model_supports_images(model_id):
         return model_id, effort
-    fallback_model_id, fallback_effort = default_vision_model_pair()
+    try:
+        fallback_model_id, fallback_effort = default_vision_model_pair(
+            await get_team_allowed_models()
+        )
+    except ValueError as exc:
+        raise HTTPException(422, "no enabled model supports image input") from exc
     logger.info(
         "Using vision fallback model %s for dashboard image input; configured model %s "
         "does not support images",
@@ -222,7 +235,7 @@ async def _create_dashboard_thread_record(
     now_ms = _now_ms()
     prompt = prompt.strip()
     resolved_model, resolved_effort = await _resolve_agent_model_choice(profile, model_id, effort)
-    resolved_model, resolved_effort = _with_vision_fallback(
+    resolved_model, resolved_effort = await _with_vision_fallback(
         resolved_model,
         resolved_effort,
         has_images=bool(images),
@@ -490,7 +503,9 @@ async def _enrich_run_start_command(
                     run_effort = value
                     break
         if command_images and run_model and run_effort:
-            run_model, run_effort = _with_vision_fallback(run_model, run_effort, has_images=True)
+            run_model, run_effort = await _with_vision_fallback(
+                run_model, run_effort, has_images=True
+            )
         _validate_command_images(content, model_id=run_model)
 
     if content is None:

--- a/agent/linear/webhook.py
+++ b/agent/linear/webhook.py
@@ -7,6 +7,7 @@ object (``common.X``) so tests that monkeypatch them keep working.
 from typing import Any, cast
 
 import httpx2
+from fastapi import HTTPException
 from langchain_core.messages.content import create_text_block
 
 from agent.input_messages import (
@@ -197,7 +198,12 @@ async def process_linear_issue(  # noqa: PLR0912, PLR0915
         image_urls = common.dedupe_urls(image_urls)
         resolved_model_id = await common.resolve_agent_model_id(mapped_login)
         if not common.model_supports_images(resolved_model_id):
-            fallback_model_id, fallback_effort = common.default_vision_model_pair()
+            try:
+                fallback_model_id, fallback_effort = common.default_vision_model_pair(
+                    await common.get_team_allowed_models()
+                )
+            except ValueError as exc:
+                raise HTTPException(422, "no enabled model supports image input") from exc
             common.logger.info(
                 "Using vision fallback model %s for %d Linear image(s); configured model %s "
                 "does not support images",

--- a/agent/reviewer.py
+++ b/agent/reviewer.py
@@ -41,8 +41,10 @@ from langchain_core.language_models.chat_models import BaseChatModel
 
 from agent.dashboard.options import gate_fable_model
 from agent.dashboard.team_settings import (
+    gate_model_availability,
     get_effective_gateway_enabled,
     get_org_review_guidelines,
+    get_team_allowed_models,
     get_team_default_grouping_model,
     get_team_default_model_pair,
     get_team_fable_enabled,
@@ -880,6 +882,9 @@ async def _resolve_grouping_model(cfg: RunConfig, *, use_gateway: bool) -> BaseC
     model_id, effort = gate_fable_model(
         model_id, effort, fable_enabled=await get_team_fable_enabled()
     )
+    model_id, effort = gate_model_availability(
+        model_id, effort, allowed_models=await get_team_allowed_models()
+    )
     model_kwargs = provider_model_kwargs(
         model_id,
         effort,
@@ -1336,6 +1341,13 @@ async def get_reviewer_agent(config: RunnableConfig) -> Pregel:
     )
     subagent_model_id, subagent_effort = gate_fable_model(
         subagent_model_id, subagent_effort, fable_enabled=fable_enabled
+    )
+    allowed_models = await get_team_allowed_models()
+    model_id, reasoning_effort = gate_model_availability(
+        model_id, reasoning_effort, allowed_models=allowed_models
+    )
+    subagent_model_id, subagent_effort = gate_model_availability(
+        subagent_model_id, subagent_effort, allowed_models=allowed_models
     )
     model_kwargs = provider_model_kwargs(
         model_id,

--- a/agent/server.py
+++ b/agent/server.py
@@ -62,12 +62,15 @@ from agent.dashboard.options import (
     SUPPORTED_MODEL_IDS,
     canonical_model_pair,
     gate_fable_model,
+    model_is_allowed,
     model_supports_effort,
 )
 from agent.dashboard.skills import ORGANIZATION_SKILLS_NAMESPACE, SKILLS_NAMESPACE
 from agent.dashboard.team_settings import (
+    gate_model_availability,
     get_effective_gateway_enabled,
     get_team_agent_routing_models,
+    get_team_allowed_models,
     get_team_default_model_pair,
     get_team_default_repo,
     get_team_default_thread_title_model,
@@ -985,6 +988,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         use_gateway = gateway_env_default()
         profile = None
         fable_enabled = False
+        allowed_models = None
     else:
         async with aphase(thread_id, "factory.settings_defaults"):
             (
@@ -994,6 +998,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                 use_gateway,
                 profile,
                 fable_enabled,
+                allowed_models,
             ) = await asyncio.gather(
                 _cached_team_default_model_pair("agent"),
                 _cached_agent_routing_models(),
@@ -1001,6 +1006,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                 _cached_gateway_enabled(),
                 _cached_profile(None if thread_settings.get("model_id") else profile_login),
                 _cached_fable_enabled(),
+                get_team_allowed_models(),
             )
 
     linear_issue = as_json_object(cfg.linear_issue.model_dump() if cfg.linear_issue else None)
@@ -1111,6 +1117,15 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     title_model_id, title_effort = gate_fable_model(
         title_model_id, title_effort, fable_enabled=fable_enabled
     )
+    model_id, profile_effort = gate_model_availability(
+        model_id, profile_effort, allowed_models=allowed_models
+    )
+    subagent_model_id, subagent_effort = gate_model_availability(
+        subagent_model_id, subagent_effort, allowed_models=allowed_models
+    )
+    title_model_id, title_effort = gate_model_availability(
+        title_model_id, title_effort, allowed_models=allowed_models
+    )
 
     model_kwargs = provider_model_kwargs(
         model_id,
@@ -1130,7 +1145,11 @@ async def get_agent(config: RunnableConfig) -> Pregel:
 
     fallback_model_id = ENV.LLM_FALLBACK_MODEL_ID.optional() or fallback_model_id_for(model_id)
     fallback_middleware: list[Any] = []
-    if fallback_model_id and fallback_model_id != model_id:
+    if (
+        fallback_model_id
+        and fallback_model_id != model_id
+        and model_is_allowed(fallback_model_id, allowed_models)
+    ):
         fallback_kwargs: ModelKwargs = {"max_tokens": DEFAULT_LLM_MAX_TOKENS}
         if fallback_model_id.startswith("openai:"):
             fallback_kwargs["reasoning"] = DEFAULT_LLM_REASONING
@@ -1304,8 +1323,12 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     main_model = _make_model_or_defer(model_id, use_gateway=use_gateway, **model_kwargs)
     model_selection_middleware: list[Any] = []
     if adaptive_model_routing:
-        routing_models = {
-            route: _make_model_or_defer(
+        routing_models = {}
+        for route, (routed_model_id, effort) in routing_defaults.items():
+            routed_model_id, effort = gate_model_availability(
+                routed_model_id, effort, allowed_models=allowed_models
+            )
+            routing_models[route] = _make_model_or_defer(
                 routed_model_id,
                 use_gateway=use_gateway,
                 **provider_model_kwargs(
@@ -1314,8 +1337,6 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                     max_tokens=DEFAULT_LLM_MAX_TOKENS,
                 ),
             )
-            for route, (routed_model_id, effort) in routing_defaults.items()
-        }
         model_selection_middleware.append(
             ModelSelectionMiddleware(
                 routing_models,

--- a/agent/slack/webhook.py
+++ b/agent/slack/webhook.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 from typing import Any, cast
 
 import httpx2
+from fastapi import HTTPException
 from langchain_core.messages.content import create_text_block
 
 from agent.dashboard.environments import ENVIRONMENTS, parse_environment_tag
@@ -724,7 +725,12 @@ async def _process_slack_mention_impl(request: SlackRequest, repo: Repo | None) 
     if image_urls:
         resolved_model_id = await common.resolve_agent_model_id(mapped_login)
         if not common.model_supports_images(resolved_model_id):
-            fallback_model_id, fallback_effort = common.default_vision_model_pair()
+            try:
+                fallback_model_id, fallback_effort = common.default_vision_model_pair(
+                    await common.get_team_allowed_models()
+                )
+            except ValueError as exc:
+                raise HTTPException(422, "no enabled model supports image input") from exc
             common.logger.info(
                 "Using vision fallback model %s for %d Slack image(s); configured model %s "
                 "does not support images",

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -30,6 +30,7 @@ from agent.dashboard.profiles import (  # noqa: F401
     has_access_token_record,
 )
 from agent.dashboard.team_settings import (
+    get_team_allowed_models,  # noqa: F401
     get_team_default_repo,
     get_team_settings,
 )
@@ -250,6 +251,7 @@ __all__ = [
     "get_slack_repo_config",
     "get_slack_user_info",
     "get_slack_user_names",
+    "get_team_allowed_models",
     "get_team_default_repo",
     "get_valid_access_token",
     "has_access_token_record",

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -2513,6 +2513,11 @@ async def test_options_omits_fable_when_disabled() -> None:
             return_value=False,
         ),
         patch(
+            "agent.dashboard.routes.get_team_allowed_models",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
             "agent.dashboard.routes.get_team_default_model",
             new_callable=AsyncMock,
             return_value=_PAIR,
@@ -2528,12 +2533,48 @@ async def test_options_omits_fable_when_disabled() -> None:
 
 
 @pytest.mark.asyncio
+async def test_options_applies_model_allowlist_and_returns_unfiltered_catalog() -> None:
+    with (
+        patch(
+            "agent.dashboard.routes.get_team_fable_enabled",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "agent.dashboard.routes.get_team_allowed_models",
+            new_callable=AsyncMock,
+            return_value=["openai:*"],
+        ),
+        patch(
+            "agent.dashboard.routes.get_team_default_model",
+            new_callable=AsyncMock,
+            return_value=_PAIR,
+        ),
+        patch(
+            "agent.dashboard.routes.get_team_default_subagent_model",
+            new_callable=AsyncMock,
+            return_value=_PAIR,
+        ),
+    ):
+        payload = await routes.options()
+
+    assert payload["models"]
+    assert all(model["family"] == "openai" for model in payload["models"])
+    assert {model["family"] for model in payload["model_catalog"]} > {"openai"}
+
+
+@pytest.mark.asyncio
 async def test_options_includes_fable_when_enabled() -> None:
     with (
         patch(
             "agent.dashboard.routes.get_team_fable_enabled",
             new_callable=AsyncMock,
             return_value=True,
+        ),
+        patch(
+            "agent.dashboard.routes.get_team_allowed_models",
+            new_callable=AsyncMock,
+            return_value=None,
         ),
         patch(
             "agent.dashboard.routes.get_team_default_model",
@@ -2563,6 +2604,11 @@ async def test_options_gates_stale_fable_default_when_disabled() -> None:
             "agent.dashboard.routes.get_team_fable_enabled",
             new_callable=AsyncMock,
             return_value=False,
+        ),
+        patch(
+            "agent.dashboard.routes.get_team_allowed_models",
+            new_callable=AsyncMock,
+            return_value=None,
         ),
         patch(
             "agent.dashboard.routes.get_team_default_model",

--- a/tests/models/test_model_fallback_resolution.py
+++ b/tests/models/test_model_fallback_resolution.py
@@ -13,6 +13,7 @@ from agent.dashboard.options import (
     fable_disabled_fallback,
     gate_fable_model,
     is_deprecated_model,
+    model_is_allowed,
     model_profile_context_window,
     models_with_profile_context_windows,
     normalize_model_choice,
@@ -21,6 +22,7 @@ from agent.dashboard.options import (
 from agent.dashboard.profiles import ProfileUpdate, normalize_profile_for_response
 from agent.dashboard.team_settings import (
     TeamSettingsUpdate,
+    get_team_allowed_models,
     get_team_default_model,
     normalize_team_settings_for_response,
 )
@@ -51,6 +53,35 @@ def test_environment_default_model_pair(monkeypatch, model, effort, expected) ->
     monkeypatch.setenv("LLM_MODEL_ID", model)
     monkeypatch.setenv("LLM_REASONING_EFFORT", effort)
     assert default_model_pair() == expected
+
+
+def test_model_allowlist_supports_exact_models_and_provider_wildcards() -> None:
+    assert model_is_allowed(SUPPORTED_OPENAI, None)
+    assert model_is_allowed(SUPPORTED_OPENAI, [SUPPORTED_OPENAI])
+    assert model_is_allowed(SUPPORTED_OPENAI, ["openai:*"])
+    assert not model_is_allowed(SUPPORTED_OPENAI, ["anthropic:*"])
+
+
+def test_team_settings_update_validates_model_allowlist() -> None:
+    assert TeamSettingsUpdate(allowed_models=["openai:*", SUPPORTED_OPENAI]).allowed_models == [
+        "openai:*",
+        SUPPORTED_OPENAI,
+    ]
+    with pytest.raises(ValueError, match="unsupported allowed models"):
+        TeamSettingsUpdate(allowed_models=["unknown:*"])
+    with pytest.raises(ValueError, match="default-capable"):
+        TeamSettingsUpdate(allowed_models=[FABLE])
+
+
+@pytest.mark.asyncio
+async def test_stored_model_allowlist_fails_closed_when_malformed() -> None:
+    with patch(
+        "agent.dashboard.team_settings.get_value",
+        new_callable=AsyncMock,
+        return_value={"allowed_models": "openai:*"},
+    ):
+        with pytest.raises(ValueError, match="list of strings"):
+            await get_team_allowed_models()
 
 
 def test_provider_fallback_preserves_provider_and_effort() -> None:
@@ -156,6 +187,22 @@ async def test_team_default_unknown_provider_falls_back_to_global() -> None:
         return_value=settings,
     ):
         assert await get_team_default_model("reviewer") == default_model_pair()
+
+
+@pytest.mark.asyncio
+async def test_team_default_falls_back_inside_model_allowlist() -> None:
+    settings = {
+        "default_agent_model": SUPPORTED_OPENAI,
+        "default_agent_reasoning_effort": "medium",
+        "allowed_models": ["anthropic:*"],
+    }
+    with patch(
+        "agent.dashboard.team_settings.get_team_settings",
+        new_callable=AsyncMock,
+        return_value=settings,
+    ):
+        model, _ = await get_team_default_model("agent")
+    assert model.startswith("anthropic:")
 
 
 def test_profile_stale_anthropic_upgrades_to_supported() -> None:

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -129,10 +129,13 @@ export interface ModelOption {
   supports_images: boolean
   can_be_default?: boolean
   context_window?: number | null
+  family?: string
+  family_label?: string
 }
 
 export interface OptionsPayload {
   models: Array<ModelOption>
+  model_catalog: Array<ModelOption>
   default_agent_model: string
   default_agent_reasoning_effort: string
   default_agent_subagent_model: string
@@ -178,6 +181,7 @@ export interface TeamSettings {
   gateway_enabled?: boolean | null
   transcription_model?: string
   fable_enabled?: boolean
+  allowed_models?: Array<string> | null
   review_tracing_project?: string | null
   org_guidelines?: string | null
   default_agent_model?: string | null

--- a/ui/src/routes/-admin.test.tsx
+++ b/ui/src/routes/-admin.test.tsx
@@ -3,7 +3,12 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { SlackIntegrationSection } from "./admin"
+import type { ModelOption } from "@/lib/api"
+import {
+  SlackIntegrationSection,
+  updateFamilyAllowlist,
+  updateModelAllowlist,
+} from "./admin"
 
 const STORAGE_KEY = "open-swe.admin.slack-code-channels-enabled"
 const storage = new Map<string, string>()
@@ -12,6 +17,64 @@ const localStorage = {
   getItem: (key: string) => storage.get(key) ?? null,
   setItem: (key: string, value: string) => storage.set(key, value),
 }
+
+const MODELS: Array<ModelOption> = [
+  {
+    id: "openai:gpt-5.6-sol",
+    label: "GPT-5.6 Sol",
+    family: "openai",
+    family_label: "OpenAI",
+    efforts: ["medium"],
+    default_effort: "medium",
+    supports_images: true,
+  },
+  {
+    id: "openai:gpt-5.6-luna",
+    label: "GPT-5.6 Luna",
+    family: "openai",
+    family_label: "OpenAI",
+    efforts: ["medium"],
+    default_effort: "medium",
+    supports_images: true,
+  },
+  {
+    id: "anthropic:claude-opus-5",
+    label: "Opus 5",
+    family: "anthropic",
+    family_label: "Anthropic",
+    efforts: ["high"],
+    default_effort: "high",
+    supports_images: true,
+  },
+]
+
+describe("model availability allowlists", () => {
+  it("stores family switches as provider wildcards", () => {
+    expect(
+      updateFamilyAllowlist(MODELS, null, "openai", MODELS.slice(0, 2), false)
+    ).toEqual(["anthropic:claude-opus-5"])
+    expect(
+      updateFamilyAllowlist(
+        MODELS,
+        ["anthropic:claude-opus-5"],
+        "openai",
+        MODELS.slice(0, 2),
+        true
+      )
+    ).toEqual(["anthropic:claude-opus-5", "openai:*"])
+  })
+
+  it("expands a family wildcard when one model is disabled", () => {
+    expect(
+      updateModelAllowlist(
+        MODELS,
+        ["openai:*", "anthropic:*"],
+        MODELS[0]!,
+        false
+      )
+    ).toEqual(["openai:gpt-5.6-luna", "anthropic:*"])
+  })
+})
 
 describe("SlackIntegrationSection", () => {
   const writeText = vi

--- a/ui/src/routes/admin.tsx
+++ b/ui/src/routes/admin.tsx
@@ -66,6 +66,8 @@ function AdminPage() {
         )}
       />
 
+      <ModelAvailabilitySection models={options.data?.model_catalog ?? []} />
+
       <SlackIntegrationSection />
       <WorkspaceMCPSection />
 
@@ -919,6 +921,172 @@ function DictationSection() {
           }
         />
       )}
+      {error && <p className="px-4 pb-3 text-xs text-destructive">{error}</p>}
+    </SettingsSection>
+  )
+}
+
+const MODEL_FAMILY_ORDER = ["anthropic", "openai", "google_genai", "fireworks"]
+
+function modelFamilyOf(model: ModelOption) {
+  return model.family ?? model.id.split(":", 1)[0] ?? model.id
+}
+
+export function updateFamilyAllowlist(
+  models: Array<ModelOption>,
+  allowedModels: Array<string> | null,
+  family: string,
+  familyModels: Array<ModelOption>,
+  enabled: boolean
+) {
+  const wildcard = `${family}:*`
+  const current = allowedModels ?? models.map((model) => model.id)
+  if (enabled) {
+    return [
+      ...current.filter(
+        (entry) =>
+          entry !== wildcard &&
+          !familyModels.some((model) => model.id === entry)
+      ),
+      wildcard,
+    ]
+  }
+  return current.filter(
+    (entry) =>
+      entry !== wildcard && !familyModels.some((model) => model.id === entry)
+  )
+}
+
+export function updateModelAllowlist(
+  models: Array<ModelOption>,
+  allowedModels: Array<string> | null,
+  model: ModelOption,
+  enabled: boolean
+) {
+  const family = modelFamilyOf(model)
+  const wildcard = `${family}:*`
+  let current = allowedModels ?? models.map((option) => option.id)
+  if (current.includes(wildcard)) {
+    current = current.flatMap((entry) =>
+      entry === wildcard
+        ? models
+            .filter((option) => modelFamilyOf(option) === family)
+            .map((option) => option.id)
+        : [entry]
+    )
+  }
+  return enabled
+    ? [...new Set([...current, model.id])]
+    : current.filter((entry) => entry !== model.id)
+}
+
+export function ModelAvailabilitySection({
+  models,
+}: {
+  models: Array<ModelOption>
+}) {
+  const qc = useQueryClient()
+  const settings = useQuery({
+    queryKey: ["teamSettings"],
+    queryFn: api.getTeamSettings,
+  })
+  const [error, setError] = useState<string | null>(null)
+  const save = useMutation({
+    mutationFn: (body: TeamSettings) => api.saveTeamSettings(body),
+    onSuccess: (saved) => {
+      qc.setQueryData(["teamSettings"], saved)
+      qc.invalidateQueries({ queryKey: ["options"] })
+      setError(null)
+    },
+    onError: (e: Error) => setError(e.message),
+  })
+  const families = useMemo(() => {
+    const grouped = new Map<string, Array<ModelOption>>()
+    for (const model of models) {
+      const family = modelFamilyOf(model)
+      grouped.set(family, [...(grouped.get(family) ?? []), model])
+    }
+    return [...grouped.entries()].sort(
+      ([left], [right]) =>
+        MODEL_FAMILY_ORDER.indexOf(left) - MODEL_FAMILY_ORDER.indexOf(right)
+    )
+  }, [models])
+  const allowedModels = settings.data?.allowed_models
+  const isPolicyAllowed = (model: ModelOption) =>
+    allowedModels == null ||
+    allowedModels.includes(model.id) ||
+    allowedModels.includes(`${modelFamilyOf(model)}:*`)
+  const isAllowed = (model: ModelOption) =>
+    isPolicyAllowed(model) &&
+    (model.id !== "anthropic:claude-fable-5-1" ||
+      !!settings.data?.fable_enabled)
+  const persist = (next: Array<string> | null) => {
+    if (!settings.data) return
+    save.mutate({ ...settings.data, allowed_models: next })
+  }
+  const toggleFamily = (
+    family: string,
+    familyModels: Array<ModelOption>,
+    enabled: boolean
+  ) =>
+    persist(
+      updateFamilyAllowlist(
+        models,
+        allowedModels ?? null,
+        family,
+        familyModels,
+        enabled
+      )
+    )
+  const toggleModel = (model: ModelOption, enabled: boolean) =>
+    persist(updateModelAllowlist(models, allowedModels ?? null, model, enabled))
+
+  return (
+    <SettingsSection
+      title="Model availability"
+      description="Choose which models workspace members can select. Family controls map to dcode-style provider:* allowlist entries."
+    >
+      <div className="divide-y divide-border">
+        {families.map(([family, familyModels]) => {
+          const enabledCount = familyModels.filter(isAllowed).length
+          const familyEnabled = enabledCount === familyModels.length
+          return (
+            <div key={family} className="divide-y divide-border/60">
+              <SettingsRow
+                label={familyModels[0]?.family_label ?? family}
+                description={`${enabledCount} of ${familyModels.length} models enabled`}
+                control={
+                  <Switch
+                    aria-label={`${familyModels[0]?.family_label ?? family} family`}
+                    checked={familyEnabled}
+                    onCheckedChange={(next) =>
+                      toggleFamily(family, familyModels, next)
+                    }
+                    disabled={!settings.data || save.isPending}
+                  />
+                }
+              />
+              <div className="divide-y divide-border/60 bg-muted/20 pl-6">
+                {familyModels.map((model) => (
+                  <SettingsRow
+                    key={model.id}
+                    label={model.label}
+                    description={model.id}
+                    control={
+                      <Switch
+                        aria-label={model.label}
+                        checked={isPolicyAllowed(model)}
+                        onCheckedChange={(next) => toggleModel(model, next)}
+                        disabled={!settings.data || save.isPending}
+                      />
+                    }
+                  />
+                ))}
+              </div>
+            </div>
+          )
+        })}
+      </div>
       {error && <p className="px-4 pb-3 text-xs text-destructive">{error}</p>}
     </SettingsSection>
   )


### PR DESCRIPTION
### Summary

- add an admin model-availability panel with provider-family and individual-model controls
- persist dcode-inspired `provider:model` and `provider:*` allowlist entries in team settings
- filter model discovery and enforce the policy across agent, reviewer, chat, analyzer, schedules, routing, fallbacks, and image handling

### Preview

![Admin model availability](https://01a08808-0724-7710-a536-fec97f451e65--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGc1T1RFM09UVXNJbXAwYVNJNklqQXhZVEE0T0RNNExUY3hZVFF0TjJFMU55MDVNbVprTFRsbE1EQXdaV1JoTkRFMU15SXNJbk5wWkNJNklqQXhZVEE0T0RBNExUQTNNalF0TnpjeE1DMWhOVE0yTFdabFl6azNaalExTVdVMk5TSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMeTV2Y0dWdUxYTjNaUzloY25ScFptRmpkSE12WVdSdGFXNHRiVzlrWld3dFlYWmhhV3hoWW1sc2FYUjVMbkJ1WnlJc0ltTjBJam9pYVcxaFoyVXZjRzVuSWl3aVkyUWlPaUpwYm14cGJtVWlmUS5lTmhzNkduQjJ6LVhTZ0N6Z3BEZGlUUHZtUDVpTlRUeTZ2SzQ5OVhpdG9HbmNNdEFRMzVMQ3hPTXlwTThOdjcwNHlKT3ZTaXlnS0t5cVhvRXRhNVZBZw)

Made by [Open SWE](https://openswe.vercel.app/agents/c1fba758-2ccc-5414-86e6-19fda49a1651) · openai:gpt-5.6-sol (high)
