### PR TITLE
ci: close stale pull requests automatically

### DIFF
--- a/.github/scripts/labeling/close-old-prs.js
+++ b/.github/scripts/labeling/close-old-prs.js
@@ -2,8 +2,8 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000
 
 const DEFAULT_BYPASS_LABEL = "do-not-close"
 const DEFAULT_PENDING_DELETION_LABEL = "pending-deletion"
-const DEFAULT_WARNING_DAYS = 14
-const DEFAULT_CLOSE_DAYS = 30
+const DEFAULT_WARNING_DAYS = 7
+const DEFAULT_CLOSE_DAYS = 14
 const DEFAULT_MAX_ITEMS = 1000
 const COMMENT_MARKER = "<!-- old-pr-auto-close -->"
 const WORKFLOW_BOT_LOGIN = "github-actions[bot]"

--- a/.github/scripts/labeling/close-old-prs.js
+++ b/.github/scripts/labeling/close-old-prs.js
@@ -1,0 +1,487 @@
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+const DEFAULT_BYPASS_LABEL = "do-not-close"
+const DEFAULT_PENDING_DELETION_LABEL = "pending-deletion"
+const DEFAULT_WARNING_DAYS = 14
+const DEFAULT_CLOSE_DAYS = 30
+const DEFAULT_MAX_ITEMS = 1000
+const COMMENT_MARKER = "<!-- old-pr-auto-close -->"
+const WORKFLOW_BOT_LOGIN = "github-actions[bot]"
+
+function parsePositiveInt(value, fallback, name) {
+  if (value === undefined || value === null || value === "") return fallback
+  if (!/^\d+$/.test(String(value).trim())) {
+    throw new Error(`${name} must be a positive integer, got "${value}"`)
+  }
+  const parsed = Number.parseInt(value, 10)
+  if (parsed <= 0) {
+    throw new Error(`${name} must be a positive integer, got "${value}"`)
+  }
+  return parsed
+}
+
+function ageInDays(createdAt, now) {
+  const created = new Date(createdAt).getTime()
+  if (!Number.isFinite(created)) {
+    throw new Error(`Unparseable created date: ${JSON.stringify(createdAt)}`)
+  }
+  return Math.floor((now.getTime() - created) / MS_PER_DAY)
+}
+
+function labelNames(labels) {
+  return labels.map((label) => (typeof label === "string" ? label : label.name))
+}
+
+async function ensureLabel({ github, owner, repo, name, color, description }) {
+  try {
+    await github.rest.issues.getLabel({ owner, repo, name })
+  } catch (error) {
+    if (error.status !== 404) throw error
+    try {
+      await github.rest.issues.createLabel({
+        owner,
+        repo,
+        name,
+        color,
+        description,
+      })
+    } catch (createError) {
+      if (createError.status !== 422) throw createError
+      await github.rest.issues.getLabel({ owner, repo, name })
+    }
+  }
+}
+
+async function getLivePr({ github, owner, repo, number }) {
+  const { data: pr } = await github.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: number,
+  })
+  return {
+    labels: labelNames(pr.labels ?? []),
+    state: pr.state,
+  }
+}
+
+async function addIssueLabel({
+  github,
+  owner,
+  repo,
+  issueNumber,
+  name,
+  labels,
+}) {
+  if (labels.includes(name)) return
+  await github.rest.issues.addLabels({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    labels: [name],
+  })
+  labels.push(name)
+}
+
+async function removeIssueLabel({
+  github,
+  owner,
+  repo,
+  issueNumber,
+  name,
+  labels,
+}) {
+  if (!labels.includes(name)) return false
+  try {
+    await github.rest.issues.removeLabel({
+      owner,
+      repo,
+      issue_number: issueNumber,
+      name,
+    })
+  } catch (error) {
+    if (error.status !== 404) throw error
+  }
+  labels.splice(labels.indexOf(name), 1)
+  return true
+}
+
+async function findMarkerComment({ github, owner, repo, issueNumber }) {
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: issueNumber,
+    per_page: 100,
+  })
+  return comments.find(
+    (comment) =>
+      comment.user?.login === WORKFLOW_BOT_LOGIN &&
+      comment.user?.type === "Bot" &&
+      comment.body?.includes(COMMENT_MARKER)
+  )
+}
+
+async function minimizeMarkerComment({
+  github,
+  core,
+  owner,
+  repo,
+  issueNumber,
+}) {
+  try {
+    const marker = await findMarkerComment({ github, owner, repo, issueNumber })
+    if (!marker) return
+    await github.graphql(
+      `
+      mutation($id: ID!) {
+        minimizeComment(input: {subjectId: $id, classifier: OUTDATED}) {
+          minimizedComment { isMinimized }
+        }
+      }
+    `,
+      { id: marker.node_id }
+    )
+  } catch (error) {
+    core.warning(
+      `Could not minimize stale warning on PR #${issueNumber}: ${error.message}`
+    )
+  }
+}
+
+async function applyBypassLabel({
+  github,
+  owner,
+  repo,
+  issueNumber,
+  bypassLabel = DEFAULT_BYPASS_LABEL,
+}) {
+  const { data: issue } = await github.rest.issues.get({
+    owner,
+    repo,
+    issue_number: issueNumber,
+  })
+  if ((issue.labels ?? []).some((label) => label.name === bypassLabel))
+    return false
+  await github.rest.issues.addLabels({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    labels: [bypassLabel],
+  })
+  return true
+}
+
+async function clearPendingDeletion({
+  github,
+  core,
+  owner,
+  repo,
+  issueNumber,
+  pendingLabel = DEFAULT_PENDING_DELETION_LABEL,
+}) {
+  let removed = true
+  try {
+    await github.rest.issues.removeLabel({
+      owner,
+      repo,
+      issue_number: issueNumber,
+      name: pendingLabel,
+    })
+  } catch (error) {
+    if (error.status !== 404) throw error
+    removed = false
+  }
+  await minimizeMarkerComment({ github, core, owner, repo, issueNumber })
+  return removed
+}
+
+function warningBody({ warningDays, closeDays, bypassLabel }) {
+  const noticeDays = closeDays - warningDays
+  return [
+    COMMENT_MARKER,
+    `This PR has been open for at least ${warningDays} days.`,
+    "",
+    `It will be closed automatically once it has been open for at least ${closeDays} days and this warning is at least ${noticeDays} days old, unless a maintainer applies the \`${bypassLabel}\` label or comments:`,
+    "",
+    "```",
+    "!keep-open",
+    "```",
+  ].join("\n")
+}
+
+function closeBody({ closeDays, bypassLabel }) {
+  return [
+    COMMENT_MARKER,
+    `This PR has been open for at least ${closeDays} days and is being closed automatically.`,
+    "",
+    `If this work is still active, feel free to reopen it or open a fresh PR. The \`${bypassLabel}\` label (or a maintainer commenting \`!keep-open\`) exempts a PR from this cleanup.`,
+  ].join("\n")
+}
+
+async function refreshCloseCandidate({
+  github,
+  core,
+  owner,
+  repo,
+  number,
+  bypassLabel,
+  pendingDeletionLabel,
+}) {
+  const live = await getLivePr({ github, owner, repo, number })
+  if (live.state === "open" && !live.labels.includes(bypassLabel))
+    return live.labels
+  await removeIssueLabel({
+    github,
+    owner,
+    repo,
+    issueNumber: number,
+    name: pendingDeletionLabel,
+    labels: live.labels,
+  })
+  if (live.labels.includes(bypassLabel)) {
+    await minimizeMarkerComment({
+      github,
+      core,
+      owner,
+      repo,
+      issueNumber: number,
+    })
+  }
+  return null
+}
+
+async function searchOpenPrs({ github, owner, repo, maxItems, core }) {
+  const items = []
+  let incomplete = false
+  try {
+    for await (const response of github.paginate.iterator(
+      github.rest.search.issuesAndPullRequests,
+      {
+        q: `repo:${owner}/${repo} is:pr is:open`,
+        per_page: 100,
+        sort: "created",
+        order: "asc",
+      }
+    )) {
+      incomplete ||= response.data.incomplete_results === true
+      for (const item of response.data) {
+        items.push(item)
+        if (items.length >= maxItems) {
+          core.warning(
+            `Reached maxItems cap (${maxItems}); some open PRs were not processed.`
+          )
+          return { items, incomplete }
+        }
+      }
+    }
+  } catch (error) {
+    core.warning(
+      `PR search failed after ${items.length} result(s): ${error.message}`
+    )
+    incomplete = true
+  }
+  return { items, incomplete }
+}
+
+async function processPr({
+  github,
+  core,
+  owner,
+  repo,
+  item,
+  now,
+  bypassLabel,
+  pendingDeletionLabel,
+  warningDays,
+  closeDays,
+}) {
+  const number = item.number
+  const age = ageInDays(item.created_at, now)
+  if (age < warningDays) return "skipped"
+
+  const labels = await refreshCloseCandidate({
+    github,
+    core,
+    owner,
+    repo,
+    number,
+    bypassLabel,
+    pendingDeletionLabel,
+  })
+  if (labels === null) return "skipped"
+
+  const existing = await findMarkerComment({
+    github,
+    owner,
+    repo,
+    issueNumber: number,
+  })
+  if (!existing) {
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: number,
+      body: warningBody({ warningDays, closeDays, bypassLabel }),
+    })
+    const refreshedLabels = await refreshCloseCandidate({
+      github,
+      core,
+      owner,
+      repo,
+      number,
+      bypassLabel,
+      pendingDeletionLabel,
+    })
+    if (refreshedLabels === null) return "skipped"
+    await addIssueLabel({
+      github,
+      owner,
+      repo,
+      issueNumber: number,
+      name: pendingDeletionLabel,
+      labels: refreshedLabels,
+    })
+    return "warned"
+  }
+
+  const warningAge = ageInDays(existing.created_at, now)
+  if (age >= closeDays && warningAge >= closeDays - warningDays) {
+    const refreshedLabels = await refreshCloseCandidate({
+      github,
+      core,
+      owner,
+      repo,
+      number,
+      bypassLabel,
+      pendingDeletionLabel,
+    })
+    if (refreshedLabels === null) return "skipped"
+    await github.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: existing.id,
+      body: closeBody({ closeDays, bypassLabel }),
+    })
+    await github.rest.pulls.update({
+      owner,
+      repo,
+      pull_number: number,
+      state: "closed",
+    })
+    await removeIssueLabel({
+      github,
+      owner,
+      repo,
+      issueNumber: number,
+      name: pendingDeletionLabel,
+      labels: refreshedLabels,
+    })
+    return "closed"
+  }
+
+  await addIssueLabel({
+    github,
+    owner,
+    repo,
+    issueNumber: number,
+    name: pendingDeletionLabel,
+    labels,
+  })
+  return "skipped"
+}
+
+async function run({ github, context, core, options = {} }) {
+  const { owner, repo } = context.repo
+  const bypassLabel =
+    options.bypassLabel || process.env.BYPASS_LABEL || DEFAULT_BYPASS_LABEL
+  const pendingDeletionLabel =
+    options.pendingDeletionLabel ||
+    process.env.PENDING_DELETION_LABEL ||
+    DEFAULT_PENDING_DELETION_LABEL
+  const warningDays = parsePositiveInt(
+    options.warningDays ?? process.env.WARNING_DAYS,
+    DEFAULT_WARNING_DAYS,
+    "warningDays"
+  )
+  const closeDays = parsePositiveInt(
+    options.closeDays ?? process.env.CLOSE_DAYS,
+    DEFAULT_CLOSE_DAYS,
+    "closeDays"
+  )
+  const maxItems = parsePositiveInt(
+    options.maxItems ?? process.env.MAX_ITEMS,
+    DEFAULT_MAX_ITEMS,
+    "maxItems"
+  )
+  if (warningDays >= closeDays) {
+    throw new Error(
+      `warningDays (${warningDays}) must be less than closeDays (${closeDays})`
+    )
+  }
+
+  await ensureLabel({
+    github,
+    owner,
+    repo,
+    name: bypassLabel,
+    color: "0e8a16",
+    description: "Bypass automatic closure of old PRs",
+  })
+  await ensureLabel({
+    github,
+    owner,
+    repo,
+    name: pendingDeletionLabel,
+    color: "fbca04",
+    description: "PR is past the auto-close warning threshold",
+  })
+
+  const { items, incomplete } = await searchOpenPrs({
+    github,
+    owner,
+    repo,
+    maxItems,
+    core,
+  })
+  const summary = { checked: 0, warned: 0, closed: 0, skipped: 0, errors: [] }
+  for (const item of items) {
+    summary.checked += 1
+    try {
+      const result = await processPr({
+        github,
+        core,
+        owner,
+        repo,
+        item,
+        now: options.now ?? new Date(),
+        bypassLabel,
+        pendingDeletionLabel,
+        warningDays,
+        closeDays,
+      })
+      summary[result] += 1
+    } catch (error) {
+      core.warning(`PR #${item.number} failed: ${error.stack ?? error.message}`)
+      summary.errors.push(`#${item.number}: ${error.message}`)
+    }
+  }
+
+  core.info(
+    `Checked ${summary.checked}; warned ${summary.warned}; closed ${summary.closed}; ` +
+      `skipped ${summary.skipped}; errors ${summary.errors.length}`
+  )
+  if (incomplete) summary.errors.unshift("PR search did not complete")
+  if (summary.errors.length > 0) core.setFailed(summary.errors.join("; "))
+  return summary
+}
+
+module.exports = {
+  run,
+  applyBypassLabel,
+  clearPendingDeletion,
+  warningBody,
+  closeBody,
+  ageInDays,
+  COMMENT_MARKER,
+  DEFAULT_BYPASS_LABEL,
+  DEFAULT_PENDING_DELETION_LABEL,
+}

