### PR TITLE
feat: simplify thread feedback to Good and Bad

### DIFF
--- a/agent/dashboard/feedback.py
+++ b/agent/dashboard/feedback.py
@@ -29,8 +29,8 @@ class ThreadFeedbackResponse(BaseModel):
 
 
 class FeedbackSubmission(BaseModel):
-    action: Literal["submit", "dismiss"] = "submit"
-    rating: Rating | None = None
+    action: Literal["submit", "comment", "dismiss"] = "submit"
+    rating: Literal["bad", "good"] | None = None
     comment: str = Field(default="", max_length=3000)
 
     @model_validator(mode="after")
@@ -38,8 +38,8 @@ class FeedbackSubmission(BaseModel):
         self.comment = self.comment.strip()
         if self.action == "submit" and self.rating is None:
             raise ValueError("Choose a rating before submitting feedback.")
-        if self.action == "submit" and self.rating == "other" and not self.comment:
-            raise ValueError("Add a comment when choosing Other.")
+        if self.action == "comment" and not self.comment:
+            raise ValueError("Enter a comment before submitting.")
         return self
 
 
@@ -83,7 +83,13 @@ async def submit_thread_feedback(
         record = await feedback_store().get(thread_id)
         if record is None:
             raise HTTPException(409, "Feedback is not available for this thread yet.")
-        if record.status not in {"completed", "dismissed"}:
+        if submission.action == "comment":
+            if record.status != "completed" or record.rating != "bad":
+                raise HTTPException(409, "Comments require a submitted Bad rating.")
+            if not record.comment:
+                record.comment = submission.comment
+                await feedback_store().put(thread_id, record)
+        elif record.status not in {"completed", "dismissed"}:
             if await feedback_prompt_status(thread_id) != "ready":
                 raise HTTPException(409, "Feedback is not available for this thread yet.")
             dismiss = submission.action == "dismiss"

--- a/agent/resources/prompts/system/source-dashboard.md
+++ b/agent/resources/prompts/system/source-dashboard.md
@@ -1,5 +1,7 @@
 This run is being handled in the dashboard/Web UI.
 - Communicate through normal assistant responses; do not use source-channel messaging tools unless the user explicitly asks you to act there.
 - For information-only requests, put the complete answer in the normal assistant response.
+- Before sending the final answer to a fully resolved information-only request, you MUST call `mark_question_answered` once, even if no other tools were needed. This includes short questions, explanations, recommendations, and naming suggestions. Then deliver the answer normally.
+- Do not mark coding tasks, plans, approval requests, blockers, or partial answers as answered. Coding tasks request feedback after their PR merges.
 - When a plan is ready, share its review link in the normal assistant response and ask the user to approve it or request changes.
 - After completing requested work, report the concise outcome and link in the normal assistant response.

--- a/agent/slack/thread_feedback.py
+++ b/agent/slack/thread_feedback.py
@@ -426,24 +426,22 @@ async def _acknowledge(record: ThreadFeedback, *, response_url: str) -> None:
             if current is None or current.dismissed or not current.completed or not response_url:
                 return
             async with asyncio.timeout(8):
-                removed = await respond_to_slack_interaction(
-                    response_url,
-                    {"delete_original": True},
-                )
-                if not removed or current.acknowledged:
-                    return
-                # Ephemeral response_url updates can also appear at the channel root.
-                posted = await post_slack_ephemeral_message(
-                    current.channel_id,
-                    current.user_id,
-                    "✅ Feedback completed. Thanks!",
-                    thread_ts=current.thread_ts if current.thread_ts != "0" else None,
-                )
-            if posted:
-                async with _locked_feedback(current) as latest:
-                    if latest is not None:
+                if not current.acknowledged:
+                    # Ephemeral response_url updates can also appear at the channel root.
+                    posted = await post_slack_ephemeral_message(
+                        current.channel_id,
+                        current.user_id,
+                        "✅ Feedback completed. Thanks!",
+                        thread_ts=current.thread_ts if current.thread_ts != "0" else None,
+                    )
+                    if not posted:
+                        return
+                    async with _locked_feedback(current) as latest:
+                        if latest is None:
+                            return
                         latest.acknowledged = True
                         await _store(latest.channel_id).put(latest.run_id, latest)
+                await respond_to_slack_interaction(response_url, {"delete_original": True})
     except Exception:
         logger.warning("Could not acknowledge saved Slack feedback")
 

--- a/agent/slack/thread_feedback.py
+++ b/agent/slack/thread_feedback.py
@@ -731,19 +731,21 @@ async def _record_rating(payload: dict[str, Any], background_tasks: BackgroundTa
             if record is None:
                 return
             async with _locked_feedback(record) as current:
-                if current is None or current.completed or current.dismissed:
+                if current is None or current.dismissed:
                     return
-                current.choice = choice
-                current.rating = 5 if choice == "good" else 1
-                current.completed = True
-                await _store(current.channel_id).put(current.run_id, current)
+                newly_saved = not current.completed
+                if newly_saved:
+                    current.choice = choice
+                    current.rating = 5 if choice == "good" else 1
+                    current.completed = True
+                    await _store(current.channel_id).put(current.run_id, current)
                 record = current
             response_url = str(payload.get("response_url") or "")
             background_tasks.add_task(complete_feedback_prompt, record.agent_thread_id, "completed")
             background_tasks.add_task(_acknowledge, record, response_url=response_url)
             background_tasks.add_task(_export_feedback, record)
             trigger_id = payload.get("trigger_id")
-            if choice == "bad" and isinstance(trigger_id, str) and trigger_id:
+            if newly_saved and choice == "bad" and isinstance(trigger_id, str) and trigger_id:
                 await open_slack_modal(
                     trigger_id, comment_modal(record, response_url, comment_only=True)
                 )

--- a/agent/slack/thread_feedback.py
+++ b/agent/slack/thread_feedback.py
@@ -58,6 +58,7 @@ class ThreadFeedback(BaseModel):
     choice: _Choice | None = None
     comment: str = Field(default="", max_length=3000)
     completed: bool = False
+    acknowledged: bool = False
     draft_rating: int | None = Field(default=None, ge=1, le=5)
     draft_choice: _Choice | None = None
     last_selection_ts: Decimal = Decimal(0)
@@ -424,19 +425,25 @@ async def _acknowledge(record: ThreadFeedback, *, response_url: str) -> None:
         async with _locked_feedback(record, purpose="feedback_response") as current:
             if current is None or current.dismissed or not current.completed or not response_url:
                 return
-            text = "✅ Feedback completed. Thanks!"
             async with asyncio.timeout(8):
-                await respond_to_slack_interaction(
+                removed = await respond_to_slack_interaction(
                     response_url,
-                    {
-                        "replace_original": True,
-                        "response_type": "ephemeral",
-                        "text": text,
-                        "blocks": [
-                            {"type": "section", "text": {"type": "plain_text", "text": text}}
-                        ],
-                    },
+                    {"delete_original": True},
                 )
+                if not removed or current.acknowledged:
+                    return
+                # Ephemeral response_url updates can also appear at the channel root.
+                posted = await post_slack_ephemeral_message(
+                    current.channel_id,
+                    current.user_id,
+                    "✅ Feedback completed. Thanks!",
+                    thread_ts=current.thread_ts if current.thread_ts != "0" else None,
+                )
+            if posted:
+                async with _locked_feedback(current) as latest:
+                    if latest is not None:
+                        latest.acknowledged = True
+                        await _store(latest.channel_id).put(latest.run_id, latest)
     except Exception:
         logger.warning("Could not acknowledge saved Slack feedback")
 

--- a/agent/slack/thread_feedback.py
+++ b/agent/slack/thread_feedback.py
@@ -31,6 +31,8 @@ from agent.utils.thread_ops import langgraph_client
 logger = logging.getLogger(__name__)
 
 _RATE_PREFIX = "open_swe_feedback_rate_"
+_FEEDBACK_ACTION = "open_swe_feedback"
+_NOTE_ACTION = "open_swe_feedback_note"
 _SELECT_PREFIX = "open_swe_feedback_select_"
 _COMMENT_ACTION = "open_swe_feedback_comment"
 _DISMISS_ACTION = "open_swe_feedback_dismiss"
@@ -132,6 +134,37 @@ def _feedback_inputs(rating: int | None = None, comment: str = "") -> list[dict[
     ]
 
 
+def feedback_blocks(run_id: str, thread_id: str) -> list[dict[str, Any]]:
+    url = dashboard_thread_url(thread_id)
+    thread_link = f"<{url}|this thread>" if url else "this thread"
+    return [
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f"How did Open SWE do on {thread_link}?"},
+        },
+        {
+            "type": "context_actions",
+            "elements": [
+                {
+                    "type": "feedback_buttons",
+                    "action_id": _FEEDBACK_ACTION,
+                    "positive_button": {
+                        "text": {"type": "plain_text", "text": "Good"},
+                        "value": json.dumps({"run_id": run_id, "choice": "good"}),
+                        "accessibility_label": "Rate this thread Good",
+                    },
+                    "negative_button": {
+                        "text": {"type": "plain_text", "text": "Bad"},
+                        "value": json.dumps({"run_id": run_id, "choice": "bad"}),
+                        "accessibility_label": "Rate this thread Bad",
+                    },
+                }
+            ],
+        },
+        {"type": "actions", "elements": [_dismiss_button(run_id)]},
+    ]
+
+
 def rating_blocks(
     run_id: str,
     thread_id: str,
@@ -142,6 +175,7 @@ def rating_blocks(
     error: str = "",
     selection_ts: Decimal = Decimal(0),
 ) -> list[dict[str, Any]]:
+    """Update selection/submit prompts delivered before the Good/Bad controls."""
     selected_choice = choice or {1: "bad", 5: "good"}.get(rating)
     selection = {"run_id": run_id, "rating": rating, "selection_ts": str(selection_ts)}
     if choice is not None:
@@ -265,9 +299,9 @@ async def post_slack_feedback_prompt(
             posted = await post_slack_ephemeral_message(
                 channel_id,
                 record.user_id,
-                "How did Open SWE do on this thread? Add a rating or comment, then submit feedback.",
+                "How did Open SWE do on this thread? Choose Good or Bad.",
                 thread_ts=record.thread_ts if record.thread_ts != "0" else None,
-                blocks=rating_blocks(run_id, thread_id),
+                blocks=feedback_blocks(run_id, thread_id),
             )
             if posted:
                 record.prompted = True
@@ -292,7 +326,14 @@ def _action(payload: dict[str, Any]) -> dict[str, Any]:
             if isinstance(action_id, str) and (
                 action_id.startswith(_RATE_PREFIX)
                 or action_id.startswith(_SELECT_PREFIX)
-                or action_id in {_COMMENT_ACTION, _DISMISS_ACTION, _SUBMIT_ACTION, _RATING_ACTION}
+                or action_id
+                in {
+                    _FEEDBACK_ACTION,
+                    _COMMENT_ACTION,
+                    _DISMISS_ACTION,
+                    _SUBMIT_ACTION,
+                    _RATING_ACTION,
+                }
             ):
                 return action
     return {}
@@ -301,7 +342,7 @@ def _action(payload: dict[str, Any]) -> dict[str, Any]:
 def is_slack_feedback_payload(payload: dict[str, Any]) -> bool:
     return (payload.get("type") == "block_actions" and bool(_action(payload))) or (
         payload.get("type") == "view_submission"
-        and _object(payload.get("view")).get("callback_id") == _COMMENT_ACTION
+        and _object(payload.get("view")).get("callback_id") in {_COMMENT_ACTION, _NOTE_ACTION}
     )
 
 
@@ -315,11 +356,12 @@ async def _load_feedback(channel_id: str, run_id: str, user_id: str) -> ThreadFe
     return record if slack_channel_allows_operations(context) else None
 
 
-def comment_modal(record: ThreadFeedback, response_url: str = "") -> dict[str, Any]:
-    """Let already-posted rating/comment buttons open the combined feedback form."""
+def comment_modal(
+    record: ThreadFeedback, response_url: str = "", *, comment_only: bool = False
+) -> dict[str, Any]:
     return {
         "type": "modal",
-        "callback_id": _COMMENT_ACTION,
+        "callback_id": _NOTE_ACTION if comment_only else _COMMENT_ACTION,
         "private_metadata": json.dumps(
             {
                 "channel_id": record.channel_id,
@@ -328,9 +370,14 @@ def comment_modal(record: ThreadFeedback, response_url: str = "") -> dict[str, A
             }
         ),
         "title": {"type": "plain_text", "text": "Open SWE feedback"},
-        "submit": {"type": "plain_text", "text": "Submit feedback"},
-        "close": {"type": "plain_text", "text": "Cancel"},
-        "blocks": _feedback_inputs(record.rating, record.comment),
+        "submit": {
+            "type": "plain_text",
+            "text": "Submit comment" if comment_only else "Submit feedback",
+        },
+        "close": {"type": "plain_text", "text": "Skip" if comment_only else "Cancel"},
+        "blocks": [_comment_input()]
+        if comment_only
+        else _feedback_inputs(record.rating, record.comment),
     }
 
 
@@ -462,10 +509,19 @@ async def _save_submission(
     values: dict[str, Any],
     *,
     legacy_modal: bool = False,
+    comment_only: bool = False,
 ) -> ThreadFeedback:
     async with _locked_feedback(record) as current:
         if current is None:
             raise _FeedbackInputError("This feedback is unavailable. Please reopen the prompt.")
+        if comment_only:
+            if current.dismissed or not current.completed or current.choice != "bad":
+                raise _FeedbackInputError("Comments require a submitted Bad rating.")
+            _, comment, _ = _form_values({_COMMENT_BLOCK: values.get(_COMMENT_BLOCK)})
+            if comment and not current.comment:
+                current.comment = comment
+                await _store(current.channel_id).put(current.run_id, current)
+            return current
         if current.completed or current.dismissed:
             return current
         default_rating = current.rating if legacy_modal and _RATING_BLOCK not in values else None
@@ -660,6 +716,41 @@ async def _select_feedback_rating(payload: dict[str, Any]) -> None:
         logger.warning("Could not update Slack feedback rating selection")
 
 
+async def _record_rating(payload: dict[str, Any], background_tasks: BackgroundTasks) -> None:
+    try:
+        async with asyncio.timeout(2.5):
+            selection = _object(json.loads(str(_action(payload).get("value") or "{}")))
+            choice = selection.get("choice")
+            if choice not in {"good", "bad"}:
+                return
+            record = await _load_feedback(
+                str(_object(payload.get("channel")).get("id") or ""),
+                str(selection.get("run_id") or ""),
+                str(_object(payload.get("user")).get("id") or ""),
+            )
+            if record is None:
+                return
+            async with _locked_feedback(record) as current:
+                if current is None or current.completed or current.dismissed:
+                    return
+                current.choice = choice
+                current.rating = 5 if choice == "good" else 1
+                current.completed = True
+                await _store(current.channel_id).put(current.run_id, current)
+                record = current
+            response_url = str(payload.get("response_url") or "")
+            background_tasks.add_task(complete_feedback_prompt, record.agent_thread_id, "completed")
+            background_tasks.add_task(_acknowledge, record, response_url=response_url)
+            background_tasks.add_task(_export_feedback, record)
+            trigger_id = payload.get("trigger_id")
+            if choice == "bad" and isinstance(trigger_id, str) and trigger_id:
+                await open_slack_modal(
+                    trigger_id, comment_modal(record, response_url, comment_only=True)
+                )
+    except Exception:
+        logger.warning("Could not process Slack feedback rating", exc_info=True)
+
+
 async def handle_slack_feedback_interaction(
     payload: dict[str, Any], background_tasks: BackgroundTasks
 ) -> FeedbackResponse:
@@ -678,7 +769,12 @@ async def handle_slack_feedback_interaction(
                         "This feedback is unavailable. Please reopen the form from the prompt."
                     )
                 values = _object(_object(view.get("state")).get("values"))
-                record = await _save_submission(record, values, legacy_modal=True)
+                record = await _save_submission(
+                    record,
+                    values,
+                    legacy_modal=True,
+                    comment_only=view.get("callback_id") == _NOTE_ACTION,
+                )
         except _FeedbackInputError as exc:
             return _comment_error(str(exc))
         except Exception:
@@ -694,6 +790,9 @@ async def handle_slack_feedback_interaction(
 
     action = _action(payload)
     action_id = action.get("action_id")
+    if action_id == _FEEDBACK_ACTION:
+        await _record_rating(payload, background_tasks)
+        return {}
     if action_id == _DISMISS_ACTION:
         background_tasks.add_task(_dismiss_feedback, payload)
         return {}

--- a/agent/slack/thread_feedback.py
+++ b/agent/slack/thread_feedback.py
@@ -5,8 +5,7 @@ import json
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from decimal import Decimal, InvalidOperation
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 from fastapi import BackgroundTasks
 from pydantic import BaseModel, Field
@@ -30,19 +29,10 @@ from agent.utils.thread_ops import langgraph_client
 
 logger = logging.getLogger(__name__)
 
-_RATE_PREFIX = "open_swe_feedback_rate_"
 _FEEDBACK_ACTION = "open_swe_feedback"
 _NOTE_ACTION = "open_swe_feedback_note"
-_SELECT_PREFIX = "open_swe_feedback_select_"
-_COMMENT_ACTION = "open_swe_feedback_comment"
 _DISMISS_ACTION = "open_swe_feedback_dismiss"
-_SUBMIT_ACTION = "open_swe_feedback_submit"
-_RATING_ACTION = "open_swe_feedback_rating"
-_RATING_BLOCK = "feedback_rating"
 _COMMENT_BLOCK = "feedback_comment"
-_RATINGS = ("😡 Very Bad", "💩 Bad", "😐 Okay", "🙂 Good", "😍 Great")
-_CHOICES = {"bad": "💩 Bad", "good": "🙂 Good", "other": "💬 Other"}
-_Choice = Literal["bad", "good", "other"]
 
 
 class ThreadFeedback(BaseModel):
@@ -55,13 +45,10 @@ class ThreadFeedback(BaseModel):
     prompted: bool = False
     dismissed: bool = False
     rating: int | None = Field(default=None, ge=1, le=5)
-    choice: _Choice | None = None
+    choice: Literal["good", "bad"] | None = None
     comment: str = Field(default="", max_length=3000)
     completed: bool = False
     acknowledged: bool = False
-    draft_rating: int | None = Field(default=None, ge=1, le=5)
-    draft_choice: _Choice | None = None
-    last_selection_ts: Decimal = Decimal(0)
 
 
 def _store(channel_id: str) -> TypedStore[ThreadFeedback]:
@@ -90,49 +77,21 @@ def _dismiss_button(run_id: str) -> dict[str, Any]:
     }
 
 
-def _comment_input(comment: str = "", *, required: bool = False) -> dict[str, Any]:
-    comment_element: dict[str, Any] = {
-        "type": "plain_text_input",
-        "action_id": "comment",
-        "multiline": True,
-        "max_length": 3000,
-        "placeholder": {"type": "plain_text", "text": "What worked well? What could be better?"},
-    }
-    if comment:
-        comment_element["initial_value"] = comment
+def _comment_input() -> dict[str, Any]:
     return {
         "type": "input",
         "block_id": _COMMENT_BLOCK,
-        "optional": not required,
+        "optional": True,
         "dispatch_action": False,
         "label": {"type": "plain_text", "text": "Comments"},
-        "element": comment_element,
-    }
-
-
-def _feedback_inputs(rating: int | None = None, comment: str = "") -> list[dict[str, Any]]:
-    options = [
-        {"text": {"type": "plain_text", "text": label, "emoji": True}, "value": str(value)}
-        for value, label in enumerate(_RATINGS, start=1)
-    ]
-    rating_element: dict[str, Any] = {
-        "type": "radio_buttons",
-        "action_id": _RATING_ACTION,
-        "options": options,
-    }
-    if rating is not None:
-        rating_element["initial_option"] = options[rating - 1]
-    return [
-        {
-            "type": "input",
-            "block_id": _RATING_BLOCK,
-            "optional": True,
-            "dispatch_action": False,
-            "label": {"type": "plain_text", "text": "Rating"},
-            "element": rating_element,
+        "element": {
+            "type": "plain_text_input",
+            "action_id": "comment",
+            "multiline": True,
+            "max_length": 3000,
+            "placeholder": {"type": "plain_text", "text": "What could be better?"},
         },
-        _comment_input(comment),
-    ]
+    }
 
 
 def feedback_blocks(run_id: str, thread_id: str) -> list[dict[str, Any]]:
@@ -163,69 +122,6 @@ def feedback_blocks(run_id: str, thread_id: str) -> list[dict[str, Any]]:
             ],
         },
         {"type": "actions", "elements": [_dismiss_button(run_id)]},
-    ]
-
-
-def rating_blocks(
-    run_id: str,
-    thread_id: str,
-    *,
-    rating: int | None = None,
-    choice: _Choice | None = None,
-    comment: str = "",
-    error: str = "",
-    selection_ts: Decimal = Decimal(0),
-) -> list[dict[str, Any]]:
-    """Update selection/submit prompts delivered before the Good/Bad controls."""
-    selected_choice = choice or {1: "bad", 5: "good"}.get(rating)
-    selection = {"run_id": run_id, "rating": rating, "selection_ts": str(selection_ts)}
-    if choice is not None:
-        selection["choice"] = choice
-    url = dashboard_thread_url(thread_id)
-    thread_link = f"<{url}|this thread>" if url else "this thread"
-    blocks = [
-        {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": f"How did Open SWE do on {thread_link}?",
-            },
-        }
-    ]
-    if error:
-        blocks.append({"type": "section", "text": {"type": "plain_text", "text": error}})
-    return [
-        *blocks,
-        {
-            "type": "actions",
-            "block_id": _RATING_BLOCK,
-            "elements": [
-                {
-                    "type": "button",
-                    "text": {"type": "plain_text", "text": label, "emoji": True},
-                    "action_id": f"{_SELECT_PREFIX}{value}",
-                    "value": run_id,
-                    **({"style": "primary"} if value == selected_choice else {}),
-                }
-                for value, label in _CHOICES.items()
-            ],
-        },
-        _comment_input(comment, required=choice == "other"),
-        {
-            "type": "actions",
-            "elements": [
-                {
-                    "type": "button",
-                    "text": {"type": "plain_text", "text": "Submit feedback"},
-                    "action_id": _SUBMIT_ACTION,
-                    "value": json.dumps(selection)
-                    if rating is not None or choice is not None
-                    else run_id,
-                    "style": "primary",
-                },
-                _dismiss_button(run_id),
-            ],
-        },
     ]
 
 
@@ -324,18 +220,7 @@ def _action(payload: dict[str, Any]) -> dict[str, Any]:
         for value in actions:
             action = _object(value)
             action_id = action.get("action_id")
-            if isinstance(action_id, str) and (
-                action_id.startswith(_RATE_PREFIX)
-                or action_id.startswith(_SELECT_PREFIX)
-                or action_id
-                in {
-                    _FEEDBACK_ACTION,
-                    _COMMENT_ACTION,
-                    _DISMISS_ACTION,
-                    _SUBMIT_ACTION,
-                    _RATING_ACTION,
-                }
-            ):
+            if isinstance(action_id, str) and action_id in {_FEEDBACK_ACTION, _DISMISS_ACTION}:
                 return action
     return {}
 
@@ -343,7 +228,7 @@ def _action(payload: dict[str, Any]) -> dict[str, Any]:
 def is_slack_feedback_payload(payload: dict[str, Any]) -> bool:
     return (payload.get("type") == "block_actions" and bool(_action(payload))) or (
         payload.get("type") == "view_submission"
-        and _object(payload.get("view")).get("callback_id") in {_COMMENT_ACTION, _NOTE_ACTION}
+        and _object(payload.get("view")).get("callback_id") == _NOTE_ACTION
     )
 
 
@@ -357,12 +242,10 @@ async def _load_feedback(channel_id: str, run_id: str, user_id: str) -> ThreadFe
     return record if slack_channel_allows_operations(context) else None
 
 
-def comment_modal(
-    record: ThreadFeedback, response_url: str = "", *, comment_only: bool = False
-) -> dict[str, Any]:
+def comment_modal(record: ThreadFeedback, response_url: str) -> dict[str, Any]:
     return {
         "type": "modal",
-        "callback_id": _NOTE_ACTION if comment_only else _COMMENT_ACTION,
+        "callback_id": _NOTE_ACTION,
         "private_metadata": json.dumps(
             {
                 "channel_id": record.channel_id,
@@ -371,14 +254,9 @@ def comment_modal(
             }
         ),
         "title": {"type": "plain_text", "text": "Open SWE feedback"},
-        "submit": {
-            "type": "plain_text",
-            "text": "Submit comment" if comment_only else "Submit feedback",
-        },
-        "close": {"type": "plain_text", "text": "Skip" if comment_only else "Cancel"},
-        "blocks": [_comment_input()]
-        if comment_only
-        else _feedback_inputs(record.rating, record.comment),
+        "submit": {"type": "plain_text", "text": "Submit comment"},
+        "close": {"type": "plain_text", "text": "Skip"},
+        "blocks": [_comment_input()],
     }
 
 
@@ -386,37 +264,32 @@ async def _export_feedback(record: ThreadFeedback) -> None:
     try:
         # Serialize exports separately so a slow LangSmith call cannot block a modal save.
         async with _locked_feedback(record, purpose="feedback_export") as current:
-            if current is not None:
-                async with asyncio.timeout(8):
-                    await _export_current_feedback(current)
+            if current is None or not current.completed:
+                return
+            async with asyncio.timeout(8):
+                synced = await create_langsmith_thread_feedback(
+                    current.agent_thread_id,
+                    "rating",
+                    score=(current.rating - 1) / 4 if current.rating is not None else None,
+                    comment=current.comment or None,
+                    source_info={
+                        "source": "slack_thread_feedback",
+                        "channel_id": current.channel_id,
+                        "message_ts": current.message_ts,
+                        "user_id": current.user_id,
+                        "run_id": current.run_id,
+                    },
+                )
+            if not synced:
+                logger.warning(
+                    "Slack feedback saved but LangSmith export failed",
+                    extra={"feedback_run_id": current.run_id},
+                )
     except Exception:
         logger.warning(
             "Could not export saved Slack feedback",
             extra={"feedback_run_id": record.run_id},
             exc_info=True,
-        )
-
-
-async def _export_current_feedback(record: ThreadFeedback) -> None:
-    if not record.completed:
-        return
-    synced = await create_langsmith_thread_feedback(
-        record.agent_thread_id,
-        "rating",
-        score=(record.rating - 1) / 4 if record.rating is not None else None,
-        comment=record.comment or None,
-        source_info={
-            "source": "slack_thread_feedback",
-            "channel_id": record.channel_id,
-            "message_ts": record.message_ts,
-            "user_id": record.user_id,
-            "run_id": record.run_id,
-        },
-    )
-    if not synced:
-        logger.warning(
-            "Slack feedback saved but LangSmith export failed",
-            extra={"feedback_run_id": record.run_id},
         )
 
 
@@ -483,242 +356,24 @@ class _FeedbackInputError(ValueError):
     pass
 
 
-def _form_values(
-    values: dict[str, Any], default_rating: int | None = None
-) -> tuple[int | None, str, _Choice | None]:
-    selected = _object(_object(values.get(_RATING_BLOCK)).get(_RATING_ACTION)).get(
-        "selected_option"
-    )
-    value = _object(selected).get("value")
-    if selected is not None and (
-        not isinstance(value, str) or value not in {*_CHOICES, "1", "2", "3", "4", "5"}
-    ):
-        raise _FeedbackInputError("Choose Bad, Good, or Other.")
-    choice: _Choice | None = value if value in _CHOICES else None
-    rating = (
-        {"bad": 1, "good": 5}.get(choice)
-        if choice is not None
-        else int(value)
-        if value is not None
-        else default_rating
-    )
-    comment = _object(_object(values.get(_COMMENT_BLOCK)).get("comment")).get("value")
-    if comment is not None and (not isinstance(comment, str) or len(comment) > 3000):
-        raise _FeedbackInputError("Comments must be at most 3,000 characters.")
-    comment = comment.strip() if isinstance(comment, str) else ""
-    return rating, comment, choice
-
-
-async def _save_submission(
-    record: ThreadFeedback,
-    values: dict[str, Any],
-    *,
-    legacy_modal: bool = False,
-    comment_only: bool = False,
-) -> ThreadFeedback:
+async def _save_comment(record: ThreadFeedback, values: dict[str, Any]) -> ThreadFeedback:
     async with _locked_feedback(record) as current:
         if current is None:
             raise _FeedbackInputError("This feedback is unavailable. Please reopen the prompt.")
-        if comment_only:
-            if current.dismissed or not current.completed or current.choice != "bad":
-                raise _FeedbackInputError("Comments require a submitted Bad rating.")
-            _, comment, _ = _form_values({_COMMENT_BLOCK: values.get(_COMMENT_BLOCK)})
-            if comment and not current.comment:
-                current.comment = comment
-                await _store(current.channel_id).put(current.run_id, current)
-            return current
-        if current.completed or current.dismissed:
-            return current
-        default_rating = current.rating if legacy_modal and _RATING_BLOCK not in values else None
-        rating, comment, choice = _form_values(values, default_rating)
-        if rating is None and not comment:
-            raise _FeedbackInputError(
-                "Add a comment when choosing Other before submitting."
-                if choice == "other"
-                else "Choose a rating or enter a comment before submitting."
-            )
-        current.rating = rating
-        current.choice = choice
-        current.comment = comment
-        current.completed = True
-        await _store(current.channel_id).put(current.run_id, current)
+        if current.dismissed or not current.completed or current.choice != "bad":
+            raise _FeedbackInputError("Comments require a submitted Bad rating.")
+        comment = _object(_object(values.get(_COMMENT_BLOCK)).get("comment")).get("value")
+        if comment is not None and (not isinstance(comment, str) or len(comment) > 3000):
+            raise _FeedbackInputError("Comments must be at most 3,000 characters.")
+        comment = comment.strip() if isinstance(comment, str) else ""
+        if comment and not current.comment:
+            current.comment = comment
+            await _store(current.channel_id).put(current.run_id, current)
         return current
-
-
-async def _show_submission_error(
-    record: ThreadFeedback,
-    values: dict[str, Any],
-    response_url: str,
-    error: str,
-    selection_ts: Decimal,
-) -> None:
-    selected = _object(
-        _object(_object(values.get(_RATING_BLOCK)).get(_RATING_ACTION)).get("selected_option")
-    ).get("value")
-    rating = (
-        int(selected)
-        if isinstance(selected, str) and selected in {"1", "2", "3", "4", "5"}
-        else None
-    )
-    choice = selected if isinstance(selected, str) and selected in _CHOICES else None
-    comment = _object(_object(values.get(_COMMENT_BLOCK)).get("comment")).get("value")
-    comment = comment[:3000] if isinstance(comment, str) else ""
-    current = await _store(record.channel_id).get(record.run_id)
-    if current is None or current.completed or current.dismissed or not response_url:
-        return
-    await respond_to_slack_interaction(
-        response_url,
-        {
-            "replace_original": True,
-            "response_type": "ephemeral",
-            "text": error,
-            "blocks": rating_blocks(
-                record.run_id,
-                record.agent_thread_id,
-                rating=rating,
-                choice=choice,
-                comment=comment,
-                error=error,
-                selection_ts=selection_ts,
-            ),
-        },
-    )
-
-
-async def _process_submission(payload: dict[str, Any]) -> None:
-    channel_id = str(_object(payload.get("channel")).get("id") or "")
-    user_id = str(_object(payload.get("user")).get("id") or "")
-    response_url = str(payload.get("response_url") or "")
-    values = _object(_object(payload.get("state")).get("values"))
-    try:
-        action_value = str(_action(payload).get("value") or "")
-        selection_ts = Decimal(0)
-        if action_value.startswith("{"):
-            selection = _object(json.loads(action_value))
-            action_value = str(selection.get("run_id") or "")
-            selection_ts = Decimal(str(selection.get("selection_ts") or "0"))
-            if not selection_ts.is_finite() or selection_ts < 0:
-                return
-            values = {
-                **values,
-                _RATING_BLOCK: {
-                    _RATING_ACTION: {
-                        "selected_option": {
-                            "value": str(selection.get("choice") or selection.get("rating"))
-                        }
-                    }
-                },
-            }
-        record = await _load_feedback(channel_id, action_value, user_id)
-        if record is None:
-            return
-        async with _locked_feedback(record, purpose="feedback_response") as current:
-            if current is None:
-                return
-            action_ts = _action(payload).get("action_ts")
-            if action_ts is not None:
-                submitted_at = Decimal(str(action_ts))
-                if (
-                    not submitted_at.is_finite()
-                    or submitted_at <= 0
-                    or submitted_at < current.last_selection_ts
-                ):
-                    return
-            # A Submit click can reach us before the preceding emoji update reaches Slack.
-            if (
-                current.draft_rating is not None or current.draft_choice is not None
-            ) and current.last_selection_ts > selection_ts:
-                selection_ts = current.last_selection_ts
-                values = {
-                    **values,
-                    _RATING_BLOCK: {
-                        _RATING_ACTION: {
-                            "selected_option": {
-                                "value": str(current.draft_choice or current.draft_rating)
-                            }
-                        }
-                    },
-                }
-            try:
-                record = await _save_submission(current, values)
-            except Exception as exc:
-                error = "Your feedback could not be saved. Please submit again."
-                if isinstance(exc, _FeedbackInputError):
-                    error = str(exc)
-                else:
-                    logger.warning("Could not save Slack feedback submission")
-                await _show_submission_error(current, values, response_url, error, selection_ts)
-                return
-        if record.completed:
-            await complete_feedback_prompt(record.agent_thread_id, "completed")
-        await _acknowledge(record, response_url=response_url)
-        await _export_feedback(record)
-    except Exception:
-        logger.warning("Could not process Slack feedback submission")
 
 
 def _comment_error(text: str) -> FeedbackResponse:
     return {"response_action": "errors", "errors": {_COMMENT_BLOCK: text}}
-
-
-async def _select_feedback_rating(payload: dict[str, Any]) -> None:
-    action = _action(payload)
-    suffix = str(action.get("action_id", "")).removeprefix(_SELECT_PREFIX)
-    if suffix not in {*_CHOICES, "1", "2", "3", "4", "5"}:
-        return
-    choice = cast(_Choice, suffix) if suffix in _CHOICES else None
-    rating = {"bad": 1, "good": 5}.get(choice) if choice is not None else int(suffix)
-    try:
-        timestamp = Decimal(str(action.get("action_ts") or "0"))
-    except InvalidOperation:
-        return
-    if not timestamp.is_finite() or timestamp <= 0:
-        return
-    channel_id = str(_object(payload.get("channel")).get("id") or "")
-    user_id = str(_object(payload.get("user")).get("id") or "")
-    response_url = str(payload.get("response_url") or "")
-    if not response_url:
-        return
-    try:
-        record = await _load_feedback(channel_id, str(action.get("value") or ""), user_id)
-        if record is None:
-            return
-        async with _locked_feedback(record, purpose="feedback_response") as current:
-            if (
-                current is None
-                or current.completed
-                or current.dismissed
-                or timestamp <= current.last_selection_ts
-            ):
-                return
-            values = _object(_object(payload.get("state")).get("values"))
-            comment = _object(_object(values.get(_COMMENT_BLOCK)).get("comment")).get("value")
-            comment = comment[:3000] if isinstance(comment, str) else ""
-            posted = await respond_to_slack_interaction(
-                response_url,
-                {
-                    "replace_original": True,
-                    "response_type": "ephemeral",
-                    "text": "Add a rating or comment, then submit feedback.",
-                    "blocks": rating_blocks(
-                        current.run_id,
-                        current.agent_thread_id,
-                        rating=rating,
-                        choice=choice,
-                        comment=comment,
-                        selection_ts=timestamp,
-                    ),
-                },
-            )
-            if posted:
-                async with _locked_feedback(current) as latest:
-                    if latest is not None and not latest.completed and not latest.dismissed:
-                        latest.draft_rating = rating
-                        latest.draft_choice = choice
-                        latest.last_selection_ts = timestamp
-                        await _store(channel_id).put(latest.run_id, latest)
-    except Exception:
-        logger.warning("Could not update Slack feedback rating selection")
 
 
 async def _record_rating(payload: dict[str, Any], background_tasks: BackgroundTasks) -> None:
@@ -751,9 +406,7 @@ async def _record_rating(payload: dict[str, Any], background_tasks: BackgroundTa
             background_tasks.add_task(_export_feedback, record)
             trigger_id = payload.get("trigger_id")
             if newly_saved and choice == "bad" and isinstance(trigger_id, str) and trigger_id:
-                await open_slack_modal(
-                    trigger_id, comment_modal(record, response_url, comment_only=True)
-                )
+                await open_slack_modal(trigger_id, comment_modal(record, response_url))
     except Exception:
         logger.warning("Could not process Slack feedback rating", exc_info=True)
 
@@ -776,19 +429,13 @@ async def handle_slack_feedback_interaction(
                         "This feedback is unavailable. Please reopen the form from the prompt."
                     )
                 values = _object(_object(view.get("state")).get("values"))
-                record = await _save_submission(
-                    record,
-                    values,
-                    legacy_modal=True,
-                    comment_only=view.get("callback_id") == _NOTE_ACTION,
-                )
+                record = await _save_comment(record, values)
         except _FeedbackInputError as exc:
             return _comment_error(str(exc))
         except Exception:
             logger.warning("Could not save Slack feedback submission")
             return _comment_error("Your feedback could not be saved. Please try again.")
-        if record.completed:
-            background_tasks.add_task(complete_feedback_prompt, record.agent_thread_id, "completed")
+        background_tasks.add_task(complete_feedback_prompt, record.agent_thread_id, "completed")
         background_tasks.add_task(
             _acknowledge, record, response_url=str(metadata.get("response_url") or "")
         )
@@ -803,43 +450,4 @@ async def handle_slack_feedback_interaction(
     if action_id == _DISMISS_ACTION:
         background_tasks.add_task(_dismiss_feedback, payload)
         return {}
-    if action_id == _SUBMIT_ACTION:
-        background_tasks.add_task(_process_submission, payload)
-        return {}
-    if action_id == _RATING_ACTION:
-        return {}
-    if isinstance(action_id, str) and action_id.startswith(_SELECT_PREFIX):
-        background_tasks.add_task(_select_feedback_rating, payload)
-        return {}
-    selected_rating = None
-    if isinstance(action_id, str) and action_id.startswith(_RATE_PREFIX):
-        suffix = action_id.removeprefix(_RATE_PREFIX)
-        if suffix not in {"1", "2", "3", "4", "5"}:
-            return {}
-        selected_rating = int(suffix)
-    channel_id = str(_object(payload.get("channel")).get("id") or "")
-    user_id = str(_object(payload.get("user")).get("id") or "")
-    try:
-        async with asyncio.timeout(2.5):
-            record = await _load_feedback(channel_id, str(action.get("value") or ""), user_id)
-            if record is None or record.dismissed:
-                return {}
-            if record.completed:
-                background_tasks.add_task(
-                    _acknowledge, record, response_url=str(payload.get("response_url") or "")
-                )
-                return {}
-            if selected_rating is not None:
-                record = record.model_copy(update={"rating": selected_rating})
-            trigger_id = payload.get("trigger_id")
-            if (
-                isinstance(trigger_id, str)
-                and trigger_id
-                and await open_slack_modal(
-                    trigger_id, comment_modal(record, str(payload.get("response_url") or ""))
-                )
-            ):
-                return {}
-    except Exception:
-        logger.warning("Could not open Slack feedback form")
     return {}

--- a/agent/slack/thread_feedback.py
+++ b/agent/slack/thread_feedback.py
@@ -401,7 +401,7 @@ async def _export_current_feedback(record: ThreadFeedback) -> None:
         return
     synced = await create_langsmith_thread_feedback(
         record.agent_thread_id,
-        f"slack_rating:{record.channel_id}:{record.user_id}:{record.run_id}",
+        "rating",
         score=(record.rating - 1) / 4 if record.rating is not None else None,
         comment=record.comment or None,
         source_info={

--- a/agent/tools/mark_question_answered.py
+++ b/agent/tools/mark_question_answered.py
@@ -9,11 +9,14 @@ from agent.thread_feedback import mark_answered_question
 
 
 async def mark_question_answered() -> dict[str, Any]:
-    """Mark that you have completely answered an information-only request.
+    """Mark that you are ready to deliver a complete answer to an information-only request.
 
-    Call after answering a question in the web UI when no clarification or further
-    work is needed. Do not use for coding tasks, plans, approval requests, blockers,
-    or partial answers. Coding tasks request feedback after their PR merges.
+    You MUST call this once before the final answer in the web UI when no
+    clarification or further work is needed, then deliver the answer normally.
+    This includes short questions, explanations, recommendations, and naming
+    suggestions, even if no other tools were needed. Do not use for coding tasks,
+    plans, approval requests, blockers, or partial answers. Coding tasks request
+    feedback after their PR merges.
     For Slack answers, use slack_thread_reply with should_ask_for_feedback=True.
     Feedback is offered only if this run succeeds and the user does not continue
     the conversation for five minutes. This does not send a message or end the run.

--- a/swagger.json
+++ b/swagger.json
@@ -556,6 +556,7 @@
             "default": "submit",
             "enum": [
               "submit",
+              "comment",
               "dismiss"
             ],
             "title": "Action",
@@ -572,8 +573,7 @@
               {
                 "enum": [
                   "bad",
-                  "good",
-                  "other"
+                  "good"
                 ],
                 "type": "string"
               },

--- a/tests/dashboard/test_thread_feedback.py
+++ b/tests/dashboard/test_thread_feedback.py
@@ -40,7 +40,7 @@ async def api(monkeypatch, fake_store):
         yield SimpleNamespace(client=client, metadata=metadata, session=session, quiet=quiet)
 
 
-@pytest.mark.parametrize("rating", ["bad", "good", "other"])
+@pytest.mark.parametrize("rating", ["bad", "good"])
 async def test_submit_saves_rating_and_comment_and_keeps_first_response(api, rating):
     response = await api.client.post(
         "/dashboard/api/threads/t1/feedback",
@@ -92,6 +92,8 @@ async def test_only_verified_initiator_gets_feedback(api, monkeypatch, identity,
     "payload",
     [
         {"rating": "other", "comment": "  "},
+        {"rating": "other", "comment": "Details"},
+        {"action": "comment", "comment": "  "},
         {"rating": "great"},
         {},
         {"action": "submit"},
@@ -103,6 +105,41 @@ async def test_invalid_feedback_is_not_saved(api, payload):
     response = await api.client.post("/dashboard/api/threads/t1/feedback", json=payload)
     assert response.status_code == 422
     assert (await api.client.get("/dashboard/api/threads/t1/feedback")).json()["status"] == "ready"
+
+
+async def test_bad_rating_is_saved_before_optional_comment(api):
+    rated = await api.client.post("/dashboard/api/threads/t1/feedback", json={"rating": "bad"})
+    assert rated.json() == {"status": "completed", "rating": "bad", "comment": ""}
+    commented = await api.client.post(
+        "/dashboard/api/threads/t1/feedback",
+        json={"action": "comment", "comment": "  The fix did not work.  "},
+    )
+    assert commented.status_code == 200
+    assert commented.json() == {
+        "status": "completed",
+        "rating": "bad",
+        "comment": "The fix did not work.",
+    }
+    duplicate = await api.client.post(
+        "/dashboard/api/threads/t1/feedback",
+        json={"action": "comment", "comment": "Overwrite"},
+    )
+    assert duplicate.json() == commented.json()
+
+
+@pytest.mark.parametrize("state", ["ready", "good", "dismissed"])
+async def test_comment_requires_completed_bad_rating(api, state):
+    if state != "ready":
+        await api.client.post(
+            "/dashboard/api/threads/t1/feedback",
+            json={"rating": "good"} if state == "good" else {"action": "dismiss"},
+        )
+    before = (await api.client.get("/dashboard/api/threads/t1/feedback")).json()
+    response = await api.client.post(
+        "/dashboard/api/threads/t1/feedback", json={"action": "comment", "comment": "Details"}
+    )
+    assert response.status_code == 409
+    assert (await api.client.get("/dashboard/api/threads/t1/feedback")).json() == before
 
 
 @pytest.mark.parametrize("payload", [{"rating": "good"}, {"action": "dismiss"}])

--- a/tests/slack/test_slack_thread_feedback.py
+++ b/tests/slack/test_slack_thread_feedback.py
@@ -1358,3 +1358,20 @@ async def test_native_modal_failure_keeps_saved_bad_rating(context, fake_store):
     await tasks()
     assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["completed"]
     assert feedback.create_langsmith_thread_feedback.await_args.kwargs["score"] == 0.0
+
+
+async def test_native_rating_retry_replaces_controls_without_reopening_modal(context, fake_store):
+    feedback.respond_to_slack_interaction.side_effect = [False, True]
+    for choice in ("bad", "good"):
+        tasks = BackgroundTasks()
+        payload = _action("open_swe_feedback", json.dumps({"run_id": "run-1", "choice": choice}))
+        await routes.slack_interactivity(_request(payload), tasks)
+        await tasks()
+    assert feedback.respond_to_slack_interaction.await_count == 2
+    assert all(
+        block["type"] == "section"
+        for block in feedback.respond_to_slack_interaction.await_args.args[1]["blocks"]
+    )
+    feedback.open_slack_modal.assert_awaited_once()
+    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["choice"] == "bad"
+    assert feedback.create_langsmith_thread_feedback.await_args.kwargs["score"] == 0.0

--- a/tests/slack/test_slack_thread_feedback.py
+++ b/tests/slack/test_slack_thread_feedback.py
@@ -676,9 +676,15 @@ async def test_prompt_uses_exact_run_mapping_and_deduplicates(
         await feedback.post_slack_feedback_prompt("thread-1", "run-1", "C1")
     feedback.post_slack_ephemeral_message.assert_awaited_once()
     call = feedback.post_slack_ephemeral_message.await_args
-    submit = call.kwargs["blocks"][-1]["elements"][0]
-    assert submit["value"] == "run-1"
-    assert submit["action_id"] == "open_swe_feedback_submit"
+    blocks = call.kwargs["blocks"]
+    assert not any(block["type"] == "input" for block in blocks)
+    controls = next(block["elements"][0] for block in blocks if block["type"] == "context_actions")
+    tasks = BackgroundTasks()
+    await routes.slack_interactivity(
+        _request(_action(controls["action_id"], controls["positive_button"]["value"])), tasks
+    )
+    await tasks()
+    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["choice"] == "good"
     assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["prompted"] is True
 
 
@@ -1275,3 +1281,80 @@ def test_prompt_without_dashboard_has_no_broken_link(monkeypatch: pytest.MonkeyP
     text = feedback.rating_blocks("run-1", "thread-1")[0]["text"]["text"]
     assert "<" not in text
     assert "this thread" in text
+
+
+@pytest.mark.parametrize("choice,score", [("good", 1.0), ("bad", 0.0)])
+async def test_native_rating_saves_immediately_and_only_bad_opens_comment(
+    context, fake_store, choice, score
+):
+    payload = _action("open_swe_feedback", json.dumps({"run_id": "run-1", "choice": choice}))
+    tasks = BackgroundTasks()
+    assert await routes.slack_interactivity(_request(payload), tasks) == {}
+    saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
+    assert saved["completed"] and saved["choice"] == choice and saved["comment"] == ""
+    if choice == "bad":
+        view = feedback.open_slack_modal.await_args.args[1]
+        assert view["callback_id"] == "open_swe_feedback_note"
+        assert len(view["blocks"]) == 1
+        assert view["blocks"][0]["optional"] is True
+        assert view["blocks"][0]["element"]["type"] == "plain_text_input"
+    else:
+        feedback.open_slack_modal.assert_not_awaited()
+    await tasks()
+    assert feedback.create_langsmith_thread_feedback.await_args.kwargs["score"] == score
+    assert fake_store.values(("thread_feedback",))["thread-1"]["status"] == "completed"
+    assert all(
+        b["type"] == "section"
+        for b in feedback.respond_to_slack_interaction.await_args.args[1]["blocks"]
+    )
+
+
+async def test_native_bad_comment_updates_rating_without_overwriting_first_comment(
+    context, fake_store
+):
+    fake_store.seed(
+        ("slack_thread_feedback", "C1"),
+        "run-1",
+        {**context, "completed": True, "choice": "bad", "rating": 1},
+    )
+    payload = _submission("  The tests still fail.  ")
+    payload["view"]["callback_id"] = "open_swe_feedback_note"
+    tasks = BackgroundTasks()
+    assert await routes.slack_interactivity(_request(payload), tasks) == {}
+    await tasks()
+    saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
+    assert saved["comment"] == "The tests still fail."
+    assert saved["rating"] == 1 and saved["completed"]
+    assert (
+        feedback.create_langsmith_thread_feedback.await_args.kwargs["comment"]
+        == "The tests still fail."
+    )
+    payload["view"]["state"]["values"]["feedback_comment"]["comment"]["value"] = "Overwrite"
+    await routes.slack_interactivity(_request(payload), BackgroundTasks())
+    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"] == saved
+
+
+@pytest.mark.parametrize("blocked", ["completed", "dismissed", "other_user"])
+async def test_native_rating_cannot_reopen_finished_feedback_or_rate_for_someone_else(
+    context, fake_store, blocked
+):
+    initial = {**context, **({blocked: True} if blocked != "other_user" else {})}
+    fake_store.seed(("slack_thread_feedback", "C1"), "run-1", initial)
+    payload = _action("open_swe_feedback", json.dumps({"run_id": "run-1", "choice": "bad"}))
+    if blocked == "other_user":
+        payload["user"]["id"] = "U2"
+    tasks = BackgroundTasks()
+    await routes.slack_interactivity(_request(payload), tasks)
+    await tasks()
+    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"] == initial
+    feedback.open_slack_modal.assert_not_awaited()
+
+
+async def test_native_modal_failure_keeps_saved_bad_rating(context, fake_store):
+    feedback.open_slack_modal.side_effect = RuntimeError("Slack unavailable")
+    tasks = BackgroundTasks()
+    payload = _action("open_swe_feedback", json.dumps({"run_id": "run-1", "choice": "bad"}))
+    assert await routes.slack_interactivity(_request(payload), tasks) == {}
+    await tasks()
+    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["completed"]
+    assert feedback.create_langsmith_thread_feedback.await_args.kwargs["score"] == 0.0

--- a/tests/slack/test_slack_thread_feedback.py
+++ b/tests/slack/test_slack_thread_feedback.py
@@ -806,7 +806,7 @@ async def test_dismiss_removes_prompt_without_saving_feedback(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("missing_url", [False, True])
-async def test_message_update_failure_preserves_feedback_without_posting_another_prompt(
+async def test_prompt_cleanup_failure_preserves_saved_feedback_and_confirmation(
     context: Any, fake_store: Any, missing_url: bool
 ) -> None:
     payload = _inline_submission()
@@ -818,7 +818,12 @@ async def test_message_update_failure_preserves_feedback_without_posting_another
     await tasks()
     assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["rating"] == 5
     feedback.create_langsmith_thread_feedback.assert_awaited_once()
-    feedback.post_slack_ephemeral_message.assert_not_awaited()
+    if missing_url:
+        feedback.post_slack_ephemeral_message.assert_not_awaited()
+    else:
+        feedback.post_slack_ephemeral_message.assert_awaited_once_with(
+            "C1", "U1", "✅ Feedback completed. Thanks!", thread_ts="1.0"
+        )
 
 
 @pytest.mark.asyncio
@@ -910,6 +915,8 @@ async def test_dismiss_during_failed_submission_update_prevents_later_acknowledg
         await asyncio.gather(rating_task, dismiss_task)
     assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["dismissed"] is True
     response_mock.reset_mock()
+    feedback.post_slack_ephemeral_message.assert_awaited_once()
+    feedback.post_slack_ephemeral_message.reset_mock()
     await feedback._acknowledge(
         feedback.ThreadFeedback(**context, rating=5, completed=True),
         response_url=_RESPONSE_URL,
@@ -1387,14 +1394,18 @@ async def test_native_rating_retry_removes_controls_without_reopening_modal(cont
     assert feedback.create_langsmith_thread_feedback.await_args.kwargs["score"] == 0.0
 
 
-async def test_confirmation_failure_can_retry_without_repeating_success(context, fake_store):
-    feedback.post_slack_ephemeral_message.side_effect = [False, True]
+@pytest.mark.parametrize("failure", [False, TimeoutError()])
+async def test_confirmation_failure_can_retry_without_repeating_success(
+    context, fake_store, failure
+):
+    feedback.post_slack_ephemeral_message.side_effect = [failure, True]
     payload = _action("open_swe_feedback", json.dumps({"run_id": "run-1", "choice": "good"}))
-    for expected_acknowledged in (False, True, True):
+    for deletions, expected_acknowledged in enumerate((False, True, True)):
         tasks = BackgroundTasks()
         await routes.slack_interactivity(_request(payload), tasks)
         await tasks()
         saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
         assert saved["completed"] and saved["rating"] == 5
         assert saved.get("acknowledged", False) is expected_acknowledged
+        assert feedback.respond_to_slack_interaction.await_count == deletions
     assert feedback.post_slack_ephemeral_message.await_count == 2

--- a/tests/slack/test_slack_thread_feedback.py
+++ b/tests/slack/test_slack_thread_feedback.py
@@ -166,8 +166,6 @@ async def test_submit_during_emoji_update_uses_latest_selection(
         return True
 
     monkeypatch.setattr(feedback, "respond_to_slack_interaction", AsyncMock(side_effect=respond))
-    writes = AsyncMock(wraps=fake_store.put_item)
-    monkeypatch.setattr(fake_store, "put_item", writes)
     old_submit = feedback.rating_blocks("run-1", "thread-1", rating=2)[-1]["elements"][0]
     payload = _action(old_submit["action_id"], old_submit["value"])
     payload["actions"][0]["action_ts"] = "4.0"
@@ -192,14 +190,14 @@ async def test_submit_during_emoji_update_uses_latest_selection(
         "Final submitted comment",
         True,
     )
-    assert sum(call.args[2].get("completed") is True for call in writes.await_args_list) == 1
     feedback.create_langsmith_thread_feedback.assert_awaited_once()
     assert feedback.create_langsmith_thread_feedback.await_args.kwargs["score"] == 1.0
     assert (
         feedback.create_langsmith_thread_feedback.await_args.kwargs["comment"]
         == "Final submitted comment"
     )
-    feedback.post_slack_ephemeral_message.assert_not_awaited()
+    feedback.post_slack_ephemeral_message.assert_awaited_once()
+    assert feedback.post_slack_ephemeral_message.await_args.kwargs["thread_ts"] == "1.0"
 
 
 @pytest.mark.asyncio
@@ -338,13 +336,9 @@ async def test_inline_rating_and_comment_submit_together_and_complete(
     assert feedback.create_langsmith_thread_feedback.await_args.kwargs["score"] == 0.75
     assert feedback.create_langsmith_thread_feedback.await_args.kwargs["comment"] == "Very helpful"
     message = feedback.respond_to_slack_interaction.await_args.args[1]
-    assert message["replace_original"] is True
-    assert "completed" in message["text"].lower()
-    assert all(
-        block["type"] not in {"input", "actions"} and "accessory" not in block
-        for block in message["blocks"]
-    )
-    feedback.post_slack_ephemeral_message.assert_not_awaited()
+    assert message == {"delete_original": True}
+    feedback.post_slack_ephemeral_message.assert_awaited_once()
+    assert feedback.post_slack_ephemeral_message.await_args.kwargs["thread_ts"] == "1.0"
 
 
 @pytest.mark.asyncio
@@ -761,7 +755,7 @@ async def test_invalid_comment_keeps_modal_open(
 
 
 @pytest.mark.asyncio
-async def test_comment_submission_replaces_the_prompt_that_opened_the_modal(context: Any) -> None:
+async def test_comment_submission_removes_the_prompt_that_opened_the_modal(context: Any) -> None:
     tasks = BackgroundTasks()
     await routes.slack_interactivity(_request(_action("open_swe_feedback_comment")), tasks)
     view = feedback.open_slack_modal.await_args.args[1]
@@ -771,9 +765,9 @@ async def test_comment_submission_replaces_the_prompt_that_opened_the_modal(cont
     await tasks()
     url, message = feedback.respond_to_slack_interaction.await_args.args
     assert url == _RESPONSE_URL
-    assert message["replace_original"] is True
-    assert all("accessory" not in block and "elements" not in block for block in message["blocks"])
-    feedback.post_slack_ephemeral_message.assert_not_awaited()
+    assert message == {"delete_original": True}
+    feedback.post_slack_ephemeral_message.assert_awaited_once()
+    assert feedback.post_slack_ephemeral_message.await_args.kwargs["thread_ts"] == "1.0"
 
 
 @pytest.mark.asyncio
@@ -897,7 +891,7 @@ async def test_dismiss_during_failed_submission_update_prevents_later_acknowledg
     started, finish = asyncio.Event(), asyncio.Event()
 
     async def respond(url: str, message: dict[str, Any]) -> bool:
-        if message.get("replace_original"):
+        if not started.is_set():
             started.set()
             await finish.wait()
             return False
@@ -1257,7 +1251,7 @@ async def test_submission_during_prompt_delivery_is_preserved(
     finish_post = asyncio.Event()
 
     async def post(*args: Any, **kwargs: Any) -> bool:
-        if kwargs["blocks"][-1]["type"] == "actions":
+        if kwargs.get("blocks"):
             started.set()
             await finish_post.wait()
         return True
@@ -1274,6 +1268,7 @@ async def test_submission_during_prompt_delivery_is_preserved(
     record = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
     assert record["prompted"] is True
     assert record["rating"] == 5
+    assert record["acknowledged"] is True
 
 
 def test_prompt_without_dashboard_has_no_broken_link(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1284,9 +1279,11 @@ def test_prompt_without_dashboard_has_no_broken_link(monkeypatch: pytest.MonkeyP
 
 
 @pytest.mark.parametrize("choice,score", [("good", 1.0), ("bad", 0.0)])
+@pytest.mark.parametrize("thread_ts", ["1.0", "0"])
 async def test_native_rating_saves_immediately_and_only_bad_opens_comment(
-    context, fake_store, choice, score
+    context, fake_store, choice, score, thread_ts
 ):
+    fake_store.seed(("slack_thread_feedback", "C1"), "run-1", {**context, "thread_ts": thread_ts})
     payload = _action("open_swe_feedback", json.dumps({"run_id": "run-1", "choice": choice}))
     tasks = BackgroundTasks()
     assert await routes.slack_interactivity(_request(payload), tasks) == {}
@@ -1303,20 +1300,26 @@ async def test_native_rating_saves_immediately_and_only_bad_opens_comment(
     await tasks()
     assert feedback.create_langsmith_thread_feedback.await_args.kwargs["score"] == score
     assert fake_store.values(("thread_feedback",))["thread-1"]["status"] == "completed"
-    assert all(
-        b["type"] == "section"
-        for b in feedback.respond_to_slack_interaction.await_args.args[1]["blocks"]
+    feedback.respond_to_slack_interaction.assert_awaited_once_with(
+        _RESPONSE_URL, {"delete_original": True}
     )
+    feedback.post_slack_ephemeral_message.assert_awaited_once()
+    confirmation = feedback.post_slack_ephemeral_message.await_args
+    assert confirmation.args[:2] == ("C1", "U1")
+    assert "completed" in confirmation.args[2].lower()
+    assert confirmation.kwargs["thread_ts"] == (None if thread_ts == "0" else "1.0")
+    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["acknowledged"]
 
 
 async def test_native_bad_comment_updates_rating_without_overwriting_first_comment(
     context, fake_store
 ):
-    fake_store.seed(
-        ("slack_thread_feedback", "C1"),
-        "run-1",
-        {**context, "completed": True, "choice": "bad", "rating": 1},
-    )
+    tasks = BackgroundTasks()
+    rating = _action("open_swe_feedback", json.dumps({"run_id": "run-1", "choice": "bad"}))
+    await routes.slack_interactivity(_request(rating), tasks)
+    await tasks()
+    feedback.post_slack_ephemeral_message.assert_awaited_once()
+    feedback.respond_to_slack_interaction.reset_mock()
     payload = _submission("  The tests still fail.  ")
     payload["view"]["callback_id"] = "open_swe_feedback_note"
     tasks = BackgroundTasks()
@@ -1325,6 +1328,10 @@ async def test_native_bad_comment_updates_rating_without_overwriting_first_comme
     saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
     assert saved["comment"] == "The tests still fail."
     assert saved["rating"] == 1 and saved["completed"]
+    feedback.respond_to_slack_interaction.assert_awaited_once_with(
+        _RESPONSE_URL, {"delete_original": True}
+    )
+    feedback.post_slack_ephemeral_message.assert_awaited_once()
     assert (
         feedback.create_langsmith_thread_feedback.await_args.kwargs["comment"]
         == "The tests still fail."
@@ -1339,6 +1346,8 @@ async def test_native_rating_cannot_reopen_finished_feedback_or_rate_for_someone
     context, fake_store, blocked
 ):
     initial = {**context, **({blocked: True} if blocked != "other_user" else {})}
+    if blocked == "completed":
+        initial["acknowledged"] = True
     fake_store.seed(("slack_thread_feedback", "C1"), "run-1", initial)
     payload = _action("open_swe_feedback", json.dumps({"run_id": "run-1", "choice": "bad"}))
     if blocked == "other_user":
@@ -1360,7 +1369,7 @@ async def test_native_modal_failure_keeps_saved_bad_rating(context, fake_store):
     assert feedback.create_langsmith_thread_feedback.await_args.kwargs["score"] == 0.0
 
 
-async def test_native_rating_retry_replaces_controls_without_reopening_modal(context, fake_store):
+async def test_native_rating_retry_removes_controls_without_reopening_modal(context, fake_store):
     feedback.respond_to_slack_interaction.side_effect = [False, True]
     for choice in ("bad", "good"):
         tasks = BackgroundTasks()
@@ -1369,9 +1378,23 @@ async def test_native_rating_retry_replaces_controls_without_reopening_modal(con
         await tasks()
     assert feedback.respond_to_slack_interaction.await_count == 2
     assert all(
-        block["type"] == "section"
-        for block in feedback.respond_to_slack_interaction.await_args.args[1]["blocks"]
+        call.args == (_RESPONSE_URL, {"delete_original": True})
+        for call in feedback.respond_to_slack_interaction.await_args_list
     )
     feedback.open_slack_modal.assert_awaited_once()
+    feedback.post_slack_ephemeral_message.assert_awaited_once()
     assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["choice"] == "bad"
     assert feedback.create_langsmith_thread_feedback.await_args.kwargs["score"] == 0.0
+
+
+async def test_confirmation_failure_can_retry_without_repeating_success(context, fake_store):
+    feedback.post_slack_ephemeral_message.side_effect = [False, True]
+    payload = _action("open_swe_feedback", json.dumps({"run_id": "run-1", "choice": "good"}))
+    for expected_acknowledged in (False, True, True):
+        tasks = BackgroundTasks()
+        await routes.slack_interactivity(_request(payload), tasks)
+        await tasks()
+        saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
+        assert saved["completed"] and saved["rating"] == 5
+        assert saved.get("acknowledged", False) is expected_acknowledged
+    assert feedback.post_slack_ephemeral_message.await_count == 2

--- a/tests/slack/test_slack_thread_feedback.py
+++ b/tests/slack/test_slack_thread_feedback.py
@@ -18,401 +18,18 @@ from agent.slack import thread_feedback as feedback
 _RESPONSE_URL = "https://hooks.slack.com/actions/T1/B1/test-response"
 
 
-def _select_rating(rating: int | str, comment: str = "", timestamp: str = "3.0") -> dict[str, Any]:
-    payload = _action(f"open_swe_feedback_select_{rating}")
-    payload["actions"][0]["action_ts"] = timestamp
-    payload["state"] = {"values": {"feedback_comment": {"comment": {"value": comment}}}}
-    return payload
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("choice,rating,score", [("bad", 1, 0.0), ("good", 5, 1.0)])
-async def test_emoji_selection_preserves_comment_and_submits_both(
-    context: Any, fake_store: Any, choice: str, rating: int, score: float
-) -> None:
-    blocks = feedback.rating_blocks("run-1", "thread-1")
-    ratings = next(
-        block["elements"] for block in blocks if block.get("block_id") == "feedback_rating"
-    )
-    assert len(ratings) == 3
-    assert all(element["type"] == "button" for element in ratings)
-    assert [element["text"]["text"].split()[0] for element in ratings] == [
-        "💩",
-        "🙂",
-        "💬",
-    ]
-    tasks = BackgroundTasks()
-    await routes.slack_interactivity(_request(_select_rating(choice, "Keep my comment")), tasks)
-    await tasks()
-    message = feedback.respond_to_slack_interaction.await_args.args[1]
-    ratings = next(
-        block["elements"]
-        for block in message["blocks"]
-        if block.get("block_id") == "feedback_rating"
-    )
-    assert [button["action_id"] for button in ratings if button.get("style") == "primary"] == [
-        f"open_swe_feedback_select_{choice}"
-    ]
-    comment = next(block["element"] for block in message["blocks"] if block["type"] == "input")
-    assert comment["initial_value"] == "Keep my comment"
-    record = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
-    assert record.get("rating") is None
-    assert not record.get("comment") and not record.get("completed")
-    feedback.create_langsmith_thread_feedback.assert_not_awaited()
-    submit = message["blocks"][-1]["elements"][0]
-    payload = _action(submit["action_id"], submit["value"])
-    payload["state"] = {"values": {"feedback_comment": {"comment": {"value": "Final comment"}}}}
-    tasks = BackgroundTasks()
-    await routes.slack_interactivity(_request(payload), tasks)
-    await tasks()
-    record = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
-    assert (record["rating"], record["comment"], record["completed"]) == (
-        rating,
-        "Final comment",
-        True,
-    )
-    assert record["choice"] == choice
-    assert feedback.create_langsmith_thread_feedback.await_args.kwargs["score"] == score
-    assert fake_store.values(("thread_feedback",))["thread-1"]["status"] == "completed"
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("comment", ["", "  ", "Please support my workflow"])
-async def test_other_clears_good_and_requires_comment_on_submit(
-    context: Any, fake_store: Any, comment: str
-) -> None:
-    await feedback._select_feedback_rating(_select_rating("good", timestamp="2.0"))
-    good_submit = feedback.respond_to_slack_interaction.await_args.args[1]["blocks"][-1][
-        "elements"
-    ][0]
-    await feedback._select_feedback_rating(_select_rating("other", timestamp="3.0"))
-    message = feedback.respond_to_slack_interaction.await_args.args[1]
-    comment_input = next(block for block in message["blocks"] if block["type"] == "input")
-    assert comment_input["optional"] is False
-    draft = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
-    assert draft["draft_rating"] is None and draft["draft_choice"] == "other"
-    assert not draft["completed"] and draft["rating"] is None and draft["comment"] == ""
-    feedback.create_langsmith_thread_feedback.assert_not_awaited()
-
-    payload = _action(good_submit["action_id"], good_submit["value"])
-    payload["actions"][0]["action_ts"] = "4.0"
-    payload["state"] = {"values": {"feedback_comment": {"comment": {"value": comment}}}}
-    await feedback._process_submission(payload)
-    saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
-    assert saved["rating"] is None
-    assert saved["completed"] is bool(comment.strip())
-    if comment.strip():
-        assert saved["choice"] == "other"
-        exported = feedback.create_langsmith_thread_feedback.await_args.kwargs
-        assert exported["score"] is None and exported["comment"] == comment
-    else:
-        assert saved == draft
-        feedback.create_langsmith_thread_feedback.assert_not_awaited()
-        assert "comment" in feedback.respond_to_slack_interaction.await_args.args[1]["text"]
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("selection", ["bad", "good", "other", 1, 5])
-@pytest.mark.parametrize("timestamp", ["3.0", "5.0"])
-async def test_selection_delivered_after_submit_cannot_change_feedback(
-    context: Any, fake_store: Any, selection: str | int, timestamp: str
-) -> None:
-    payload = _inline_submission(5, "Final comment")
-    payload["actions"][0]["action_ts"] = "4.0"
-    await feedback._process_submission(payload)
-    previous = dict(fake_store.values(("slack_thread_feedback", "C1"))["run-1"])
-    feedback.create_langsmith_thread_feedback.reset_mock()
-    feedback.respond_to_slack_interaction.reset_mock()
-    tasks = BackgroundTasks()
-    await routes.slack_interactivity(
-        _request(_select_rating(selection, "Later draft", timestamp)), tasks
-    )
-    await tasks()
-    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"] == previous
-    feedback.create_langsmith_thread_feedback.assert_not_awaited()
-    feedback.respond_to_slack_interaction.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_older_emoji_click_cannot_replace_newer_selection(context: Any) -> None:
-    for rating, timestamp in [(5, "4.0"), (2, "3.0")]:
-        tasks = BackgroundTasks()
-        await routes.slack_interactivity(
-            _request(_select_rating(rating, timestamp=timestamp)), tasks
-        )
-        await tasks()
-    feedback.respond_to_slack_interaction.assert_awaited_once()
-    message = feedback.respond_to_slack_interaction.await_args.args[1]
-    selected = next(
-        button
-        for block in message["blocks"]
-        if block.get("block_id") == "feedback_rating"
-        for button in block["elements"]
-        if button.get("style") == "primary"
-    )
-    assert selected["action_id"] == "open_swe_feedback_select_good"
-
-
-@pytest.mark.asyncio
-async def test_submit_during_emoji_update_uses_latest_selection(
-    context: Any, fake_store: Any, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    started, finish = asyncio.Event(), asyncio.Event()
-
-    async def respond(url: str, message: dict[str, Any]) -> bool:
-        if not started.is_set():
-            started.set()
-            await finish.wait()
-        return True
-
-    monkeypatch.setattr(feedback, "respond_to_slack_interaction", AsyncMock(side_effect=respond))
-    old_submit = feedback.rating_blocks("run-1", "thread-1", rating=2)[-1]["elements"][0]
-    payload = _action(old_submit["action_id"], old_submit["value"])
-    payload["actions"][0]["action_ts"] = "4.0"
-    payload["state"] = {
-        "values": {"feedback_comment": {"comment": {"value": "Final submitted comment"}}}
-    }
-    async with asyncio.timeout(2):
-        selection_task = asyncio.create_task(
-            feedback._select_feedback_rating(
-                _select_rating("good", "Earlier draft", timestamp="3.0")
-            )
-        )
-        await started.wait()
-        submit_task = asyncio.create_task(feedback._process_submission(payload))
-        await asyncio.sleep(0)
-        finish.set()
-        await asyncio.gather(selection_task, submit_task)
-
-    saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
-    assert (saved["rating"], saved["comment"], saved["completed"]) == (
-        5,
-        "Final submitted comment",
-        True,
-    )
-    feedback.create_langsmith_thread_feedback.assert_awaited_once()
-    assert feedback.create_langsmith_thread_feedback.await_args.kwargs["score"] == 1.0
-    assert (
-        feedback.create_langsmith_thread_feedback.await_args.kwargs["comment"]
-        == "Final submitted comment"
-    )
-    feedback.post_slack_ephemeral_message.assert_awaited_once()
-    assert feedback.post_slack_ephemeral_message.await_args.kwargs["thread_ts"] == "1.0"
-
-
-@pytest.mark.asyncio
-async def test_emoji_selection_after_pending_error_preserves_new_draft(
-    context: Any, fake_store: Any, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    started, finish = asyncio.Event(), asyncio.Event()
-
-    async def respond(url: str, message: dict[str, Any]) -> bool:
-        if not started.is_set():
-            assert "before submitting" in message["text"]
-            started.set()
-            await finish.wait()
-        return True
-
-    response_mock = AsyncMock(side_effect=respond)
-    monkeypatch.setattr(feedback, "respond_to_slack_interaction", response_mock)
-    invalid_payload = _inline_submission(None, "")
-    invalid_payload["actions"][0]["action_ts"] = "3.0"
-    async with asyncio.timeout(2):
-        invalid_task = asyncio.create_task(feedback._process_submission(invalid_payload))
-        await started.wait()
-        selection_task = asyncio.create_task(
-            feedback._select_feedback_rating(_select_rating(5, "Latest draft", timestamp="4.0"))
-        )
-        await asyncio.sleep(0)
-        finish.set()
-        await asyncio.gather(invalid_task, selection_task)
-
-    assert response_mock.await_count == 2
-    message = response_mock.await_args.args[1]
-    ratings = next(
-        block["elements"]
-        for block in message["blocks"]
-        if block.get("block_id") == "feedback_rating"
-    )
-    assert [button["action_id"] for button in ratings if button.get("style") == "primary"] == [
-        "open_swe_feedback_select_good"
-    ]
-    comment = next(block["element"] for block in message["blocks"] if block["type"] == "input")
-    assert comment["initial_value"] == "Latest draft"
-    assert json.loads(message["blocks"][-1]["elements"][0]["value"])["rating"] == 5
-    saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
-    assert not saved.get("completed")
-    feedback.create_langsmith_thread_feedback.assert_not_awaited()
-    feedback.post_slack_ephemeral_message.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_older_invalid_submit_cannot_replace_newer_emoji_selection(
-    context: Any, fake_store: Any
-) -> None:
-    await feedback._select_feedback_rating(_select_rating(5, "Latest draft", timestamp="4.0"))
-    invalid_payload = _inline_submission(None, "")
-    invalid_payload["actions"][0]["action_ts"] = "3.0"
-    await feedback._process_submission(invalid_payload)
-
-    feedback.respond_to_slack_interaction.assert_awaited_once()
-    saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
-    assert not saved.get("completed")
-    feedback.create_langsmith_thread_feedback.assert_not_awaited()
-    feedback.post_slack_ephemeral_message.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_failed_emoji_selection_can_be_retried(context: Any, fake_store: Any) -> None:
-    feedback.respond_to_slack_interaction.side_effect = [False, True]
-    payload = _select_rating(4, "Keep my draft")
-    tasks = BackgroundTasks()
-    await routes.slack_interactivity(_request(payload), tasks)
-    await tasks()
-    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"] == context
-    tasks = BackgroundTasks()
-    await routes.slack_interactivity(_request(payload), tasks)
-    await tasks()
-    assert feedback.respond_to_slack_interaction.await_count == 2
-    message = feedback.respond_to_slack_interaction.await_args.args[1]
-    submit = message["blocks"][-1]["elements"][0]
-    assert json.loads(submit["value"])["rating"] == 4
-    feedback.create_langsmith_thread_feedback.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("status", ["completed", "dismissed"])
-async def test_emoji_selection_cannot_reopen_finished_feedback(
-    context: Any, fake_store: Any, status: str
-) -> None:
-    record = {**context, status: True}
-    fake_store.seed(("slack_thread_feedback", "C1"), "run-1", record)
-    tasks = BackgroundTasks()
-    await routes.slack_interactivity(_request(_select_rating(4)), tasks)
-    await tasks()
-    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"] == record
-    feedback.respond_to_slack_interaction.assert_not_awaited()
-    feedback.create_langsmith_thread_feedback.assert_not_awaited()
-
-
-def _inline_submission(rating: int | None = 5, comment: str = "Helpful") -> dict[str, Any]:
-    payload = _action(
-        "open_swe_feedback_submit",
-        json.dumps({"run_id": "run-1", "rating": rating}) if rating is not None else "run-1",
-    )
-    payload["state"] = {"values": {"feedback_comment": {"comment": {"value": comment}}}}
-    return payload
-
-
-def _legacy_inline_submission(rating: int | None = 5, comment: str = "Helpful") -> dict[str, Any]:
-    payload = _action("open_swe_feedback_submit")
-    payload["state"] = {
-        "values": {
-            "feedback_rating": {
-                "open_swe_feedback_rating": {
-                    "selected_option": {"value": str(rating)} if rating is not None else None
-                }
-            },
-            "feedback_comment": {"comment": {"value": comment}},
-        }
-    }
-    return payload
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("legacy", [False, True])
-async def test_inline_rating_and_comment_submit_together_and_complete(
-    context: Any, fake_store: Any, legacy: bool
-) -> None:
-    tasks = BackgroundTasks()
-    submission = _legacy_inline_submission if legacy else _inline_submission
-    assert (
-        await routes.slack_interactivity(_request(submission(4, "  Very helpful  ")), tasks) == {}
-    )
-    await tasks()
-    record = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
-    assert (record["rating"], record["comment"], record["completed"]) == (4, "Very helpful", True)
-    feedback.create_langsmith_thread_feedback.assert_awaited_once()
-    assert feedback.create_langsmith_thread_feedback.await_args.kwargs["score"] == 0.75
-    assert feedback.create_langsmith_thread_feedback.await_args.kwargs["comment"] == "Very helpful"
-    message = feedback.respond_to_slack_interaction.await_args.args[1]
-    assert message == {"delete_original": True}
-    feedback.post_slack_ephemeral_message.assert_awaited_once()
-    assert feedback.post_slack_ephemeral_message.await_args.kwargs["thread_ts"] == "1.0"
-
-
-@pytest.mark.asyncio
-async def test_completed_submission_cannot_be_overwritten(context: Any, fake_store: Any) -> None:
-    for rating, comment in [(5, "Great"), (1, "Stale submission")]:
-        tasks = BackgroundTasks()
-        await routes.slack_interactivity(_request(_inline_submission(rating, comment)), tasks)
-        await tasks()
-    record = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
-    assert (record["rating"], record["comment"], record["completed"]) == (5, "Great", True)
-
-
-@pytest.mark.asyncio
-async def test_inline_save_failure_keeps_draft_in_original_message(
-    context: Any, fake_store: Any, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setattr(fake_store, "put_item", AsyncMock(side_effect=RuntimeError("unavailable")))
-    tasks = BackgroundTasks()
-    await routes.slack_interactivity(_request(_inline_submission(3, "Keep this draft")), tasks)
-    await tasks()
-    assert not fake_store.values(("slack_thread_feedback", "C1"))["run-1"].get("completed")
-    message = feedback.respond_to_slack_interaction.await_args.args[1]
-    inputs = {
-        block["block_id"]: block["element"]
-        for block in message["blocks"]
-        if block["type"] == "input"
-    }
-    submit = message["blocks"][-1]["elements"][0]
-    assert json.loads(submit["value"]) == {
-        "run_id": "run-1",
-        "rating": 3,
-        "selection_ts": "0",
-    }
-    assert inputs["feedback_comment"]["initial_value"] == "Keep this draft"
-    feedback.create_langsmith_thread_feedback.assert_not_awaited()
-    feedback.post_slack_ephemeral_message.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "rating,comment,score",
-    [
-        (1, "", 0.0),
-        (2, "", 0.25),
-        (3, "", 0.5),
-        (4, "", 0.75),
-        (5, "", 1.0),
-        (None, "Comment only", None),
-    ],
-)
-async def test_inline_optional_fields_and_rating_scale(
-    context: Any, fake_store: Any, rating: int | None, comment: str, score: float | None
-) -> None:
-    tasks = BackgroundTasks()
-    await routes.slack_interactivity(_request(_inline_submission(rating, comment)), tasks)
-    await tasks()
-    record = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
-    assert (record["rating"], record["comment"], record["completed"]) == (rating, comment, True)
-    assert feedback.create_langsmith_thread_feedback.await_args.kwargs["score"] == score
-
-
 @pytest.mark.asyncio
 @pytest.mark.parametrize("change", ["other_user", "other_channel", "unknown_run", "external"])
-@pytest.mark.parametrize("selecting", [False, True])
 async def test_feedback_interaction_requires_prompt_recipient(
-    context: Any, fake_store: Any, monkeypatch: pytest.MonkeyPatch, change: str, selecting: bool
+    context: Any, fake_store: Any, monkeypatch: pytest.MonkeyPatch, change: str
 ) -> None:
-    payload = _select_rating("good") if selecting else _inline_submission()
+    payload = _rating()
     if change == "other_user":
         payload["user"]["id"] = "U2"
     elif change == "other_channel":
         payload["channel"]["id"] = "C2"
     elif change == "unknown_run":
-        payload["actions"][0]["value"] = "run-2"
+        payload = _rating(run_id="run-2")
     else:
         monkeypatch.setattr(
             feedback, "get_slack_channel_context", AsyncMock(return_value={"is_ext_shared": True})
@@ -423,68 +40,6 @@ async def test_feedback_interaction_requires_prompt_recipient(
     assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"] == context
     feedback.create_langsmith_thread_feedback.assert_not_awaited()
     feedback.respond_to_slack_interaction.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "rating,comment", [(None, "  "), (0, "Draft"), (6, "Draft"), (3, "x" * 3001)]
-)
-async def test_invalid_inline_submission_keeps_prompt_open(
-    context: Any, fake_store: Any, rating: int | None, comment: str
-) -> None:
-    tasks = BackgroundTasks()
-    await routes.slack_interactivity(_request(_inline_submission(rating, comment)), tasks)
-    await tasks()
-    saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
-    assert not saved.get("completed") and not saved.get("rating") and not saved.get("comment")
-    feedback.create_langsmith_thread_feedback.assert_not_awaited()
-    message = feedback.respond_to_slack_interaction.await_args.args[1]
-    assert message["replace_original"] is True
-    assert any(block["type"] == "input" for block in message["blocks"])
-    feedback.post_slack_ephemeral_message.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_changing_rating_does_not_submit_feedback(context: Any, fake_store: Any) -> None:
-    tasks = BackgroundTasks()
-    await routes.slack_interactivity(_request(_action("open_swe_feedback_rating")), tasks)
-    await tasks()
-    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"] == context
-    feedback.create_langsmith_thread_feedback.assert_not_awaited()
-    feedback.respond_to_slack_interaction.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_legacy_rating_button_opens_combined_form_without_saving(
-    context: Any, fake_store: Any
-) -> None:
-    tasks = BackgroundTasks()
-    await routes.slack_interactivity(_request(_action("open_swe_feedback_rate_4")), tasks)
-    await tasks()
-    view = feedback.open_slack_modal.await_args.args[1]
-    assert view["blocks"][0]["element"]["initial_option"]["value"] == "4"
-    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"] == context
-    feedback.create_langsmith_thread_feedback.assert_not_awaited()
-    payload = _submission("Combined")
-    payload["view"]["private_metadata"] = view["private_metadata"]
-    payload["view"]["state"] = _legacy_inline_submission(4, "Combined")["state"]
-    submit_tasks = BackgroundTasks()
-    assert await routes.slack_interactivity(_request(payload), submit_tasks) == {}
-    await submit_tasks()
-    record = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
-    assert (record["rating"], record["comment"], record["completed"]) == (4, "Combined", True)
-
-
-@pytest.mark.asyncio
-async def test_dismissed_feedback_cannot_be_submitted(context: Any, fake_store: Any) -> None:
-    previous = {**context, "dismissed": True}
-    fake_store.seed(("slack_thread_feedback", "C1"), "run-1", previous)
-    tasks = BackgroundTasks()
-    await routes.slack_interactivity(_request(_inline_submission()), tasks)
-    await tasks()
-    assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"] == previous
-    feedback.respond_to_slack_interaction.assert_not_awaited()
-    feedback.create_langsmith_thread_feedback.assert_not_awaited()
 
 
 def _request(payload: dict[str, Any]) -> Request:
@@ -547,7 +102,7 @@ def context(monkeypatch: pytest.MonkeyPatch, fake_store: Any) -> dict[str, Any]:
     return record
 
 
-def _action(action_id: str = "open_swe_feedback_rate_5", value: str = "run-1") -> dict[str, Any]:
+def _action(action_id: str, value: str = "run-1") -> dict[str, Any]:
     return {
         "type": "block_actions",
         "trigger_id": "trigger-1",
@@ -558,25 +113,14 @@ def _action(action_id: str = "open_swe_feedback_rate_5", value: str = "run-1") -
     }
 
 
-@pytest.mark.asyncio
-async def test_comment_modal_opens_with_saved_rating_and_comment(
-    context: Any, fake_store: Any
-) -> None:
-    fake_store.seed(
-        ("slack_thread_feedback", "C1"), "run-1", {**context, "rating": 4, "comment": "Useful"}
-    )
+def _rating(choice: str = "good", run_id: str = "run-1") -> dict[str, Any]:
+    return _action("open_swe_feedback", json.dumps({"run_id": run_id, "choice": choice}))
+
+
+async def _submit_rating(choice: str = "good") -> None:
     tasks = BackgroundTasks()
-    result = await routes.slack_interactivity(_request(_action("open_swe_feedback_comment")), tasks)
-    assert result == {}
-    feedback.open_slack_modal.assert_awaited_once()
-    trigger_id, view = feedback.open_slack_modal.await_args.args
-    assert trigger_id == "trigger-1"
-    assert json.loads(view["private_metadata"]) == {
-        "channel_id": "C1",
-        "run_id": "run-1",
-        "response_url": _RESPONSE_URL,
-    }
-    assert view["blocks"][-1]["element"]["initial_value"] == "Useful"
+    assert await routes.slack_interactivity(_request(_rating(choice)), tasks) == {}
+    await tasks()
 
 
 def _submission(comment: str = "Please run the tests next time.") -> dict[str, Any]:
@@ -584,7 +128,7 @@ def _submission(comment: str = "Please run the tests next time.") -> dict[str, A
         "type": "view_submission",
         "user": {"id": "U1"},
         "view": {
-            "callback_id": "open_swe_feedback_comment",
+            "callback_id": "open_swe_feedback_note",
             "private_metadata": json.dumps(
                 {"channel_id": "C1", "run_id": "run-1", "response_url": _RESPONSE_URL}
             ),
@@ -595,14 +139,19 @@ def _submission(comment: str = "Please run the tests next time.") -> dict[str, A
 
 @pytest.mark.parametrize("valid", [False, True])
 def test_feedback_http_response_preserves_modal_errors_and_empty_ack(
-    context: Any, valid: bool
+    context: Any, fake_store: Any, valid: bool
 ) -> None:
+    fake_store.seed(
+        ("slack_thread_feedback", "C1"),
+        "run-1",
+        {**context, "rating": 1, "choice": "bad", "completed": True},
+    )
     app = FastAPI()
     app.include_router(routes.router)
     with TestClient(app) as client:
         response = client.post(
             "/webhooks/slack/interactivity",
-            data={"payload": json.dumps(_submission("Helpful" if valid else " "))},
+            data={"payload": json.dumps(_submission("Helpful" if valid else "x" * 3001))},
         )
     assert response.status_code == 200
     if valid:
@@ -613,36 +162,37 @@ def test_feedback_http_response_preserves_modal_errors_and_empty_ack(
 
 
 @pytest.mark.asyncio
-async def test_comment_submission_updates_same_feedback(context: Any, fake_store: Any) -> None:
-    fake_store.seed(("slack_thread_feedback", "C1"), "run-1", {**context, "rating": 2})
+@pytest.mark.parametrize("choice", [None, "good"])
+async def test_comment_requires_bad_rating(context: Any, choice: str | None) -> None:
+    if choice:
+        await _submit_rating(choice)
     tasks = BackgroundTasks()
     result = await routes.slack_interactivity(_request(_submission()), tasks)
-    assert result == {}
-    assert (
-        fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["comment"]
-        == "Please run the tests next time."
-    )
-    await tasks()
-    assert feedback.create_langsmith_thread_feedback.await_args.args == (
-        "thread-1",
-        "rating",
-    )
-    assert feedback.create_langsmith_thread_feedback.await_args.kwargs["score"] == 0.25
+    assert result["response_action"] == "errors"
+    assert tasks.tasks == []
 
 
 @pytest.mark.asyncio
-async def test_empty_comment_without_rating_keeps_form_open(context: Any) -> None:
+async def test_empty_optional_comment_preserves_bad_rating(context: Any, fake_store: Any) -> None:
+    await _submit_rating("bad")
     tasks = BackgroundTasks()
-    result = await routes.slack_interactivity(_request(_submission("  ")), tasks)
-    assert result["response_action"] == "errors"
-    assert tasks.tasks == []
+    assert await routes.slack_interactivity(_request(_submission("  ")), tasks) == {}
+    await tasks()
+    saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
+    assert saved["choice"] == "bad" and saved["completed"] and saved["comment"] == ""
+    assert feedback.create_langsmith_thread_feedback.await_args.kwargs["score"] == 0.0
+    feedback.post_slack_ephemeral_message.assert_awaited_once()
 
 
 @pytest.mark.asyncio
 async def test_storage_failure_keeps_comment_modal_open(
     context: Any, monkeypatch: pytest.MonkeyPatch, fake_store: Any
 ) -> None:
-    fake_store.seed(("slack_thread_feedback", "C1"), "run-1", {**context, "rating": 2})
+    fake_store.seed(
+        ("slack_thread_feedback", "C1"),
+        "run-1",
+        {**context, "rating": 1, "choice": "bad", "completed": True},
+    )
     monkeypatch.setattr(fake_store, "put_item", AsyncMock(side_effect=RuntimeError("unavailable")))
     tasks = BackgroundTasks()
     result = await routes.slack_interactivity(_request(_submission()), tasks)
@@ -730,7 +280,9 @@ async def test_invalid_comment_keeps_modal_open(
     context: Any, fake_store: Any, change: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     fake_store.seed(
-        ("slack_thread_feedback", "C1"), "run-1", {**context, "rating": 3, "comment": "Original"}
+        ("slack_thread_feedback", "C1"),
+        "run-1",
+        {**context, "rating": 1, "choice": "bad", "completed": True, "comment": "Original"},
     )
     payload = _submission()
     if change == "other_user":
@@ -755,29 +307,13 @@ async def test_invalid_comment_keeps_modal_open(
 
 
 @pytest.mark.asyncio
-async def test_comment_submission_removes_the_prompt_that_opened_the_modal(context: Any) -> None:
-    tasks = BackgroundTasks()
-    await routes.slack_interactivity(_request(_action("open_swe_feedback_comment")), tasks)
-    view = feedback.open_slack_modal.await_args.args[1]
-    payload = _submission("Helpful")
-    payload["view"]["private_metadata"] = view["private_metadata"]
-    await routes.slack_interactivity(_request(payload), tasks)
-    await tasks()
-    url, message = feedback.respond_to_slack_interaction.await_args.args
-    assert url == _RESPONSE_URL
-    assert message == {"delete_original": True}
-    feedback.post_slack_ephemeral_message.assert_awaited_once()
-    assert feedback.post_slack_ephemeral_message.await_args.kwargs["thread_ts"] == "1.0"
-
-
-@pytest.mark.asyncio
 @pytest.mark.parametrize("other_user", [False, True])
 async def test_dismiss_removes_prompt_without_saving_feedback(
     context: Any, fake_store: Any, other_user: bool
 ) -> None:
     button = next(
         element
-        for block in feedback.rating_blocks("run-1", "thread-1")
+        for block in feedback.feedback_blocks("run-1", "thread-1")
         for element in block.get("elements", [])
         if element["action_id"] == "open_swe_feedback_dismiss"
     )
@@ -809,7 +345,7 @@ async def test_dismiss_removes_prompt_without_saving_feedback(
 async def test_prompt_cleanup_failure_preserves_saved_feedback_and_confirmation(
     context: Any, fake_store: Any, missing_url: bool
 ) -> None:
-    payload = _inline_submission()
+    payload = _rating()
     if missing_url:
         payload.pop("response_url")
     feedback.respond_to_slack_interaction.return_value = False
@@ -836,9 +372,9 @@ async def test_dismiss_failure_keeps_feedback_submittable(context: Any, fake_sto
     assert not saved.get("dismissed")
     feedback.post_slack_ephemeral_message.assert_not_awaited()
     feedback.create_langsmith_thread_feedback.assert_not_awaited()
-    await feedback._process_submission(_inline_submission(4, "Retry after failed dismissal"))
+    await _submit_rating()
     saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
-    assert saved["completed"] and saved["rating"] == 4
+    assert saved["completed"] and saved["rating"] == 5
 
 
 @pytest.mark.asyncio
@@ -868,7 +404,7 @@ async def test_dismiss_retry_after_failed_rollback_cannot_save_late_feedback(
     monkeypatch.setattr(fake_store, "put_item", put)
     feedback.respond_to_slack_interaction.side_effect = [False, True]
     await feedback._dismiss_feedback(_action("open_swe_feedback_dismiss"))
-    await feedback._process_submission(_inline_submission())
+    await _submit_rating()
     assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["dismissed"]
     feedback.create_langsmith_thread_feedback.assert_not_awaited()
     await feedback._dismiss_feedback(_action("open_swe_feedback_dismiss"))
@@ -878,11 +414,12 @@ async def test_dismiss_retry_after_failed_rollback_cannot_save_late_feedback(
 
 @pytest.mark.asyncio
 async def test_dismiss_preserves_already_submitted_feedback(context: Any, fake_store: Any) -> None:
-    await feedback._process_submission(_inline_submission(4, "Submitted"))
+    await _submit_rating("bad")
+    await routes.slack_interactivity(_request(_submission("Submitted")), BackgroundTasks())
     await feedback._dismiss_feedback(_action("open_swe_feedback_dismiss"))
     saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
     assert (saved["rating"], saved["comment"], saved["completed"], saved["dismissed"]) == (
-        4,
+        1,
         "Submitted",
         True,
         True,
@@ -905,7 +442,7 @@ async def test_dismiss_during_failed_submission_update_prevents_later_acknowledg
     response_mock = AsyncMock(side_effect=respond)
     monkeypatch.setattr(feedback, "respond_to_slack_interaction", response_mock)
     async with asyncio.timeout(2):
-        rating_task = asyncio.create_task(feedback._process_submission(_inline_submission()))
+        rating_task = asyncio.create_task(_submit_rating())
         await started.wait()
         dismiss_task = asyncio.create_task(
             feedback._dismiss_feedback(_action("open_swe_feedback_dismiss"))
@@ -929,6 +466,11 @@ async def test_dismiss_during_failed_submission_update_prevents_later_acknowledg
 async def test_late_comment_during_dismissal_is_not_saved(
     context: Any, fake_store: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    fake_store.seed(
+        ("slack_thread_feedback", "C1"),
+        "run-1",
+        {**context, "rating": 1, "choice": "bad", "completed": True},
+    )
     started, finish = asyncio.Event(), asyncio.Event()
 
     async def respond(url: str, message: dict[str, Any]) -> bool:
@@ -944,7 +486,8 @@ async def test_late_comment_during_dismissal_is_not_saved(
         )
         await started.wait()
         tasks = BackgroundTasks()
-        assert await routes.slack_interactivity(_request(_submission("Helpful")), tasks) == {}
+        result = await routes.slack_interactivity(_request(_submission("Helpful")), tasks)
+        assert result["response_action"] == "errors"
         finish.set()
         await asyncio.gather(dismiss_task, tasks())
     saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
@@ -959,7 +502,7 @@ async def test_langsmith_failure_preserves_saved_feedback(
 ) -> None:
     monkeypatch.setattr(feedback, "create_langsmith_thread_feedback", AsyncMock(return_value=False))
     tasks = BackgroundTasks()
-    await routes.slack_interactivity(_request(_inline_submission()), tasks)
+    await routes.slack_interactivity(_request(_rating()), tasks)
     await tasks()
     assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["rating"] == 5
 
@@ -1065,7 +608,7 @@ async def test_feedback_requires_verified_slack_signature(
     monkeypatch.setattr(routes.common, "verify_slack_signature", lambda **kwargs: False)
     tasks = BackgroundTasks()
     with pytest.raises(HTTPException) as exc:
-        await routes.slack_interactivity(_request(_action()), tasks)
+        await routes.slack_interactivity(_request(_rating()), tasks)
     assert exc.value.status_code == 401
     assert tasks.tasks == []
 
@@ -1209,9 +752,9 @@ async def test_followup_prompts_only_thread_initiator(
     assert feedback.post_slack_ephemeral_message.await_args.args[:2] == ("C1", "U1")
     record = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
     assert record["user_id"] == "U1"
-    other_user_rating = _action()
+    other_user_rating = _rating()
     other_user_rating["user"]["id"] = "U2"
-    await feedback._process_submission({**_inline_submission(), "user": {"id": "U2"}})
+    await routes.slack_interactivity(_request(other_user_rating), BackgroundTasks())
     assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["rating"] is None
     feedback.create_langsmith_thread_feedback.assert_not_awaited()
 
@@ -1269,7 +812,7 @@ async def test_submission_during_prompt_delivery_is_preserved(
             feedback.post_slack_feedback_prompt("thread-1", "run-1", "C1")
         )
         await started.wait()
-        rating_task = asyncio.create_task(feedback._process_submission(_inline_submission()))
+        rating_task = asyncio.create_task(_submit_rating())
         finish_post.set()
         await asyncio.gather(prompt_task, rating_task)
     record = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
@@ -1280,7 +823,7 @@ async def test_submission_during_prompt_delivery_is_preserved(
 
 def test_prompt_without_dashboard_has_no_broken_link(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(feedback, "dashboard_thread_url", lambda _: None)
-    text = feedback.rating_blocks("run-1", "thread-1")[0]["text"]["text"]
+    text = feedback.feedback_blocks("run-1", "thread-1")[0]["text"]["text"]
     assert "<" not in text
     assert "this thread" in text
 
@@ -1328,13 +871,17 @@ async def test_native_bad_comment_updates_rating_without_overwriting_first_comme
     feedback.post_slack_ephemeral_message.assert_awaited_once()
     feedback.respond_to_slack_interaction.reset_mock()
     payload = _submission("  The tests still fail.  ")
-    payload["view"]["callback_id"] = "open_swe_feedback_note"
+    payload["view"]["private_metadata"] = feedback.open_slack_modal.await_args.args[1][
+        "private_metadata"
+    ]
     tasks = BackgroundTasks()
     assert await routes.slack_interactivity(_request(payload), tasks) == {}
     await tasks()
     saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
     assert saved["comment"] == "The tests still fail."
     assert saved["rating"] == 1 and saved["completed"]
+    assert feedback.create_langsmith_thread_feedback.await_args.args == ("thread-1", "rating")
+    assert feedback.create_langsmith_thread_feedback.await_args.kwargs["score"] == 0.0
     feedback.respond_to_slack_interaction.assert_awaited_once_with(
         _RESPONSE_URL, {"delete_original": True}
     )
@@ -1409,3 +956,41 @@ async def test_confirmation_failure_can_retry_without_repeating_success(
         assert saved.get("acknowledged", False) is expected_acknowledged
         assert feedback.respond_to_slack_interaction.await_count == deletions
     assert feedback.post_slack_ephemeral_message.await_count == 2
+
+
+@pytest.mark.parametrize(
+    "slow_call", ["post_slack_ephemeral_message", "create_langsmith_thread_feedback"]
+)
+async def test_comment_saved_during_slow_confirmation_or_export_is_preserved(
+    context: Any, fake_store: Any, slow_call: str
+) -> None:
+    started, finish = asyncio.Event(), asyncio.Event()
+
+    async def wait_for_network(*args: Any, **kwargs: Any) -> bool:
+        started.set()
+        await finish.wait()
+        return True
+
+    getattr(feedback, slow_call).side_effect = wait_for_network
+    async with asyncio.timeout(2):
+        rating_task = asyncio.create_task(_submit_rating("bad"))
+        await started.wait()
+        comment_tasks = BackgroundTasks()
+        assert (
+            await routes.slack_interactivity(_request(_submission("Missing tests")), comment_tasks)
+            == {}
+        )
+        assert (
+            fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["comment"]
+            == "Missing tests"
+        )
+        finish.set()
+        await asyncio.gather(rating_task, comment_tasks())
+
+    saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
+    assert (
+        saved["choice"] == "bad" and saved["comment"] == "Missing tests" and saved["acknowledged"]
+    )
+    exported = feedback.create_langsmith_thread_feedback.await_args.kwargs
+    assert exported["score"] == 0.0 and exported["comment"] == "Missing tests"
+    feedback.post_slack_ephemeral_message.assert_awaited_once()

--- a/tests/slack/test_slack_thread_feedback.py
+++ b/tests/slack/test_slack_thread_feedback.py
@@ -631,7 +631,7 @@ async def test_comment_submission_updates_same_feedback(context: Any, fake_store
     await tasks()
     assert feedback.create_langsmith_thread_feedback.await_args.args == (
         "thread-1",
-        "slack_rating:C1:U1:run-1",
+        "rating",
     )
     assert feedback.create_langsmith_thread_feedback.await_args.kwargs["score"] == 0.25
 

--- a/ui/src/features/agents/components/ThreadFeedbackCard.test.tsx
+++ b/ui/src/features/agents/components/ThreadFeedbackCard.test.tsx
@@ -48,7 +48,7 @@ afterEach(() => {
 
 it("shows only Good/Bad and saves Good without a comment form", async () => {
   renderCard()
-  const good = await screen.findByRole("button", { name: "👍 Good" })
+  const good = await screen.findByRole("button", { name: "🙂 Good" })
   expect(screen.queryByRole("textbox")).toBeNull()
   expect(screen.queryByRole("button", { name: /Other|Submit/ })).toBeNull()
   fireEvent.click(good)
@@ -61,14 +61,14 @@ it("shows only Good/Bad and saves Good without a comment form", async () => {
 
 it("saves Bad before offering an optional comment and keeps the draft on failure", async () => {
   renderCard()
-  fireEvent.click(await screen.findByRole("button", { name: "👎 Bad" }))
+  fireEvent.click(await screen.findByRole("button", { name: "💩 Bad" }))
   const comment = await screen.findByRole("textbox", {
     name: "Comment (optional)",
   })
   expect(api.submitThreadFeedback).toHaveBeenCalledExactlyOnceWith("thread-1", {
     rating: "bad",
   })
-  expect(screen.queryByRole("button", { name: "👍 Good" })).toBeNull()
+  expect(screen.queryByRole("button", { name: "🙂 Good" })).toBeNull()
   fireEvent.change(comment, { target: { value: " More detail please. " } })
   api.submitThreadFeedback.mockRejectedValueOnce(new Error("Temporary outage"))
   fireEvent.click(screen.getByRole("button", { name: "Submit comment" }))
@@ -85,7 +85,7 @@ it("saves Bad before offering an optional comment and keeps the draft on failure
 
 it("allows skipping the comment without undoing the Bad rating", async () => {
   renderCard()
-  fireEvent.click(await screen.findByRole("button", { name: "👎 Bad" }))
+  fireEvent.click(await screen.findByRole("button", { name: "💩 Bad" }))
   fireEvent.click(await screen.findByRole("button", { name: "Skip" }))
   await screen.findByText("Thanks for your feedback.")
   expect(api.submitThreadFeedback).toHaveBeenCalledExactlyOnceWith("thread-1", {
@@ -97,10 +97,10 @@ it("allows skipping the comment without undoing the Bad rating", async () => {
 it("keeps the rating controls available when saving the rating fails", async () => {
   api.submitThreadFeedback.mockRejectedValueOnce(new Error("Temporary outage"))
   renderCard()
-  fireEvent.click(await screen.findByRole("button", { name: "👎 Bad" }))
+  fireEvent.click(await screen.findByRole("button", { name: "💩 Bad" }))
   await screen.findByRole("alert")
   expect(screen.queryByRole("textbox")).toBeNull()
-  fireEvent.click(screen.getByRole("button", { name: "👎 Bad" }))
+  fireEvent.click(screen.getByRole("button", { name: "💩 Bad" }))
   await screen.findByRole("textbox")
 })
 

--- a/ui/src/features/agents/components/ThreadFeedbackCard.test.tsx
+++ b/ui/src/features/agents/components/ThreadFeedbackCard.test.tsx
@@ -48,7 +48,7 @@ afterEach(() => {
 
 it("shows only Good/Bad and saves Good without a comment form", async () => {
   renderCard()
-  const good = await screen.findByRole("button", { name: "🙂 Good" })
+  const good = await screen.findByRole("button", { name: "Good" })
   expect(screen.queryByRole("textbox")).toBeNull()
   expect(screen.queryByRole("button", { name: /Other|Submit/ })).toBeNull()
   fireEvent.click(good)
@@ -61,14 +61,14 @@ it("shows only Good/Bad and saves Good without a comment form", async () => {
 
 it("saves Bad before offering an optional comment and keeps the draft on failure", async () => {
   renderCard()
-  fireEvent.click(await screen.findByRole("button", { name: "💩 Bad" }))
+  fireEvent.click(await screen.findByRole("button", { name: "Bad" }))
   const comment = await screen.findByRole("textbox", {
     name: "Comment (optional)",
   })
   expect(api.submitThreadFeedback).toHaveBeenCalledExactlyOnceWith("thread-1", {
     rating: "bad",
   })
-  expect(screen.queryByRole("button", { name: "🙂 Good" })).toBeNull()
+  expect(screen.queryByRole("button", { name: "Good" })).toBeNull()
   fireEvent.change(comment, { target: { value: " More detail please. " } })
   api.submitThreadFeedback.mockRejectedValueOnce(new Error("Temporary outage"))
   fireEvent.click(screen.getByRole("button", { name: "Submit comment" }))
@@ -85,7 +85,7 @@ it("saves Bad before offering an optional comment and keeps the draft on failure
 
 it("allows skipping the comment without undoing the Bad rating", async () => {
   renderCard()
-  fireEvent.click(await screen.findByRole("button", { name: "💩 Bad" }))
+  fireEvent.click(await screen.findByRole("button", { name: "Bad" }))
   fireEvent.click(await screen.findByRole("button", { name: "Skip" }))
   await screen.findByText("Thanks for your feedback.")
   expect(api.submitThreadFeedback).toHaveBeenCalledExactlyOnceWith("thread-1", {
@@ -97,10 +97,10 @@ it("allows skipping the comment without undoing the Bad rating", async () => {
 it("keeps the rating controls available when saving the rating fails", async () => {
   api.submitThreadFeedback.mockRejectedValueOnce(new Error("Temporary outage"))
   renderCard()
-  fireEvent.click(await screen.findByRole("button", { name: "💩 Bad" }))
+  fireEvent.click(await screen.findByRole("button", { name: "Bad" }))
   await screen.findByRole("alert")
   expect(screen.queryByRole("textbox")).toBeNull()
-  fireEvent.click(screen.getByRole("button", { name: "💩 Bad" }))
+  fireEvent.click(screen.getByRole("button", { name: "Bad" }))
   await screen.findByRole("textbox")
 })
 

--- a/ui/src/features/agents/components/ThreadFeedbackCard.test.tsx
+++ b/ui/src/features/agents/components/ThreadFeedbackCard.test.tsx
@@ -33,6 +33,7 @@ function renderCard() {
 }
 
 beforeEach(() => {
+  vi.resetAllMocks()
   api.getThreadFeedback.mockResolvedValue(ready)
   api.submitThreadFeedback.mockImplementation(async (_threadId, body) => ({
     ...ready,
@@ -45,49 +46,73 @@ afterEach(() => {
   vi.clearAllMocks()
 })
 
-it.each([
-  { rating: "good", label: "🙂 Good", comment: "" },
-  { rating: "bad", label: "💩 Bad", comment: "The tests still fail." },
-])(
-  "saves $rating and an optional comment only on Submit",
-  async ({ rating, label, comment }) => {
-    renderCard()
-    fireEvent.click(await screen.findByRole("button", { name: "💩 Bad" }))
-    fireEvent.click(screen.getByRole("button", { name: label }))
-    fireEvent.change(screen.getByRole("textbox"), {
-      target: { value: comment },
-    })
-    expect(api.submitThreadFeedback).not.toHaveBeenCalled()
-    fireEvent.click(screen.getByRole("button", { name: "Submit feedback" }))
-    await screen.findByText("Thanks for your feedback.")
-    expect(api.submitThreadFeedback).toHaveBeenCalledExactlyOnceWith(
-      "thread-1",
-      { rating, comment }
-    )
-    expect(screen.queryByRole("button")).toBeNull()
-  }
-)
-
-it("requires a comment for Other and keeps the draft when saving fails", async () => {
-  api.submitThreadFeedback.mockRejectedValueOnce(new Error("Temporary outage"))
+it("shows only Good/Bad and saves Good without a comment form", async () => {
   renderCard()
-  fireEvent.click(await screen.findByRole("button", { name: "💬 Other" }))
-  const comment = screen.getByRole("textbox", { name: "Comment (required)" })
-  const submit = screen.getByRole("button", {
-    name: "Submit feedback",
-  }) as HTMLButtonElement
-  fireEvent.change(comment, { target: { value: "  " } })
-  expect(submit.disabled).toBe(true)
+  const good = await screen.findByRole("button", { name: "👍 Good" })
+  expect(screen.queryByRole("textbox")).toBeNull()
+  expect(screen.queryByRole("button", { name: /Other|Submit/ })).toBeNull()
+  fireEvent.click(good)
+  await screen.findByText("Thanks for your feedback.")
+  expect(api.submitThreadFeedback).toHaveBeenCalledExactlyOnceWith("thread-1", {
+    rating: "good",
+  })
+  expect(screen.queryByRole("button")).toBeNull()
+})
+
+it("saves Bad before offering an optional comment and keeps the draft on failure", async () => {
+  renderCard()
+  fireEvent.click(await screen.findByRole("button", { name: "👎 Bad" }))
+  const comment = await screen.findByRole("textbox", {
+    name: "Comment (optional)",
+  })
+  expect(api.submitThreadFeedback).toHaveBeenCalledExactlyOnceWith("thread-1", {
+    rating: "bad",
+  })
+  expect(screen.queryByRole("button", { name: "👍 Good" })).toBeNull()
   fireEvent.change(comment, { target: { value: " More detail please. " } })
-  fireEvent.click(submit)
+  api.submitThreadFeedback.mockRejectedValueOnce(new Error("Temporary outage"))
+  fireEvent.click(screen.getByRole("button", { name: "Submit comment" }))
   await screen.findByRole("alert")
   expect((comment as HTMLTextAreaElement).value).toBe(" More detail please. ")
-  fireEvent.click(submit)
+  fireEvent.click(screen.getByRole("button", { name: "Submit comment" }))
   await screen.findByText("Thanks for your feedback.")
   expect(api.submitThreadFeedback).toHaveBeenLastCalledWith("thread-1", {
-    rating: "other",
+    action: "comment",
     comment: "More detail please.",
   })
+  expect(screen.queryByRole("textbox")).toBeNull()
+})
+
+it("allows skipping the comment without undoing the Bad rating", async () => {
+  renderCard()
+  fireEvent.click(await screen.findByRole("button", { name: "👎 Bad" }))
+  fireEvent.click(await screen.findByRole("button", { name: "Skip" }))
+  await screen.findByText("Thanks for your feedback.")
+  expect(api.submitThreadFeedback).toHaveBeenCalledExactlyOnceWith("thread-1", {
+    rating: "bad",
+  })
+  expect(screen.queryByRole("textbox")).toBeNull()
+})
+
+it("keeps the rating controls available when saving the rating fails", async () => {
+  api.submitThreadFeedback.mockRejectedValueOnce(new Error("Temporary outage"))
+  renderCard()
+  fireEvent.click(await screen.findByRole("button", { name: "👎 Bad" }))
+  await screen.findByRole("alert")
+  expect(screen.queryByRole("textbox")).toBeNull()
+  fireEvent.click(screen.getByRole("button", { name: "👎 Bad" }))
+  await screen.findByRole("textbox")
+})
+
+it("does not reopen the comment form for previously completed feedback", async () => {
+  api.getThreadFeedback.mockResolvedValue({
+    status: "completed",
+    rating: "bad",
+    comment: "",
+  })
+  renderCard()
+  await screen.findByText("Thanks for your feedback.")
+  expect(screen.queryByRole("textbox")).toBeNull()
 })
 
 it("dismisses the card without saving a rating", async () => {

--- a/ui/src/features/agents/components/ThreadFeedbackCard.tsx
+++ b/ui/src/features/agents/components/ThreadFeedbackCard.tsx
@@ -1,4 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { ThumbsDown, ThumbsUp } from "lucide-react"
+import type { LucideIcon } from "lucide-react"
 import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
@@ -13,17 +15,20 @@ import { cn } from "@/lib/utils"
 const ratings: Array<{
   value: ThreadFeedbackRating
   label: string
+  icon: LucideIcon
   className: string
 }> = [
   {
     value: "good",
-    label: "🙂 Good",
+    label: "Good",
+    icon: ThumbsUp,
     className:
       "border-success/40 bg-success/10 text-success-foreground hover:bg-success/20 hover:text-success-foreground dark:bg-success/10",
   },
   {
     value: "bad",
-    label: "💩 Bad",
+    label: "Bad",
+    icon: ThumbsDown,
     className:
       "border-destructive/40 bg-destructive/10 text-destructive-foreground hover:bg-destructive/20 hover:text-destructive-foreground dark:bg-destructive/10",
   },
@@ -133,6 +138,7 @@ export function ThreadFeedbackCard({
               disabled={mutation.isPending}
               onClick={() => mutation.mutate({ rating: option.value })}
             >
+              <option.icon aria-hidden="true" className="size-4" />
               {option.label}
             </Button>
           ))}

--- a/ui/src/features/agents/components/ThreadFeedbackCard.tsx
+++ b/ui/src/features/agents/components/ThreadFeedbackCard.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from "@tanstack/react-query"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
@@ -10,9 +10,8 @@ import type {
 } from "@/features/agents/lib/api"
 
 const ratings: Array<{ value: ThreadFeedbackRating; label: string }> = [
-  { value: "bad", label: "💩 Bad" },
-  { value: "good", label: "🙂 Good" },
-  { value: "other", label: "💬 Other" },
+  { value: "good", label: "👍 Good" },
+  { value: "bad", label: "👎 Bad" },
 ]
 
 export function ThreadFeedbackCard({
@@ -22,9 +21,22 @@ export function ThreadFeedbackCard({
   threadId: string
   login: string | null
 }) {
+  const queryClient = useQueryClient()
+  const [showComment, setShowComment] = useState(false)
+  const [comment, setComment] = useState("")
   const mutation = useMutation({
     mutationFn: (value: ThreadFeedbackSubmission) =>
       agentsApi.submitThreadFeedback(threadId, value),
+    onSuccess: (data, value) => {
+      queryClient.setQueryData(["thread-feedback", threadId, login], data)
+      setShowComment(
+        "rating" in value &&
+          value.rating === "bad" &&
+          data.status === "completed" &&
+          data.rating === "bad" &&
+          !data.comment
+      )
+    },
   })
   const query = useQuery({
     queryKey: ["thread-feedback", threadId, login],
@@ -37,8 +49,6 @@ export function ThreadFeedbackCard({
     },
     retry: false,
   })
-  const [rating, setRating] = useState<ThreadFeedbackRating | null>(null)
-  const [comment, setComment] = useState("")
   const feedback =
     mutation.data ??
     (query.isFetchedAfterMount && !query.isError ? query.data : undefined)
@@ -50,7 +60,7 @@ export function ThreadFeedbackCard({
     return null
   }
 
-  if (feedback.status === "completed") {
+  if (feedback.status === "completed" && !showComment) {
     return (
       <div
         role="status"
@@ -61,69 +71,82 @@ export function ThreadFeedbackCard({
     )
   }
 
-  const canSubmit =
-    rating !== null && (rating !== "other" || comment.trim().length > 0)
   return (
     <form
       aria-label="Thread feedback"
       className="mt-4 space-y-3 rounded-xl border border-border bg-muted/30 p-4"
       onSubmit={(event) => {
         event.preventDefault()
-        if (!canSubmit || mutation.isPending || !rating) return
-        mutation.mutate({ rating, comment: comment.trim() })
+        if (!showComment || mutation.isPending || !comment.trim()) return
+        mutation.mutate({ action: "comment", comment: comment.trim() })
       }}
     >
-      <p className="text-sm font-medium">How did Open SWE do?</p>
-      <div className="flex gap-2" role="group" aria-label="Rating">
-        {ratings.map((option) => (
-          <Button
-            key={option.value}
-            type="button"
-            variant={rating === option.value ? "secondary" : "outline"}
-            size="sm"
-            aria-pressed={rating === option.value}
+      <p className="text-sm font-medium">
+        {showComment ? "How could Open SWE do better?" : "How did Open SWE do?"}
+      </p>
+      {showComment ? (
+        <label className="flex flex-col gap-1.5 text-xs text-muted-foreground">
+          Comment (optional)
+          <Textarea
+            autoFocus
+            value={comment}
+            onChange={(event) => setComment(event.target.value)}
+            maxLength={3000}
             disabled={mutation.isPending}
-            onClick={() => setRating(option.value)}
+            placeholder="What could be better?"
+            className="min-h-20 text-sm"
+          />
+        </label>
+      ) : (
+        <div className="flex gap-2" role="group" aria-label="Rating">
+          {ratings.map((option) => (
+            <Button
+              key={option.value}
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={mutation.isPending}
+              onClick={() => mutation.mutate({ rating: option.value })}
+            >
+              {option.label}
+            </Button>
+          ))}
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            disabled={mutation.isPending}
+            onClick={() => mutation.mutate({ action: "dismiss" })}
           >
-            {option.label}
+            Dismiss
           </Button>
-        ))}
-      </div>
-      <label className="flex flex-col gap-1.5 text-xs text-muted-foreground">
-        Comment ({rating === "other" ? "required" : "optional"})
-        <Textarea
-          value={comment}
-          onChange={(event) => setComment(event.target.value)}
-          required={rating === "other"}
-          maxLength={3000}
-          disabled={mutation.isPending}
-          placeholder="What worked well? What could be better?"
-          className="min-h-20 text-sm"
-        />
-      </label>
+        </div>
+      )}
       {mutation.isError && (
         <p role="alert" className="text-xs text-destructive">
           Your feedback could not be saved. Please try again.
         </p>
       )}
-      <div className="flex items-center gap-2">
-        <Button
-          type="submit"
-          size="sm"
-          disabled={!canSubmit || mutation.isPending}
-        >
-          {mutation.isPending ? "Saving…" : "Submit feedback"}
-        </Button>
-        <Button
-          type="button"
-          size="sm"
-          variant="ghost"
-          disabled={mutation.isPending}
-          onClick={() => mutation.mutate({ action: "dismiss" })}
-        >
-          Dismiss
-        </Button>
-      </div>
+      {showComment && (
+        <div className="flex items-center gap-2">
+          <Button
+            type="submit"
+            size="sm"
+            disabled={!comment.trim() || mutation.isPending}
+          >
+            {mutation.isPending ? "Saving…" : "Submit comment"}
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            disabled={mutation.isPending}
+            onClick={() => setShowComment(false)}
+          >
+            Skip
+          </Button>
+        </div>
+      )}
     </form>
   )
 }

--- a/ui/src/features/agents/components/ThreadFeedbackCard.tsx
+++ b/ui/src/features/agents/components/ThreadFeedbackCard.tsx
@@ -8,10 +8,25 @@ import type {
   ThreadFeedbackRating,
   ThreadFeedbackSubmission,
 } from "@/features/agents/lib/api"
+import { cn } from "@/lib/utils"
 
-const ratings: Array<{ value: ThreadFeedbackRating; label: string }> = [
-  { value: "good", label: "👍 Good" },
-  { value: "bad", label: "👎 Bad" },
+const ratings: Array<{
+  value: ThreadFeedbackRating
+  label: string
+  className: string
+}> = [
+  {
+    value: "good",
+    label: "🙂 Good",
+    className:
+      "border-success/40 bg-success/10 text-success-foreground hover:bg-success/20 hover:text-success-foreground dark:bg-success/10",
+  },
+  {
+    value: "bad",
+    label: "💩 Bad",
+    className:
+      "border-destructive/40 bg-destructive/10 text-destructive-foreground hover:bg-destructive/20 hover:text-destructive-foreground dark:bg-destructive/10",
+  },
 ]
 
 export function ThreadFeedbackCard({
@@ -64,7 +79,7 @@ export function ThreadFeedbackCard({
     return (
       <div
         role="status"
-        className="mt-4 rounded-xl border border-border bg-muted/30 px-4 py-3 text-sm text-muted-foreground"
+        className="mt-4 rounded-lg bg-card px-4 py-3 text-sm text-muted-foreground"
       >
         Thanks for your feedback.
       </div>
@@ -74,7 +89,12 @@ export function ThreadFeedbackCard({
   return (
     <form
       aria-label="Thread feedback"
-      className="mt-4 space-y-3 rounded-xl border border-border bg-muted/30 p-4"
+      className={cn(
+        "mt-4 rounded-lg bg-card p-4",
+        showComment
+          ? "space-y-3"
+          : "flex flex-wrap items-center justify-between gap-x-6 gap-y-3"
+      )}
       onSubmit={(event) => {
         event.preventDefault()
         if (!showComment || mutation.isPending || !comment.trim()) return
@@ -94,17 +114,22 @@ export function ThreadFeedbackCard({
             maxLength={3000}
             disabled={mutation.isPending}
             placeholder="What could be better?"
-            className="min-h-20 text-sm"
+            className="min-h-20 border-foreground/20 bg-background text-sm"
           />
         </label>
       ) : (
-        <div className="flex gap-2" role="group" aria-label="Rating">
+        <div
+          className="flex flex-wrap items-center gap-2"
+          role="group"
+          aria-label="Rating"
+        >
           {ratings.map((option) => (
             <Button
               key={option.value}
               type="button"
               variant="outline"
-              size="sm"
+              size="lg"
+              className={cn("px-3 text-sm", option.className)}
               disabled={mutation.isPending}
               onClick={() => mutation.mutate({ rating: option.value })}
             >
@@ -113,8 +138,9 @@ export function ThreadFeedbackCard({
           ))}
           <Button
             type="button"
-            size="sm"
+            size="lg"
             variant="ghost"
+            className="text-muted-foreground"
             disabled={mutation.isPending}
             onClick={() => mutation.mutate({ action: "dismiss" })}
           >
@@ -123,7 +149,7 @@ export function ThreadFeedbackCard({
         </div>
       )}
       {mutation.isError && (
-        <p role="alert" className="text-xs text-destructive">
+        <p role="alert" className="w-full text-xs text-destructive">
           Your feedback could not be saved. Please try again.
         </p>
       )}

--- a/ui/src/features/agents/lib/api.ts
+++ b/ui/src/features/agents/lib/api.ts
@@ -262,15 +262,16 @@ export interface PullRequestSnapshot {
   state: PullRequestLiveState | null
 }
 
-export type ThreadFeedbackRating = "bad" | "good" | "other"
+export type ThreadFeedbackRating = "bad" | "good"
 
 export type ThreadFeedbackSubmission =
-  | { action?: "submit"; rating: ThreadFeedbackRating; comment: string }
+  | { action?: "submit"; rating: ThreadFeedbackRating; comment?: string }
+  | { action: "comment"; comment: string }
   | { action: "dismiss" }
 
 export interface ThreadFeedback {
   status: "unavailable" | "ready" | "completed" | "dismissed"
-  rating: ThreadFeedbackRating | null
+  rating: ThreadFeedbackRating | "other" | null
   comment: string
 }
 


### PR DESCRIPTION
Feedback in Slack and the web UI now follows GTM’s Good/Bad flow. Clicking either rating saves it immediately and removes the rating controls. Bad then offers an optional comment: a Slack modal or an inline web form with Submit comment and Skip. The comment box is hidden by default.

Slack posts one private completion confirmation directly in the same thread, then removes the original prompt. If confirmation fails, the controls remain available to retry. Once confirmed, retries only remove the controls; submitting a comment does not post another confirmation.

LangSmith feedback uses the common `rating` key, with Slack recorded in the source metadata.

Dashboard instructions explicitly require marking fully resolved information-only requests before the final answer, including short questions and naming suggestions that need no other tools.

The existing five-minute quiet delay, initiator-only prompts, and Dismiss action remain. Web submissions and comments use the same feedback POST endpoint. Slack now handles only Good/Bad clicks, optional Bad comments, and Dismiss; legacy forms and draft-selection state are removed.

The web UI uses subtle green and red buttons with outline thumbs-up and thumbs-down icons.

Screenshots from the local thread:

![Feedback prompt](https://raw.githubusercontent.com/langchain-ai/open-swe/2d75995004220e8c911942b6459be4554abf5222/pr-screenshots/feedback-live-prompt.png)

![Feedback completed](https://raw.githubusercontent.com/langchain-ai/open-swe/2d75995004220e8c911942b6459be4554abf5222/pr-screenshots/feedback-live-completed.png)