### PR TITLE
feat: add web thread feedback

### DIFF
--- a/agent/dashboard/feedback.py
+++ b/agent/dashboard/feedback.py
@@ -1,6 +1,6 @@
 """Private web feedback on completed agent threads."""
 
-from typing import Any, Self
+from typing import Any, Literal, Self
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field, model_validator
@@ -29,13 +29,16 @@ class ThreadFeedbackResponse(BaseModel):
 
 
 class FeedbackSubmission(BaseModel):
-    rating: Rating
+    action: Literal["submit", "dismiss"] = "submit"
+    rating: Rating | None = None
     comment: str = Field(default="", max_length=3000)
 
     @model_validator(mode="after")
-    def validate_comment(self) -> Self:
+    def validate_submission(self) -> Self:
         self.comment = self.comment.strip()
-        if self.rating == "other" and not self.comment:
+        if self.action == "submit" and self.rating is None:
+            raise ValueError("Choose a rating before submitting feedback.")
+        if self.action == "submit" and self.rating == "other" and not self.comment:
             raise ValueError("Add a comment when choosing Other.")
         return self
 
@@ -69,9 +72,11 @@ async def get_thread_feedback(
     )
 
 
-async def _save_feedback(
-    thread_id: str, login: str, submission: FeedbackSubmission | None
+@feedback_router.post("/{thread_id}/feedback")
+async def submit_thread_feedback(
+    thread_id: str, submission: FeedbackSubmission, session: dict[str, Any] = _SESSION_DEP
 ) -> ThreadFeedbackResponse:
+    login = str(session["sub"]).strip().lower()
     if not await _is_initiator(thread_id, login):
         raise HTTPException(403, "Only the thread initiator can give feedback.")
     async with agent_thread_pr_state_lock(langgraph_client(), thread_id):
@@ -81,22 +86,9 @@ async def _save_feedback(
         if record.status not in {"completed", "dismissed"}:
             if await feedback_prompt_status(thread_id) != "ready":
                 raise HTTPException(409, "Feedback is not available for this thread yet.")
-            record.status = "completed" if submission else "dismissed"
-            record.rating = submission.rating if submission else None
-            record.comment = submission.comment if submission else ""
+            dismiss = submission.action == "dismiss"
+            record.status = "dismissed" if dismiss else "completed"
+            record.rating = None if dismiss else submission.rating
+            record.comment = "" if dismiss else submission.comment
             await feedback_store().put(thread_id, record)
     return ThreadFeedbackResponse.model_validate(record, from_attributes=True)
-
-
-@feedback_router.post("/{thread_id}/feedback")
-async def submit_thread_feedback(
-    thread_id: str, submission: FeedbackSubmission, session: dict[str, Any] = _SESSION_DEP
-) -> ThreadFeedbackResponse:
-    return await _save_feedback(thread_id, str(session["sub"]).strip().lower(), submission)
-
-
-@feedback_router.post("/{thread_id}/feedback/dismiss")
-async def dismiss_thread_feedback(
-    thread_id: str, session: dict[str, Any] = _SESSION_DEP
-) -> ThreadFeedbackResponse:
-    return await _save_feedback(thread_id, str(session["sub"]).strip().lower(), None)

--- a/agent/dashboard/feedback.py
+++ b/agent/dashboard/feedback.py
@@ -10,7 +10,7 @@ from agent.dashboard.plan_api import fetch_thread_metadata
 from agent.dashboard.threads.summary import thread_is_readable
 from agent.dashboard.user_mappings import login_for_slack_id
 from agent.source_context import SourceContext
-from agent.thread_feedback import Rating, feedback_prompt_status, feedback_store
+from agent.thread_feedback import PromptStatus, Rating, feedback_prompt_status, feedback_store
 from agent.utils.thread_ops import langgraph_client
 from agent.utils.thread_pr_state import agent_thread_pr_state_lock
 
@@ -20,6 +20,12 @@ feedback_router = APIRouter(
     dependencies=[Depends(require_same_origin_for_mutations)],
 )
 _SESSION_DEP = Depends(require_session)
+
+
+class ThreadFeedbackResponse(BaseModel):
+    status: PromptStatus
+    rating: Rating | None = None
+    comment: str = ""
 
 
 class FeedbackSubmission(BaseModel):
@@ -51,21 +57,21 @@ async def _is_initiator(thread_id: str, login: str) -> bool:
 @feedback_router.get("/{thread_id}/feedback")
 async def get_thread_feedback(
     thread_id: str, session: dict[str, Any] = _SESSION_DEP
-) -> dict[str, Any]:
+) -> ThreadFeedbackResponse:
     login = str(session["sub"]).strip().lower()
     if not await _is_initiator(thread_id, login):
-        return {"status": "unavailable"}
+        return ThreadFeedbackResponse(status="unavailable")
     record = await feedback_store().get(thread_id)
-    return {
-        "status": await feedback_prompt_status(thread_id),
-        "rating": record.rating if record else None,
-        "comment": record.comment if record else "",
-    }
+    return ThreadFeedbackResponse(
+        status=await feedback_prompt_status(thread_id),
+        rating=record.rating if record else None,
+        comment=record.comment if record else "",
+    )
 
 
 async def _save_feedback(
     thread_id: str, login: str, submission: FeedbackSubmission | None
-) -> dict[str, Any]:
+) -> ThreadFeedbackResponse:
     if not await _is_initiator(thread_id, login):
         raise HTTPException(403, "Only the thread initiator can give feedback.")
     async with agent_thread_pr_state_lock(langgraph_client(), thread_id):
@@ -79,18 +85,18 @@ async def _save_feedback(
             record.rating = submission.rating if submission else None
             record.comment = submission.comment if submission else ""
             await feedback_store().put(thread_id, record)
-    return record.model_dump(include={"status", "rating", "comment"})
+    return ThreadFeedbackResponse.model_validate(record, from_attributes=True)
 
 
 @feedback_router.post("/{thread_id}/feedback")
 async def submit_thread_feedback(
     thread_id: str, submission: FeedbackSubmission, session: dict[str, Any] = _SESSION_DEP
-) -> dict[str, Any]:
+) -> ThreadFeedbackResponse:
     return await _save_feedback(thread_id, str(session["sub"]).strip().lower(), submission)
 
 
 @feedback_router.post("/{thread_id}/feedback/dismiss")
 async def dismiss_thread_feedback(
     thread_id: str, session: dict[str, Any] = _SESSION_DEP
-) -> dict[str, Any]:
+) -> ThreadFeedbackResponse:
     return await _save_feedback(thread_id, str(session["sub"]).strip().lower(), None)