--- a/.github/scripts/labeling/close-old-prs.test.js
+++ b/.github/scripts/labeling/close-old-prs.test.js
@@ -1,0 +1,124 @@
+const assert = require("node:assert/strict")
+const test = require("node:test")
+
+const { run, ageInDays, closeBody, warningBody } = require("./close-old-prs.js")
+
+function fixture({ createdAt, comments = [], labels = [] }) {
+  const calls = []
+  const github = {
+    graphql: async () => {},
+    paginate: Object.assign(async () => comments, {
+      iterator: async function* () {
+        yield {
+          data: Object.assign([{ number: 1, created_at: createdAt }], {
+            incomplete_results: false,
+          }),
+        }
+      },
+    }),
+    rest: {
+      search: {
+        issuesAndPullRequests: async () => {},
+      },
+      issues: {
+        addLabels: async (input) => calls.push(["addLabels", input]),
+        createComment: async (input) => calls.push(["createComment", input]),
+        createLabel: async (input) => calls.push(["createLabel", input]),
+        getLabel: async () => {},
+        get: async () => ({
+          data: { labels: labels.map((name) => ({ name })) },
+        }),
+        listComments: async () => {},
+        removeLabel: async (input) => calls.push(["removeLabel", input]),
+        updateComment: async (input) => calls.push(["updateComment", input]),
+      },
+      pulls: {
+        get: async () => ({
+          data: { state: "open", labels: labels.map((name) => ({ name })) },
+        }),
+        update: async (input) => calls.push(["updatePull", input]),
+      },
+    },
+  }
+  const core = {
+    info: () => {},
+    warning: (message) => calls.push(["warning", message]),
+    setFailed: (message) => calls.push(["setFailed", message]),
+  }
+  return { calls, core, github }
+}
+
+const context = { repo: { owner: "langchain-ai", repo: "open-swe" } }
+const now = new Date("2026-09-10T00:00:00Z")
+
+test("calculates PR age in whole days", () => {
+  assert.equal(ageInDays("2026-08-26T12:00:00Z", now), 14)
+})
+
+test("warns at 14 days and marks the PR pending deletion", async () => {
+  const { calls, core, github } = fixture({ createdAt: "2026-08-26T00:00:00Z" })
+
+  const summary = await run({ github, context, core, options: { now } })
+
+  assert.equal(summary.warned, 1)
+  assert.ok(calls.some(([name]) => name === "createComment"))
+  assert.ok(
+    calls.some(
+      ([name, input]) =>
+        name === "addLabels" && input.labels.includes("pending-deletion")
+    )
+  )
+})
+
+test("closes at 30 days after a full warning period", async () => {
+  const body = warningBody({
+    warningDays: 14,
+    closeDays: 30,
+    bypassLabel: "do-not-close",
+  })
+  const { calls, core, github } = fixture({
+    createdAt: "2026-08-11T00:00:00Z",
+    comments: [
+      {
+        id: 10,
+        created_at: "2026-08-25T00:00:00Z",
+        body,
+        user: { login: "github-actions[bot]", type: "Bot" },
+      },
+    ],
+    labels: ["pending-deletion"],
+  })
+
+  const summary = await run({ github, context, core, options: { now } })
+
+  assert.equal(summary.closed, 1)
+  assert.ok(
+    calls.some(
+      ([name, input]) => name === "updatePull" && input.state === "closed"
+    )
+  )
+  assert.ok(
+    calls.some(
+      ([name, input]) =>
+        name === "updateComment" &&
+        input.body ===
+          closeBody({
+            closeDays: 30,
+            bypassLabel: "do-not-close",
+          })
+    )
+  )
+})
+
+test("does not warn PRs with do-not-close", async () => {
+  const { calls, core, github } = fixture({
+    createdAt: "2026-08-11T00:00:00Z",
+    labels: ["do-not-close"],
+  })
+
+  const summary = await run({ github, context, core, options: { now } })
+
+  assert.equal(summary.skipped, 1)
+  assert.ok(!calls.some(([name]) => name === "createComment"))
+  assert.ok(!calls.some(([name]) => name === "updatePull"))
+})

