### PR TITLE
feat(desktop): move backend URL to settings

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -35,8 +35,8 @@ key and never calls the raw LangGraph API directly. GitHub login creates the sam
 session used by the web UI.
 
 Packaged builds ask for the organization's backend URL on first launch and store it in the app's
-local user data. They have no maintainer-hosted default. Use **Open SWE → Backend URL…** to switch
-deployments; switching clears the previous deployment's local session data.
+local user data. They have no maintainer-hosted default. Use **Open SWE → Settings… → Desktop** to
+switch deployments; switching clears the previous deployment's local session data.
 
 The backend's GitHub App must allow `<backend-url>/dashboard/api/auth/callback` as a callback URL.
 Set `ALLOWED_GITHUB_ORGS` on the backend to prevent GitHub users outside the organization from

--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -416,6 +416,14 @@ function configureDesktopIpc() {
     requireTrustedDesktopIpc(event);
     return updateState;
   });
+  ipcMain.handle("desktop:backend-url", (event) => {
+    requireTrustedDesktopIpc(event);
+    return backendUrl;
+  });
+  ipcMain.handle("desktop:set-backend-url", (event, value) => {
+    requireTrustedDesktopIpc(event);
+    return updateBackendUrl(value);
+  });
   ipcMain.handle("desktop:install-update", async (event) => {
     requireTrustedDesktopIpc(event);
     if (updateState.status === "installing") return true;
@@ -787,6 +795,18 @@ function storeBackendUrl(value) {
   return url;
 }
 
+async function updateBackendUrl(value) {
+  if (typeof value !== "string") throw new Error("Enter a backend URL");
+  const previousUrl = backendUrl;
+  backendUrl = storeBackendUrl(value);
+  const changed = previousUrl !== backendUrl;
+  if (previousUrl && changed) {
+    await clearBackendCookies(previousUrl);
+    await session.defaultSession.clearStorageData({ origin: APP_URL });
+  }
+  return { backendUrl, changed };
+}
+
 function iconPath() {
   return app.isPackaged
     ? path.join(process.resourcesPath, "icon.png")
@@ -977,10 +997,6 @@ async function loadApp(window) {
 }
 
 function createMenu() {
-  const backendSettingsItem = {
-    label: "Backend URL…",
-    click: () => createSetupWindow(),
-  };
   const settingsItem = {
     id: "open-settings",
     label: "Settings…",
@@ -1001,7 +1017,6 @@ function createMenu() {
               { role: "about" },
               settingsItem,
               checkForUpdatesItem,
-              backendSettingsItem,
               { type: "separator" },
               { role: "services" },
               { type: "separator" },
@@ -1030,7 +1045,7 @@ function createMenu() {
         },
         ...(process.platform === "darwin"
           ? []
-          : [{ type: "separator" }, settingsItem, backendSettingsItem]),
+          : [{ type: "separator" }, settingsItem]),
         { type: "separator" },
         { role: process.platform === "darwin" ? "close" : "quit" },
       ],
@@ -1360,13 +1375,7 @@ function createSetupWindow() {
     event.preventDefault();
     try {
       const value = new URL(targetUrl).searchParams.get("url");
-      if (!value) throw new Error("Enter a backend URL");
-      const previousUrl = backendUrl;
-      backendUrl = storeBackendUrl(value);
-      if (previousUrl && previousUrl !== backendUrl) {
-        await clearBackendCookies(previousUrl);
-        await session.defaultSession.clearStorageData({ origin: APP_URL });
-      }
+      await updateBackendUrl(value);
       if (mainWindow && !mainWindow.isDestroyed()) await loadApp(mainWindow);
       else createWindow();
       window.close();

--- a/desktop/src/preload.cts
+++ b/desktop/src/preload.cts
@@ -38,6 +38,8 @@ contextBridge.exposeInMainWorld("openSweDesktop", {
   addProject: () => ipcRenderer.invoke("desktop:add-project"),
   removeProject: (cwd) => ipcRenderer.invoke("desktop:remove-project", cwd),
   getVersion: () => ipcRenderer.invoke("desktop:version"),
+  getBackendUrl: () => ipcRenderer.invoke("desktop:backend-url"),
+  setBackendUrl: (url) => ipcRenderer.invoke("desktop:set-backend-url", url),
   getUpdateState: () => ipcRenderer.invoke("desktop:update-state"),
   installUpdate: () => ipcRenderer.invoke("desktop:install-update"),
   onUpdateState: (callback) => {

--- a/tests/e2e/tests/desktop.spec.ts
+++ b/tests/e2e/tests/desktop.spec.ts
@@ -147,6 +147,22 @@ test("Desktop runs a local thread on the Open SWE graph against the shared fakes
       await maybeLater.click();
     }
 
+    await page.goto("open-swe://app/my-settings");
+    const backendUrl = page.getByLabel("Backend URL");
+    await expect(backendUrl).toHaveValue(`${baseURL}/`);
+    const settingsScreenshot = testInfo.outputPath(
+      "desktop-backend-settings.png",
+    );
+    await page.screenshot({ path: settingsScreenshot, fullPage: true });
+    await testInfo.attach("desktop-backend-settings", {
+      path: settingsScreenshot,
+      contentType: "image/png",
+    });
+    await page.getByRole("link", { name: "Back to app" }).click();
+    const maybeLater = page.getByRole("button", { name: "Maybe later" });
+    await expect(maybeLater).toBeVisible();
+    await maybeLater.click();
+
     await expect(
       page.getByRole("button", { name: /Cloud threads, \d+/ }),
     ).toHaveCount(0);

--- a/ui/src/desktop.d.ts
+++ b/ui/src/desktop.d.ts
@@ -176,6 +176,10 @@ declare global {
       addProject: () => Promise<DesktopProject | null>
       removeProject: (cwd: string) => Promise<boolean>
       getVersion: () => Promise<string>
+      getBackendUrl: () => Promise<string>
+      setBackendUrl: (
+        url: string
+      ) => Promise<{ backendUrl: string; changed: boolean }>
       getUpdateState: () => Promise<DesktopUpdateState>
       installUpdate: () => Promise<boolean>
       onUpdateState: (

--- a/ui/src/features/settings/components/DesktopBackendSection.tsx
+++ b/ui/src/features/settings/components/DesktopBackendSection.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react"
+
+import { SettingsRow, SettingsSection } from "@/components/AppShell"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+
+export function DesktopBackendSection() {
+  const desktop = window.openSweDesktop
+  const [saved, setSaved] = useState("")
+  const [value, setValue] = useState("")
+  const [loading, setLoading] = useState(!!desktop)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!desktop) return
+    void desktop
+      .getBackendUrl()
+      .then((url) => {
+        setSaved(url)
+        setValue(url)
+      })
+      .catch((reason: unknown) => {
+        setError(reason instanceof Error ? reason.message : String(reason))
+      })
+      .finally(() => setLoading(false))
+  }, [desktop])
+
+  if (!desktop) return null
+
+  const save = async () => {
+    setSaving(true)
+    setError(null)
+    try {
+      const result = await desktop.setBackendUrl(value)
+      setSaved(result.backendUrl)
+      setValue(result.backendUrl)
+      if (result.changed) window.location.reload()
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : String(reason))
+    }
+    setSaving(false)
+  }
+
+  return (
+    <SettingsSection
+      title="Desktop"
+      description="Configuration stored by the Open SWE desktop app on this computer."
+    >
+      <SettingsRow
+        label="Backend URL"
+        description="Changing deployments signs you out of the current deployment."
+        htmlFor="desktop-backend-url"
+        control={
+          <div className="flex w-full flex-col gap-1.5 sm:w-80">
+            <div className="flex gap-2">
+              <Input
+                id="desktop-backend-url"
+                type="url"
+                value={value}
+                onChange={(event) => setValue(event.target.value)}
+                disabled={loading || saving}
+              />
+              <Button
+                onClick={() => void save()}
+                disabled={loading || saving || value.trim() === saved}
+              >
+                {saving ? "Saving…" : "Save"}
+              </Button>
+            </div>
+            {error && <p className="text-xs text-destructive">{error}</p>}
+          </div>
+        }
+      />
+    </SettingsSection>
+  )
+}

--- a/ui/src/routes/my-settings.tsx
+++ b/ui/src/routes/my-settings.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react"
 import { AccountSection } from "@/features/settings/components/AccountSection"
 import { AppShell, SettingsRow, SettingsSection } from "@/components/AppShell"
 import { ConnectionsSection } from "@/features/settings/components/ConnectionsSection"
+import { DesktopBackendSection } from "@/features/settings/components/DesktopBackendSection"
 import { EnvironmentsSection } from "@/features/settings/components/EnvironmentsSection"
 import { PersonalInstructionsSection } from "@/features/settings/components/PersonalInstructionsSection"
 import { PreferencesSection } from "@/features/settings/components/PreferencesSection"
@@ -56,6 +57,7 @@ function MySettingsPage() {
       title="Settings"
       description="Personal preferences, connected accounts, and instructions that apply to every run you trigger."
     >
+      <DesktopBackendSection />
       <AccountSection user={session.data} />
       <PreferencesSection />
       <PullRequestsSection />


### PR DESCRIPTION
Moves backend deployment configuration into the existing Settings page and removes the separate native Backend URL menu item.

The Desktop settings field loads the current normalized backend URL, validates and persists changes through trusted Electron IPC, clears the previous deployment session when switching, and reloads the app against the selected deployment.

![Desktop backend URL setting](https://01a0886b-ab31-79d9-b37d-4d31e68cdc22--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGc1T1RZM01URXNJbXAwYVNJNklqQXhZVEE0T0RnekxUYzFObVl0TnpFek9TMWlaREU1TFRRNE9UZzFNbVF3TVRNMVlpSXNJbk5wWkNJNklqQXhZVEE0T0RaaUxXRmlNekV0Tnpsa09TMWlNemRrTFRSa016RmxOamhqWkdNeU1pSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMM1JsYzNSekwyVXlaUzkwWlhOMExYSmxjM1ZzZEhNdlpHVnphM1J2Y0M5a1pYTnJkRzl3TFVSbGMydDBiM0F0Y25WdWN5MWhMV3h2WXkwNFpEVmlOaTF3YUMxaFoyRnBibk4wTFhSb1pTMXphR0Z5WldRdFptRnJaWE10Wld4bFkzUnliMjR2WVhSMFlXTm9iV1Z1ZEhNdlpHVnphM1J2Y0MxaVlXTnJaVzVrTFhObGRIUnBibWR6TFdFNU16VXlPR0kyTlRkaE56WmpNV0ZoWmpJMk4yWmlObVJsTnpsak5UQTJPVGMzWmpBeU5HRXVjRzVuSWl3aVkzUWlPaUpwYldGblpTOXdibWNpTENKalpDSTZJbWx1YkdsdVpTSjkuczR5Z0xBaTVCMkRKQ3NFeEhsa3hzWUd4ZkxfeEppSTJnaGsxREtFNE9SWjBOOGlEaVZ1ZnVTOHVPLXctb2lnbnM4TEZuNU0xdDVaeEt1WV9DZ1RDQUE)

Made by [Open SWE](https://openswe.vercel.app/agents/95a09fae-18dd-5798-9179-357f310c47d6) · openai:gpt-5.6-sol (high)