--- a/agent/dashboard/feedback.py
+++ b/agent/dashboard/feedback.py
@@ -1,0 +1,96 @@
+"""Private web feedback on completed agent threads."""
+
+from typing import Any, Self
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field, model_validator
+
+from agent.dashboard.oauth import require_same_origin_for_mutations, require_session
+from agent.dashboard.plan_api import fetch_thread_metadata
+from agent.dashboard.threads.summary import thread_is_readable
+from agent.dashboard.user_mappings import login_for_slack_id
+from agent.source_context import SourceContext
+from agent.thread_feedback import Rating, feedback_prompt_status, feedback_store
+from agent.utils.thread_ops import langgraph_client
+from agent.utils.thread_pr_state import agent_thread_pr_state_lock
+
+feedback_router = APIRouter(
+    prefix="/threads",
+    tags=["thread-feedback"],
+    dependencies=[Depends(require_same_origin_for_mutations)],
+)
+_SESSION_DEP = Depends(require_session)
+
+
+class FeedbackSubmission(BaseModel):
+    rating: Rating
+    comment: str = Field(default="", max_length=3000)
+
+    @model_validator(mode="after")
+    def validate_comment(self) -> Self:
+        self.comment = self.comment.strip()
+        if self.rating == "other" and not self.comment:
+            raise ValueError("Add a comment when choosing Other.")
+        return self
+
+
+async def _is_initiator(thread_id: str, login: str) -> bool:
+    metadata = await fetch_thread_metadata(thread_id)
+    if not thread_is_readable(metadata):
+        raise HTTPException(404, "thread not found")
+    initiator = metadata.get("feedback_initiator_login")
+    if isinstance(initiator, str) and initiator.strip():
+        return initiator.strip().lower() == login
+    origin = SourceContext.from_metadata(metadata).slack_thread
+    if origin and origin.triggering_user_id:
+        mapped = await login_for_slack_id(origin.triggering_user_id)
+        return bool(mapped and mapped.strip().lower() == login)
+    return False
+
+
+@feedback_router.get("/{thread_id}/feedback")
+async def get_thread_feedback(
+    thread_id: str, session: dict[str, Any] = _SESSION_DEP
+) -> dict[str, Any]:
+    login = str(session["sub"]).strip().lower()
+    if not await _is_initiator(thread_id, login):
+        return {"status": "unavailable"}
+    record = await feedback_store().get(thread_id)
+    return {
+        "status": await feedback_prompt_status(thread_id),
+        "rating": record.rating if record else None,
+        "comment": record.comment if record else "",
+    }
+
+
+async def _save_feedback(
+    thread_id: str, login: str, submission: FeedbackSubmission | None
+) -> dict[str, Any]:
+    if not await _is_initiator(thread_id, login):
+        raise HTTPException(403, "Only the thread initiator can give feedback.")
+    async with agent_thread_pr_state_lock(langgraph_client(), thread_id):
+        record = await feedback_store().get(thread_id)
+        if record is None:
+            raise HTTPException(409, "Feedback is not available for this thread yet.")
+        if record.status not in {"completed", "dismissed"}:
+            if await feedback_prompt_status(thread_id) != "ready":
+                raise HTTPException(409, "Feedback is not available for this thread yet.")
+            record.status = "completed" if submission else "dismissed"
+            record.rating = submission.rating if submission else None
+            record.comment = submission.comment if submission else ""
+            await feedback_store().put(thread_id, record)
+    return record.model_dump(include={"status", "rating", "comment"})
+
+
+@feedback_router.post("/{thread_id}/feedback")
+async def submit_thread_feedback(
+    thread_id: str, submission: FeedbackSubmission, session: dict[str, Any] = _SESSION_DEP
+) -> dict[str, Any]:
+    return await _save_feedback(thread_id, str(session["sub"]).strip().lower(), submission)
+
+
+@feedback_router.post("/{thread_id}/feedback/dismiss")
+async def dismiss_thread_feedback(
+    thread_id: str, session: dict[str, Any] = _SESSION_DEP
+) -> dict[str, Any]:
+    return await _save_feedback(thread_id, str(session["sub"]).strip().lower(), None)

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -46,6 +46,7 @@ from agent.dashboard.environments import (
     list_environment_options,
     slugify,
 )