--- a/.github/scripts/labeling/close-old-prs.test.js
+++ b/.github/scripts/labeling/close-old-prs.test.js
@@ -55,8 +55,8 @@ test("calculates PR age in whole days", () => {
   assert.equal(ageInDays("2026-08-26T12:00:00Z", now), 14)
 })
 
-test("warns at 14 days and marks the PR pending deletion", async () => {
-  const { calls, core, github } = fixture({ createdAt: "2026-08-26T00:00:00Z" })
+test("warns at 7 days and marks the PR pending deletion", async () => {
+  const { calls, core, github } = fixture({ createdAt: "2026-09-03T00:00:00Z" })
 
   const summary = await run({ github, context, core, options: { now } })
 
@@ -70,18 +70,18 @@ test("warns at 14 days and marks the PR pending deletion", async () => {
   )
 })
 
-test("closes at 30 days after a full warning period", async () => {
+test("closes at 14 days after a full warning period", async () => {
   const body = warningBody({
-    warningDays: 14,
-    closeDays: 30,
+    warningDays: 7,
+    closeDays: 14,
     bypassLabel: "do-not-close",
   })
   const { calls, core, github } = fixture({
-    createdAt: "2026-08-11T00:00:00Z",
+    createdAt: "2026-08-27T00:00:00Z",
     comments: [
       {
         id: 10,
-        created_at: "2026-08-25T00:00:00Z",
+        created_at: "2026-09-03T00:00:00Z",
         body,
         user: { login: "github-actions[bot]", type: "Bot" },
       },
@@ -103,7 +103,7 @@ test("closes at 30 days after a full warning period", async () => {
         name === "updateComment" &&
         input.body ===
           closeBody({
-            closeDays: 30,
+            closeDays: 14,
             bypassLabel: "do-not-close",
           })
     )

--- a/.github/workflows/clear_pending_deletion.yml
+++ b/.github/workflows/clear_pending_deletion.yml
@@ -1,0 +1,45 @@
+name: Clear Pending Deletion
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  clear-pending-deletion:
+    if: >-
+      github.event.label.name == 'do-not-close' &&
+      contains(github.event.pull_request.labels.*.name, 'pending-deletion')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Clear pending-deletion label
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          retries: 3
+          script: |
+            const {
+              clearPendingDeletion,
+            } = require('./.github/scripts/labeling/close-old-prs.js');
+            await clearPendingDeletion({
+              github,
+              core,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issueNumber: context.payload.pull_request.number,
+            });

--- a/.github/workflows/close_old_prs.yml
+++ b/.github/workflows/close_old_prs.yml
@@ -1,0 +1,39 @@
+name: Close Old PRs
+
+on:
+  schedule:
+    - cron: "17 14 * * *"
+  workflow_dispatch:
+    inputs:
+      max_items:
+        description: "Maximum open PRs to process"
+        default: "1000"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  close-old-prs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Warn or close old PRs
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          MAX_ITEMS: ${{ inputs.max_items || '1000' }}
+        with:
+          script: |
+            const { run } = require('./.github/scripts/labeling/close-old-prs.js');
+            await run({ github, context, core });

--- a/.github/workflows/keep_open_on_comment.yml
+++ b/.github/workflows/keep_open_on_comment.yml
@@ -1,0 +1,62 @@
+name: Keep Old PR Open
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  apply-bypass-label:
+    if: >-
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '!keep-open') &&
+      contains(fromJSON('["MEMBER", "OWNER", "COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Apply do-not-close label
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          retries: 3
+          script: |
+            const { owner, repo } = context.repo;
+            const issueNumber = context.payload.issue.number;
+            const commentId = context.payload.comment.id;
+            const {
+              applyBypassLabel,
+              clearPendingDeletion,
+            } = require('./.github/scripts/labeling/close-old-prs.js');
+
+            await github.rest.reactions.createForIssueComment({
+              owner,
+              repo,
+              comment_id: commentId,
+              content: 'eyes',
+            });
+            await applyBypassLabel({ github, owner, repo, issueNumber });
+            await clearPendingDeletion({
+              github,
+              core,
+              owner,
+              repo,
+              issueNumber,
+            });
+            await github.rest.reactions.createForIssueComment({
+              owner,
+              repo,
+              comment_id: commentId,
+              content: 'rocket',
+            });


### PR DESCRIPTION
- Warn open PRs after 7 days and close them after 14 days.
- Apply `pending-deletion` during the warning window.
- Let maintainers protect active work with `do-not-close` or `!keep-open`.
- Port the deterministic Deep Agents cleanup workflow with focused coverage.

Made by [Open SWE](https://openswe.vercel.app/agents/b97bcfda-ad06-5595-b51c-f4aac42e6eaf) · openai:gpt-5.6-sol (high)