+from agent.dashboard.feedback import feedback_router
 from agent.dashboard.notion_oauth import (
     NOTION_STATE_COOKIE_NAME,
     NotionOAuthError,
@@ -265,6 +266,7 @@ router = APIRouter(
     tags=["dashboard"],
     dependencies=[Depends(require_same_origin_for_mutations)],
 )
+router.include_router(feedback_router)
 _GITHUB_API_TIMEOUT = httpx2.Timeout(10.0, connect=3.0)
 _CLOUD_TERMINAL_SLOTS = asyncio.Semaphore(20)
 _CLOUD_TERMINAL_SUBPROTOCOL = "open-swe-terminal"

--- a/agent/dashboard/threads/runs.py
+++ b/agent/dashboard/threads/runs.py
@@ -267,7 +267,11 @@ async def _create_dashboard_thread_record(
         metadata["repo_explicitly_none"] = True
 
     client = langgraph_client()
-    await client.threads.create(thread_id=thread_id, metadata=metadata, if_exists="do_nothing")
+    await client.threads.create(
+        thread_id=thread_id,
+        metadata={**metadata, "feedback_initiator_login": login},
+        if_exists="do_nothing",
+    )
     await client.threads.update(thread_id=thread_id, metadata=metadata)
     thread = await client.threads.get(thread_id)
     return as_thread_dict(thread)

--- a/agent/server.py
+++ b/agent/server.py
@@ -167,6 +167,7 @@ from agent.tools import (
     manage_baby_sit,
     manage_code_channel,
     manage_thread,
+    mark_question_answered,
     notify_automation_channel,
     open_pull_request,
     output_iframe,
@@ -1075,6 +1076,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         get_thread,
         manage_thread,
         manage_baby_sit,
+        mark_question_answered,
         notify_automation_channel,
         open_pull_request,
         *(

--- a/agent/thread_feedback.py
+++ b/agent/thread_feedback.py
@@ -15,6 +15,7 @@ from agent.utils.thread_pr_state import agent_thread_pr_state_lock
 logger = logging.getLogger(__name__)
 DELAY_MS = 5 * 60 * 1000
 ACTIVITY_KEY = "feedback_last_activity_at_ms"
+Rating = Literal["bad", "good", "other"]
 
 
 class Feedback(BaseModel):
@@ -22,6 +23,8 @@ class Feedback(BaseModel):
     event_id: str = ""
     answer_run_id: str = ""
     activity_at_ms: int = 0
+    rating: Rating | None = None
+    comment: str = ""
 
 
 def feedback_store() -> TypedStore[Feedback]:
@@ -168,6 +171,13 @@ async def _schedule(
         logger.warning("Could not schedule feedback prompt", extra={"thread_id": thread_id})
 
 
+async def mark_answered_question(thread_id: str, run_id: str) -> None:
+    thread = await langgraph_client().threads.get(thread_id)
+    await _schedule(
+        thread_id, thread.get("metadata") or {}, event_id=f"answer:{run_id}", answer_run_id=run_id
+    )
+
+
 async def schedule_answer_feedback(thread_id: str, run_id: str, metadata: dict[str, Any]) -> None:
     from agent.slack.client import lookup_slack_run_message_mapping
 
@@ -195,8 +205,6 @@ async def schedule_pr_feedback(thread_id: str, metadata: dict[str, Any], pr_url:
         (pr for pr in (metadata.get("pull_requests") or []) if pr.get("url") == pr_url), {}
     )
     origin = record.get("slack_feedback") or {}
-    if not origin.get("channel_id") or not origin.get("run_id"):
-        return
     await _schedule(
         thread_id,
         metadata,

--- a/agent/thread_feedback.py
+++ b/agent/thread_feedback.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 DELAY_MS = 5 * 60 * 1000
 ACTIVITY_KEY = "feedback_last_activity_at_ms"
 Rating = Literal["bad", "good", "other"]
+PromptStatus = Literal["unavailable", "ready", "completed", "dismissed"]
 
 
 class Feedback(BaseModel):
@@ -71,7 +72,7 @@ async def _quiet_until(thread_id: str, record: Feedback) -> int | None:
     return activity + DELAY_MS
 
 
-async def feedback_prompt_status(thread_id: str) -> str:
+async def feedback_prompt_status(thread_id: str) -> PromptStatus:
     record = await feedback_store().get(thread_id)
     if record is None or record.status == "pending":
         return "unavailable"

--- a/agent/tools/__init__.py
+++ b/agent/tools/__init__.py
@@ -27,6 +27,7 @@ _TOOL_MODULES = {
     "manage_baby_sit": ".manage_baby_sit",
     "manage_code_channel": "agent.slack.tools.manage_code_channel",
     "manage_thread": ".threads",
+    "mark_question_answered": ".mark_question_answered",
     "notify_automation_channel": ".notify_automation_channel",
     "open_pull_request": ".open_pull_request",
     "output_iframe": ".output_iframe",
@@ -85,6 +86,7 @@ __all__ = [
     "manage_baby_sit",
     "manage_code_channel",
     "manage_thread",
+    "mark_question_answered",
     "notify_automation_channel",
     "open_pull_request",
     "output_iframe",
@@ -155,6 +157,7 @@ if TYPE_CHECKING:
     from agent.tools.list_findings import list_findings
     from agent.tools.list_review_findings import list_review_findings
     from agent.tools.manage_baby_sit import manage_baby_sit
+    from agent.tools.mark_question_answered import mark_question_answered
     from agent.tools.notify_automation_channel import notify_automation_channel
     from agent.tools.open_pull_request import open_pull_request
     from agent.tools.organization_skills import delete_organization_skill, save_organization_skill

--- a/agent/tools/mark_question_answered.py
+++ b/agent/tools/mark_question_answered.py
@@ -1,0 +1,27 @@
+"""Mark a fully answered information request for delayed thread feedback."""
+
+from typing import Any
+
+from langgraph.config import get_config
+
+from agent.run_config import RunConfig
+from agent.thread_feedback import mark_answered_question
+
+
+async def mark_question_answered() -> dict[str, Any]:
+    """Mark that you have completely answered an information-only request.
+
+    Call after answering a question in the web UI when no clarification or further
+    work is needed. Do not use for coding tasks, plans, approval requests, blockers,
+    or partial answers. Coding tasks request feedback after their PR merges.
+    For Slack answers, use slack_thread_reply with should_ask_for_feedback=True.
+    Feedback is offered only if this run succeeds and the user does not continue
+    the conversation for five minutes. This does not send a message or end the run.
+    """
+    config = get_config()
+    cfg = RunConfig.from_config(config)
+    run_id = str(config.get("run_id") or cfg.run_id or "")
+    if not cfg.thread_id or not run_id:
+        return {"success": False, "error": "No active thread and run"}
+    await mark_answered_question(cfg.thread_id, run_id)
+    return {"success": True}

--- a/swagger.json
+++ b/swagger.json
@@ -550,6 +550,30 @@
         "title": "FeedbackResponse",
         "type": "object"
       },
+      "FeedbackSubmission": {
+        "properties": {
+          "comment": {
+            "default": "",
+            "maxLength": 3000,
+            "title": "Comment",
+            "type": "string"
+          },
+          "rating": {
+            "enum": [
+              "bad",
+              "good",
+              "other"
+            ],
+            "title": "Rating",
+            "type": "string"
+          }
+        },
+        "required": [
+          "rating"
+        ],
+        "title": "FeedbackSubmission",
+        "type": "object"
+      },
       "HTTPValidationError": {
         "properties": {
           "detail": {
@@ -7078,6 +7102,164 @@
         "summary": "Api Thread Commands",
         "tags": [
           "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/threads/{thread_id}/feedback": {
+      "get": {
+        "operationId": "get_thread_feedback_dashboard_api_threads__thread_id__feedback_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Thread Feedback Dashboard Api Threads  Thread Id  Feedback Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
+        "summary": "Get Thread Feedback",
+        "tags": [
+          "dashboard",
+          "thread-feedback"
+        ]
+      },
+      "post": {
+        "operationId": "submit_thread_feedback_dashboard_api_threads__thread_id__feedback_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FeedbackSubmission"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Submit Thread Feedback Dashboard Api Threads  Thread Id  Feedback Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
+        "summary": "Submit Thread Feedback",
+        "tags": [
+          "dashboard",
+          "thread-feedback"
+        ]
+      }
+    },
+    "/dashboard/api/threads/{thread_id}/feedback/dismiss": {
+      "post": {
+        "operationId": "dismiss_thread_feedback_dashboard_api_threads__thread_id__feedback_dismiss_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "thread_id",
+            "required": true,
+            "schema": {
+              "title": "Thread Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Dismiss Thread Feedback Dashboard Api Threads  Thread Id  Feedback Dismiss Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
+        "summary": "Dismiss Thread Feedback",
+        "tags": [
+          "dashboard",
+          "thread-feedback"
         ]
       }
     },

--- a/swagger.json
+++ b/swagger.json
@@ -1827,6 +1827,46 @@
         "title": "TextAnchor",
         "type": "object"
       },
+      "ThreadFeedbackResponse": {
+        "properties": {
+          "comment": {
+            "default": "",
+            "title": "Comment",
+            "type": "string"
+          },
+          "rating": {
+            "anyOf": [
+              {
+                "enum": [
+                  "bad",
+                  "good",
+                  "other"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rating"
+          },
+          "status": {
+            "enum": [
+              "unavailable",
+              "ready",
+              "completed",
+              "dismissed"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "ThreadFeedbackResponse",
+        "type": "object"
+      },
       "ThreadMessageBody": {
         "properties": {
           "client_message_id": {
@@ -7124,9 +7164,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Get Thread Feedback Dashboard Api Threads  Thread Id  Feedback Get",
-                  "type": "object"
+                  "$ref": "#/components/schemas/ThreadFeedbackResponse"
                 }
               }
             },
@@ -7182,9 +7220,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Submit Thread Feedback Dashboard Api Threads  Thread Id  Feedback Post",
-                  "type": "object"
+                  "$ref": "#/components/schemas/ThreadFeedbackResponse"
                 }
               }
             },
@@ -7232,9 +7268,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Dismiss Thread Feedback Dashboard Api Threads  Thread Id  Feedback Dismiss Post",
-                  "type": "object"
+                  "$ref": "#/components/schemas/ThreadFeedbackResponse"
                 }
               }
             },

--- a/swagger.json
+++ b/swagger.json
@@ -552,6 +552,15 @@
       },
       "FeedbackSubmission": {
         "properties": {
+          "action": {
+            "default": "submit",
+            "enum": [
+              "submit",
+              "dismiss"
+            ],
+            "title": "Action",
+            "type": "string"
+          },
           "comment": {
             "default": "",
             "maxLength": 3000,
@@ -559,18 +568,22 @@
             "type": "string"
           },
           "rating": {
-            "enum": [
-              "bad",
-              "good",
-              "other"
+            "anyOf": [
+              {
+                "enum": [
+                  "bad",
+                  "good",
+                  "other"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
             ],
-            "title": "Rating",
-            "type": "string"
+            "title": "Rating"
           }
         },
-        "required": [
-          "rating"
-        ],
         "title": "FeedbackSubmission",
         "type": "object"
       },
@@ -7243,54 +7256,6 @@
           }
         ],
         "summary": "Submit Thread Feedback",
-        "tags": [
-          "dashboard",
-          "thread-feedback"
-        ]
-      }
-    },
-    "/dashboard/api/threads/{thread_id}/feedback/dismiss": {
-      "post": {
-        "operationId": "dismiss_thread_feedback_dashboard_api_threads__thread_id__feedback_dismiss_post",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "thread_id",
-            "required": true,
-            "schema": {
-              "title": "Thread Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ThreadFeedbackResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "DashboardSession": []
-          }
-        ],
-        "summary": "Dismiss Thread Feedback",
         "tags": [
           "dashboard",
           "thread-feedback"

--- a/tests/agent/test_thread_feedback_prompt.py
+++ b/tests/agent/test_thread_feedback_prompt.py
@@ -141,12 +141,24 @@ async def test_unsuccessful_answers_do_not_prompt(context: Any, status: str) -> 
     slack_feedback.post_slack_feedback_prompt.assert_not_awaited()
 
 
+async def test_web_answer_only_becomes_ready_after_run_succeeds(context: Any) -> None:
+    await feedback.mark_answered_question("t1", "r1")
+    payload = context.runs.create.call_args.kwargs["input"]
+    context.runs.list.return_value = [{"run_id": "r1", "status": "running"}]
+    await _run(context, payload, 302000)
+    assert await feedback.feedback_prompt_status("t1") == "unavailable"
+    context.runs.list.return_value = [
+        {"run_id": "r1", "status": "success", "updated_at": "1970-01-01T00:06:00Z"}
+    ]
+    await _run(context, context.runs.create.call_args.kwargs["input"], 660000)
+    assert await feedback.feedback_prompt_status("t1") == "ready"
+    slack_feedback.post_slack_feedback_prompt.assert_not_awaited()
+
+
 async def test_late_completion_cannot_replace_newer_answer(context: Any) -> None:
     context.runs.list.return_value = [{"run_id": "r2", "status": "success"}]
-    await _schedule(context)
-    await feedback._schedule(
-        "t1", context.threads.get.return_value["metadata"], answer_run_id="r1", event_id="answer:r1"
-    )
+    await feedback.mark_answered_question("t1", "r2")
+    await feedback.mark_answered_question("t1", "r1")
     prompt = await feedback.feedback_store().get("t1")
     assert prompt is not None and prompt.answer_run_id == "r2"
 
@@ -170,8 +182,3 @@ async def test_failed_enqueue_allows_later_completion_to_schedule(context: Any) 
     assert context.runs.create.await_count == 2
     await _run(context, payload, 302000)
     slack_feedback.post_slack_feedback_prompt.assert_awaited_once()
-
-
-async def test_web_pr_does_not_schedule_slack_feedback(context: Any) -> None:
-    await feedback.schedule_pr_feedback("t1", {"pull_requests": [{"url": "pr1"}]}, "pr1")
-    context.runs.create.assert_not_awaited()

--- a/tests/dashboard/test_thread_feedback.py
+++ b/tests/dashboard/test_thread_feedback.py
@@ -76,7 +76,11 @@ async def test_only_verified_initiator_gets_feedback(api, monkeypatch, identity)
             monkeypatch.setattr(feedback, "login_for_slack_id", AsyncMock(return_value="owner"))
     visible = await api.client.get("/dashboard/api/threads/t1/feedback")
     submitted = await api.client.post("/dashboard/api/threads/t1/feedback", json={"rating": "good"})
-    assert visible.json()["status"] == ("ready" if identity == "slack_initiator" else "unavailable")
+    assert visible.json() == {
+        "status": "ready" if identity == "slack_initiator" else "unavailable",
+        "rating": None,
+        "comment": "",
+    }
     assert submitted.status_code == (200 if identity == "slack_initiator" else 403)
 
 
@@ -113,3 +117,26 @@ async def test_slack_completion_hides_web_controls(api, status):
     await thread_feedback.complete_feedback_prompt("t1", status)
     response = await api.client.get("/dashboard/api/threads/t1/feedback")
     assert response.json() == {"status": status, "rating": None, "comment": ""}
+
+
+def test_openapi_exposes_one_typed_feedback_response():
+    app = FastAPI()
+    app.include_router(feedback.feedback_router)
+    schema = app.openapi()
+    responses = [
+        schema["paths"][path][method]["responses"]["200"]["content"]["application/json"]["schema"]
+        for path, method in [
+            ("/threads/{thread_id}/feedback", "get"),
+            ("/threads/{thread_id}/feedback", "post"),
+            ("/threads/{thread_id}/feedback/dismiss", "post"),
+        ]
+    ]
+    assert responses[0] == responses[1] == responses[2]
+    model = schema["components"]["schemas"][responses[0]["$ref"].rsplit("/", 1)[1]]
+    assert set(model["properties"]) == {"status", "rating", "comment"}
+    assert set(model["properties"]["status"]["enum"]) == {
+        "unavailable",
+        "ready",
+        "completed",
+        "dismissed",
+    }

--- a/tests/dashboard/test_thread_feedback.py
+++ b/tests/dashboard/test_thread_feedback.py
@@ -55,7 +55,10 @@ async def test_submit_saves_rating_and_comment_and_keeps_first_response(api, rat
 
 
 async def test_dismiss_prevents_later_submission(api):
-    dismissed = await api.client.post("/dashboard/api/threads/t1/feedback/dismiss")
+    dismissed = await api.client.post(
+        "/dashboard/api/threads/t1/feedback", json={"action": "dismiss"}
+    )
+    assert dismissed.status_code == 200
     submitted = await api.client.post("/dashboard/api/threads/t1/feedback", json={"rating": "bad"})
     assert (
         submitted.json()
@@ -64,8 +67,9 @@ async def test_dismiss_prevents_later_submission(api):
     )
 
 
+@pytest.mark.parametrize("payload", [{"rating": "good"}, {"action": "dismiss"}])
 @pytest.mark.parametrize("identity", ["other_member", "unknown_initiator", "slack_initiator"])
-async def test_only_verified_initiator_gets_feedback(api, monkeypatch, identity):
+async def test_only_verified_initiator_gets_feedback(api, monkeypatch, identity, payload):
     if identity == "other_member":
         api.session["sub"] = "other"
     else:
@@ -75,7 +79,7 @@ async def test_only_verified_initiator_gets_feedback(api, monkeypatch, identity)
             api.metadata["source_context"] = {"slack_thread": {"triggering_user_id": "U1"}}
             monkeypatch.setattr(feedback, "login_for_slack_id", AsyncMock(return_value="owner"))
     visible = await api.client.get("/dashboard/api/threads/t1/feedback")
-    submitted = await api.client.post("/dashboard/api/threads/t1/feedback", json={"rating": "good"})
+    submitted = await api.client.post("/dashboard/api/threads/t1/feedback", json=payload)
     assert visible.json() == {
         "status": "ready" if identity == "slack_initiator" else "unavailable",
         "rating": None,
@@ -89,6 +93,9 @@ async def test_only_verified_initiator_gets_feedback(api, monkeypatch, identity)
     [
         {"rating": "other", "comment": "  "},
         {"rating": "great"},
+        {},
+        {"action": "submit"},
+        {"action": "unknown", "rating": "good"},
         {"rating": "good", "comment": "x" * 3001},
     ],
 )
@@ -98,15 +105,16 @@ async def test_invalid_feedback_is_not_saved(api, payload):
     assert (await api.client.get("/dashboard/api/threads/t1/feedback")).json()["status"] == "ready"
 
 
+@pytest.mark.parametrize("payload", [{"rating": "good"}, {"action": "dismiss"}])
 @pytest.mark.parametrize("blocked", ["activity", "cross_origin"])
-async def test_submit_rechecks_eligibility_and_origin(api, blocked):
+async def test_submission_rechecks_eligibility_and_origin(api, blocked, payload):
     headers = {}
     if blocked == "activity":
         api.quiet.return_value = None
     else:
         headers["origin"] = "https://untrusted.example"
     response = await api.client.post(
-        "/dashboard/api/threads/t1/feedback", json={"rating": "good"}, headers=headers
+        "/dashboard/api/threads/t1/feedback", json=payload, headers=headers
     )
     assert response.status_code == (409 if blocked == "activity" else 403)
     assert (await thread_feedback.feedback_store().get("t1")).status == "ready"
@@ -128,10 +136,9 @@ def test_openapi_exposes_one_typed_feedback_response():
         for path, method in [
             ("/threads/{thread_id}/feedback", "get"),
             ("/threads/{thread_id}/feedback", "post"),
-            ("/threads/{thread_id}/feedback/dismiss", "post"),
         ]
     ]
-    assert responses[0] == responses[1] == responses[2]
+    assert responses[0] == responses[1]
     model = schema["components"]["schemas"][responses[0]["$ref"].rsplit("/", 1)[1]]
     assert set(model["properties"]) == {"status", "rating", "comment"}
     assert set(model["properties"]["status"]["enum"]) == {

--- a/tests/dashboard/test_thread_feedback.py
+++ b/tests/dashboard/test_thread_feedback.py
@@ -1,0 +1,115 @@
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from agent import thread_feedback
+from agent.dashboard import feedback, routes
+from agent.dashboard.oauth import require_session
+
+
+@pytest.fixture
+async def api(monkeypatch, fake_store):
+    monkeypatch.setenv("DASHBOARD_BASE_URL", "http://testserver")
+    metadata = {"source": "dashboard", "feedback_initiator_login": "owner"}
+    session = {"sub": "owner"}
+    monkeypatch.setattr(
+        feedback, "fetch_thread_metadata", AsyncMock(side_effect=lambda _: metadata)
+    )
+    quiet = AsyncMock(return_value=0)
+    monkeypatch.setattr(thread_feedback, "_quiet_until", quiet)
+
+    @asynccontextmanager
+    async def unlocked(*args):
+        yield
+
+    monkeypatch.setattr(feedback, "agent_thread_pr_state_lock", unlocked)
+    monkeypatch.setattr(feedback, "langgraph_client", lambda: None)
+    await thread_feedback.feedback_store().put("t1", thread_feedback.Feedback(status="ready"))
+    app = FastAPI()
+    app.include_router(routes.router)
+    app.dependency_overrides[require_session] = lambda: session
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://testserver",
+        headers={"origin": "http://testserver"},
+    ) as client:
+        yield SimpleNamespace(client=client, metadata=metadata, session=session, quiet=quiet)
+
+
+@pytest.mark.parametrize("rating", ["bad", "good", "other"])
+async def test_submit_saves_rating_and_comment_and_keeps_first_response(api, rating):
+    response = await api.client.post(
+        "/dashboard/api/threads/t1/feedback",
+        json={"rating": rating, "comment": "  Helpful detail  "},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"status": "completed", "rating": rating, "comment": "Helpful detail"}
+    duplicate = await api.client.post("/dashboard/api/threads/t1/feedback", json={"rating": "good"})
+    reloaded = await api.client.get("/dashboard/api/threads/t1/feedback")
+    assert response.json() == duplicate.json() == reloaded.json()
+    assert await thread_feedback.feedback_prompt_status("t1") == "completed"
+
+
+async def test_dismiss_prevents_later_submission(api):
+    dismissed = await api.client.post("/dashboard/api/threads/t1/feedback/dismiss")
+    submitted = await api.client.post("/dashboard/api/threads/t1/feedback", json={"rating": "bad"})
+    assert (
+        submitted.json()
+        == dismissed.json()
+        == {"status": "dismissed", "rating": None, "comment": ""}
+    )
+
+
+@pytest.mark.parametrize("identity", ["other_member", "unknown_initiator", "slack_initiator"])
+async def test_only_verified_initiator_gets_feedback(api, monkeypatch, identity):
+    if identity == "other_member":
+        api.session["sub"] = "other"
+    else:
+        api.metadata.pop("feedback_initiator_login")
+        api.metadata["participant_logins"] = {"owner": True}
+        if identity == "slack_initiator":
+            api.metadata["source_context"] = {"slack_thread": {"triggering_user_id": "U1"}}
+            monkeypatch.setattr(feedback, "login_for_slack_id", AsyncMock(return_value="owner"))
+    visible = await api.client.get("/dashboard/api/threads/t1/feedback")
+    submitted = await api.client.post("/dashboard/api/threads/t1/feedback", json={"rating": "good"})
+    assert visible.json()["status"] == ("ready" if identity == "slack_initiator" else "unavailable")
+    assert submitted.status_code == (200 if identity == "slack_initiator" else 403)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"rating": "other", "comment": "  "},
+        {"rating": "great"},
+        {"rating": "good", "comment": "x" * 3001},
+    ],
+)
+async def test_invalid_feedback_is_not_saved(api, payload):
+    response = await api.client.post("/dashboard/api/threads/t1/feedback", json=payload)
+    assert response.status_code == 422
+    assert (await api.client.get("/dashboard/api/threads/t1/feedback")).json()["status"] == "ready"
+
+
+@pytest.mark.parametrize("blocked", ["activity", "cross_origin"])
+async def test_submit_rechecks_eligibility_and_origin(api, blocked):
+    headers = {}
+    if blocked == "activity":
+        api.quiet.return_value = None
+    else:
+        headers["origin"] = "https://untrusted.example"
+    response = await api.client.post(
+        "/dashboard/api/threads/t1/feedback", json={"rating": "good"}, headers=headers
+    )
+    assert response.status_code == (409 if blocked == "activity" else 403)
+    assert (await thread_feedback.feedback_store().get("t1")).status == "ready"
+
+
+@pytest.mark.parametrize("status", ["completed", "dismissed"])
+async def test_slack_completion_hides_web_controls(api, status):
+    await thread_feedback.complete_feedback_prompt("t1", status)
+    response = await api.client.get("/dashboard/api/threads/t1/feedback")
+    assert response.json() == {"status": status, "rating": None, "comment": ""}

--- a/tests/tools/test_mark_question_answered.py
+++ b/tests/tools/test_mark_question_answered.py
@@ -1,0 +1,29 @@
+import importlib
+from unittest.mock import AsyncMock
+
+import pytest
+
+answered = importlib.import_module("agent.tools.mark_question_answered")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("config", [{}, {"configurable": {"thread_id": "t1"}}])
+async def test_missing_run_context_cannot_qualify_feedback(monkeypatch, config):
+    mark = AsyncMock()
+    monkeypatch.setattr(answered, "get_config", lambda: config)
+    monkeypatch.setattr(answered, "mark_answered_question", mark)
+    assert (await answered.mark_question_answered())["success"] is False
+    mark.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_qualifies_only_current_thread_and_run(monkeypatch):
+    mark = AsyncMock()
+    monkeypatch.setattr(
+        answered,
+        "get_config",
+        lambda: {"run_id": "current-run", "configurable": {"thread_id": "current-thread"}},
+    )
+    monkeypatch.setattr(answered, "mark_answered_question", mark)
+    assert await answered.mark_question_answered() == {"success": True}
+    mark.assert_awaited_once_with("current-thread", "current-run")

--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -20,6 +20,7 @@ import { SIBLING_COLUMN_MIN_WIDTH } from "@/features/agents/components/panel/Rig
 import { AgentPromptBar } from "@/features/agents/components/AgentPromptBar"
 import { AgentComposerDock } from "@/features/agents/components/composer/AgentComposerDock"
 import { ThreadPullRequests } from "@/features/agents/components/ThreadPullRequests"
+import { ThreadFeedbackCard } from "@/features/agents/components/ThreadFeedbackCard"
 import {
   readStoredPanelCollapsed,
   writeStoredPanelCollapsed,
@@ -340,6 +341,17 @@ export function AgentThreadView({
               settingUpSandbox={settingUpSandbox}
               pollWorkflowApprovalsWhileActive={isStreaming}
               contentWidthClass="max-w-3xl"
+              footer={
+                !isStreaming &&
+                !sendMessage.isPending &&
+                queuedMessages.length === 0 && (
+                  <ThreadFeedbackCard
+                    key={`${thread.id}:${session.data?.login ?? ""}`}
+                    threadId={thread.id}
+                    login={session.data?.login ?? null}
+                  />
+                )
+              }
             />
           )}
           {!isHydrating && (

--- a/ui/src/features/agents/components/ThreadFeedbackCard.test.tsx
+++ b/ui/src/features/agents/components/ThreadFeedbackCard.test.tsx
@@ -1,0 +1,118 @@
+/** @vitest-environment jsdom */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react"
+import { afterEach, beforeEach, expect, it, vi } from "vitest"
+
+import { ThreadFeedbackCard } from "./ThreadFeedbackCard"
+
+const api = vi.hoisted(() => ({
+  getThreadFeedback: vi.fn(),
+  submitThreadFeedback: vi.fn(),
+  dismissThreadFeedback: vi.fn(),
+}))
+vi.mock("@/features/agents/lib/api", () => ({ agentsApi: api }))
+
+const ready = { status: "ready", rating: null, comment: "" }
+
+function renderCard() {
+  const client = new QueryClient()
+  const card = (active: boolean) => (
+    <QueryClientProvider client={client}>
+      {!active && <ThreadFeedbackCard threadId="thread-1" login="owner" />}
+    </QueryClientProvider>
+  )
+  const result = render(card(false))
+  return (active: boolean) => result.rerender(card(active))
+}
+
+beforeEach(() => {
+  api.getThreadFeedback.mockResolvedValue(ready)
+  api.submitThreadFeedback.mockImplementation(async (_threadId, body) => ({
+    ...body,
+    status: "completed",
+  }))
+  api.dismissThreadFeedback.mockResolvedValue({ ...ready, status: "dismissed" })
+})
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+it.each([
+  { rating: "good", label: "🙂 Good", comment: "" },
+  { rating: "bad", label: "💩 Bad", comment: "The tests still fail." },
+])(
+  "saves $rating and an optional comment only on Submit",
+  async ({ rating, label, comment }) => {
+    renderCard()
+    fireEvent.click(await screen.findByRole("button", { name: "💩 Bad" }))
+    fireEvent.click(screen.getByRole("button", { name: label }))
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: comment },
+    })
+    expect(api.submitThreadFeedback).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole("button", { name: "Submit feedback" }))
+    await screen.findByText("Thanks for your feedback.")
+    expect(api.submitThreadFeedback).toHaveBeenCalledExactlyOnceWith(
+      "thread-1",
+      { rating, comment }
+    )
+    expect(screen.queryByRole("button")).toBeNull()
+  }
+)
+
+it("requires a comment for Other and keeps the draft when saving fails", async () => {
+  api.submitThreadFeedback.mockRejectedValueOnce(new Error("Temporary outage"))
+  renderCard()
+  fireEvent.click(await screen.findByRole("button", { name: "💬 Other" }))
+  const comment = screen.getByRole("textbox", { name: "Comment (required)" })
+  const submit = screen.getByRole("button", {
+    name: "Submit feedback",
+  }) as HTMLButtonElement
+  fireEvent.change(comment, { target: { value: "  " } })
+  expect(submit.disabled).toBe(true)
+  fireEvent.change(comment, { target: { value: " More detail please. " } })
+  fireEvent.click(submit)
+  await screen.findByRole("alert")
+  expect((comment as HTMLTextAreaElement).value).toBe(" More detail please. ")
+  fireEvent.click(submit)
+  await screen.findByText("Thanks for your feedback.")
+  expect(api.submitThreadFeedback).toHaveBeenLastCalledWith("thread-1", {
+    rating: "other",
+    comment: "More detail please.",
+  })
+})
+
+it("dismisses the card without saving a rating", async () => {
+  renderCard()
+  fireEvent.click(await screen.findByRole("button", { name: "Dismiss" }))
+  await waitFor(() => expect(screen.queryByRole("form")).toBeNull())
+  expect(api.submitThreadFeedback).not.toHaveBeenCalled()
+  expect(api.dismissThreadFeedback).toHaveBeenCalledExactlyOnceWith("thread-1")
+})
+
+it("hides during activity and rechecks eligibility before showing a cached prompt", async () => {
+  const setActive = renderCard()
+  await screen.findByRole("form")
+  setActive(true)
+  expect(screen.queryByRole("form")).toBeNull()
+  let resolve!: (value: typeof ready) => void
+  api.getThreadFeedback.mockImplementation(
+    () =>
+      new Promise((done) => {
+        resolve = done
+      })
+  )
+  setActive(false)
+  expect(screen.queryByRole("form")).toBeNull()
+  await act(async () => resolve({ ...ready, status: "unavailable" }))
+  expect(screen.queryByRole("form")).toBeNull()
+})

--- a/ui/src/features/agents/components/ThreadFeedbackCard.test.tsx
+++ b/ui/src/features/agents/components/ThreadFeedbackCard.test.tsx
@@ -16,7 +16,6 @@ import { ThreadFeedbackCard } from "./ThreadFeedbackCard"
 const api = vi.hoisted(() => ({
   getThreadFeedback: vi.fn(),
   submitThreadFeedback: vi.fn(),
-  dismissThreadFeedback: vi.fn(),
 }))
 vi.mock("@/features/agents/lib/api", () => ({ agentsApi: api }))
 
@@ -36,10 +35,10 @@ function renderCard() {
 beforeEach(() => {
   api.getThreadFeedback.mockResolvedValue(ready)
   api.submitThreadFeedback.mockImplementation(async (_threadId, body) => ({
+    ...ready,
     ...body,
-    status: "completed",
+    status: body.action === "dismiss" ? "dismissed" : "completed",
   }))
-  api.dismissThreadFeedback.mockResolvedValue({ ...ready, status: "dismissed" })
 })
 afterEach(() => {
   cleanup()
@@ -95,8 +94,9 @@ it("dismisses the card without saving a rating", async () => {
   renderCard()
   fireEvent.click(await screen.findByRole("button", { name: "Dismiss" }))
   await waitFor(() => expect(screen.queryByRole("form")).toBeNull())
-  expect(api.submitThreadFeedback).not.toHaveBeenCalled()
-  expect(api.dismissThreadFeedback).toHaveBeenCalledExactlyOnceWith("thread-1")
+  expect(api.submitThreadFeedback).toHaveBeenCalledExactlyOnceWith("thread-1", {
+    action: "dismiss",
+  })
 })
 
 it("hides during activity and rechecks eligibility before showing a cached prompt", async () => {

--- a/ui/src/features/agents/components/ThreadFeedbackCard.tsx
+++ b/ui/src/features/agents/components/ThreadFeedbackCard.tsx
@@ -1,0 +1,130 @@
+import { useMutation, useQuery } from "@tanstack/react-query"
+import { useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Textarea } from "@/components/ui/textarea"
+import { agentsApi } from "@/features/agents/lib/api"
+import type { ThreadFeedbackRating } from "@/features/agents/lib/api"
+
+const ratings: Array<{ value: ThreadFeedbackRating; label: string }> = [
+  { value: "bad", label: "💩 Bad" },
+  { value: "good", label: "🙂 Good" },
+  { value: "other", label: "💬 Other" },
+]
+
+export function ThreadFeedbackCard({
+  threadId,
+  login,
+}: {
+  threadId: string
+  login: string | null
+}) {
+  const mutation = useMutation({
+    mutationFn: (
+      value: { rating: ThreadFeedbackRating; comment: string } | "dismiss"
+    ) =>
+      value === "dismiss"
+        ? agentsApi.dismissThreadFeedback(threadId)
+        : agentsApi.submitThreadFeedback(threadId, value),
+  })
+  const query = useQuery({
+    queryKey: ["thread-feedback", threadId, login],
+    queryFn: () => agentsApi.getThreadFeedback(threadId),
+    enabled: Boolean(login),
+    staleTime: 0,
+    refetchInterval: (current) => {
+      const status = mutation.data?.status ?? current.state.data?.status
+      return status === "completed" || status === "dismissed" ? false : 30_000
+    },
+    retry: false,
+  })
+  const [rating, setRating] = useState<ThreadFeedbackRating | null>(null)
+  const [comment, setComment] = useState("")
+  const feedback =
+    mutation.data ??
+    (query.isFetchedAfterMount && !query.isError ? query.data : undefined)
+
+  if (
+    !login ||
+    (feedback?.status !== "ready" && feedback?.status !== "completed")
+  ) {
+    return null
+  }
+
+  if (feedback.status === "completed") {
+    return (
+      <div
+        role="status"
+        className="mt-4 rounded-xl border border-border bg-muted/30 px-4 py-3 text-sm text-muted-foreground"
+      >
+        Thanks for your feedback.
+      </div>
+    )
+  }
+
+  const canSubmit =
+    rating !== null && (rating !== "other" || comment.trim().length > 0)
+  return (
+    <form
+      aria-label="Thread feedback"
+      className="mt-4 space-y-3 rounded-xl border border-border bg-muted/30 p-4"
+      onSubmit={(event) => {
+        event.preventDefault()
+        if (!canSubmit || mutation.isPending || !rating) return
+        mutation.mutate({ rating, comment: comment.trim() })
+      }}
+    >
+      <p className="text-sm font-medium">How did Open SWE do?</p>
+      <div className="flex gap-2" role="group" aria-label="Rating">
+        {ratings.map((option) => (
+          <Button
+            key={option.value}
+            type="button"
+            variant={rating === option.value ? "secondary" : "outline"}
+            size="sm"
+            aria-pressed={rating === option.value}
+            disabled={mutation.isPending}
+            onClick={() => setRating(option.value)}
+          >
+            {option.label}
+          </Button>
+        ))}
+      </div>
+      <label className="flex flex-col gap-1.5 text-xs text-muted-foreground">
+        Comment ({rating === "other" ? "required" : "optional"})
+        <Textarea
+          value={comment}
+          onChange={(event) => setComment(event.target.value)}
+          required={rating === "other"}
+          maxLength={3000}
+          disabled={mutation.isPending}
+          placeholder="What worked well? What could be better?"
+          className="min-h-20 text-sm"
+        />
+      </label>
+      {mutation.isError && (
+        <p role="alert" className="text-xs text-destructive">
+          Your feedback could not be saved. Please try again.
+        </p>
+      )}
+      <div className="flex items-center gap-2">
+        <Button
+          type="submit"
+          size="sm"
+          disabled={!canSubmit || mutation.isPending}
+        >
+          {mutation.isPending ? "Saving…" : "Submit feedback"}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          disabled={mutation.isPending}
+          onClick={() => mutation.mutate("dismiss")}
+        >
+          Dismiss
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/ui/src/features/agents/components/ThreadFeedbackCard.tsx
+++ b/ui/src/features/agents/components/ThreadFeedbackCard.tsx
@@ -4,7 +4,10 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
 import { agentsApi } from "@/features/agents/lib/api"
-import type { ThreadFeedbackRating } from "@/features/agents/lib/api"
+import type {
+  ThreadFeedbackRating,
+  ThreadFeedbackSubmission,
+} from "@/features/agents/lib/api"
 
 const ratings: Array<{ value: ThreadFeedbackRating; label: string }> = [
   { value: "bad", label: "💩 Bad" },
@@ -20,12 +23,8 @@ export function ThreadFeedbackCard({
   login: string | null
 }) {
   const mutation = useMutation({
-    mutationFn: (
-      value: { rating: ThreadFeedbackRating; comment: string } | "dismiss"
-    ) =>
-      value === "dismiss"
-        ? agentsApi.dismissThreadFeedback(threadId)
-        : agentsApi.submitThreadFeedback(threadId, value),
+    mutationFn: (value: ThreadFeedbackSubmission) =>
+      agentsApi.submitThreadFeedback(threadId, value),
   })
   const query = useQuery({
     queryKey: ["thread-feedback", threadId, login],
@@ -120,7 +119,7 @@ export function ThreadFeedbackCard({
           size="sm"
           variant="ghost"
           disabled={mutation.isPending}
-          onClick={() => mutation.mutate("dismiss")}
+          onClick={() => mutation.mutate({ action: "dismiss" })}
         >
           Dismiss
         </Button>

--- a/ui/src/features/agents/components/messages/Messages.tsx
+++ b/ui/src/features/agents/components/messages/Messages.tsx
@@ -61,6 +61,7 @@ export const Messages = memo(function MessagesComponent({
   scrollKey,
   showPlanArtifact = false,
   emptyState,
+  footer,
   pollWorkflowApprovalsWhileActive = false,
   queuedMessages = [],
   isStreaming,
@@ -167,6 +168,7 @@ export const Messages = memo(function MessagesComponent({
               />
             )}
             <QueuedMessages queuedMessages={queuedMessages} />
+            {footer}
             <ThinkingSpinner
               isActive={
                 !!(isThinking || streamIsLoading || isStreaming) &&

--- a/ui/src/features/agents/components/messages/types.ts
+++ b/ui/src/features/agents/components/messages/types.ts
@@ -24,6 +24,7 @@ export interface MessagesProps extends ApprovalCallbacks {
   scrollKey?: string
   showPlanArtifact?: boolean
   emptyState?: React.ReactNode
+  footer?: React.ReactNode
   pollWorkflowApprovalsWhileActive?: boolean
   queuedMessages?: Array<QueuedThreadMessage>
   isStreaming: boolean

--- a/ui/src/features/agents/lib/api.ts
+++ b/ui/src/features/agents/lib/api.ts
@@ -262,8 +262,38 @@ export interface PullRequestSnapshot {
   state: PullRequestLiveState | null
 }
 
+export type ThreadFeedbackRating = "bad" | "good" | "other"
+
+export interface ThreadFeedback {
+  status: "unavailable" | "ready" | "completed" | "dismissed"
+  rating: ThreadFeedbackRating | null
+  comment: string
+}
+
 export const agentsApi = {
   langGraphApiUrl: agentsLangGraphApiUrl,
+  getThreadFeedback: (threadId: string) =>
+    agentsRequest<ThreadFeedback>(
+      `/threads/${encodeURIComponent(threadId)}/feedback`
+    ),
+  submitThreadFeedback: (
+    threadId: string,
+    body: { rating: ThreadFeedbackRating; comment: string }
+  ) =>
+    agentsRequest<ThreadFeedback>(
+      `/threads/${encodeURIComponent(threadId)}/feedback`,
+      {
+        method: "POST",
+        body: JSON.stringify(body),
+      }
+    ),
+  dismissThreadFeedback: (threadId: string) =>
+    agentsRequest<ThreadFeedback>(
+      `/threads/${encodeURIComponent(threadId)}/feedback/dismiss`,
+      {
+        method: "POST",
+      }
+    ),
   listThreadProjects: (
     params: {
       includeResolved?: boolean

--- a/ui/src/features/agents/lib/api.ts
+++ b/ui/src/features/agents/lib/api.ts
@@ -264,6 +264,10 @@ export interface PullRequestSnapshot {
 
 export type ThreadFeedbackRating = "bad" | "good" | "other"
 
+export type ThreadFeedbackSubmission =
+  | { action?: "submit"; rating: ThreadFeedbackRating; comment: string }
+  | { action: "dismiss" }
+
 export interface ThreadFeedback {
   status: "unavailable" | "ready" | "completed" | "dismissed"
   rating: ThreadFeedbackRating | null
@@ -276,22 +280,12 @@ export const agentsApi = {
     agentsRequest<ThreadFeedback>(
       `/threads/${encodeURIComponent(threadId)}/feedback`
     ),
-  submitThreadFeedback: (
-    threadId: string,
-    body: { rating: ThreadFeedbackRating; comment: string }
-  ) =>
+  submitThreadFeedback: (threadId: string, body: ThreadFeedbackSubmission) =>
     agentsRequest<ThreadFeedback>(
       `/threads/${encodeURIComponent(threadId)}/feedback`,
       {
         method: "POST",
         body: JSON.stringify(body),
-      }
-    ),
-  dismissThreadFeedback: (threadId: string) =>
-    agentsRequest<ThreadFeedback>(
-      `/threads/${encodeURIComponent(threadId)}/feedback/dismiss`,
-      {
-        method: "POST",
       }
     ),
   listThreadProjects: (


### PR DESCRIPTION
Adds a feedback card for the thread initiator after a merged PR or an explicitly answered question, using the five-minute quiet period and shared feedback state from #2598.

The card offers horizontal 💩 Bad, 🙂 Good, and 💬 Other choices. Rating clicks only update the draft; Submit saves the rating and comment together and replaces the form with a completed message. Other requires a comment, and Dismiss hides the prompt. New activity hides the form and clears the draft until feedback is eligible again.

Includes the dashboard API, OpenAPI schema, initiator metadata, and the agent tool for marking web questions answered. Web feedback stays in Open SWE, with completion and dismissal shared across Slack and web.

Builds on the Slack feedback and scheduling changes merged in #2598. This PR targets `main` and contains only the web additions.


**Local thread test**

![Feedback form shown in the local thread](https://raw.githubusercontent.com/langchain-ai/open-swe/c49ebaf80155cdebe5a76d0a032828035c1ce65c/pr-screenshots/web-feedback-local.png)

**After submitting feedback locally**

![Thank-you message after local feedback submission](https://raw.githubusercontent.com/langchain-ai/open-swe/c49ebaf80155cdebe5a76d0a032828035c1ce65c/pr-screenshots/web-feedback-local-completed.png)
