### PR TITLE
feat(ui): link automation threads to management

### DIFF
--- a/ui/src/features/agents/components/AgentThreadHeader.test.tsx
+++ b/ui/src/features/agents/components/AgentThreadHeader.test.tsx
@@ -9,6 +9,7 @@ import {
 } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
+import type { AgentThread } from "@/features/agents/lib/types"
 import { AgentThreadHeader } from "./AgentThreadHeader"
 
 vi.mock("@/lib/session", () => ({ useSession: () => ({ data: null }) }))
@@ -85,5 +86,27 @@ describe("AgentThreadHeader", () => {
     expect(onRename).not.toHaveBeenCalled()
     expect(screen.queryByRole("textbox")).toBeNull()
     expect(screen.getByText(title)).toBeTruthy()
+  })
+
+  it("links automation threads to their management page", () => {
+    render(
+      <AgentThreadHeader
+        title={title}
+        target="Cloud"
+        panelCollapsed={false}
+        thread={
+          {
+            id: "thread-id",
+            repoFullName: "",
+            automationId: "automation/id",
+          } as AgentThread
+        }
+      />
+    )
+    fireEvent.click(screen.getByRole("button", { name: "Thread actions" }))
+    const link = screen.getByRole("menuitem", { name: "Manage automation" })
+    expect(link.getAttribute("href")).toBe(
+      "/agents/automations/automation%2Fid"
+    )
   })
 })

--- a/ui/src/features/agents/components/ThreadMenuItems.tsx
+++ b/ui/src/features/agents/components/ThreadMenuItems.tsx
@@ -2,6 +2,7 @@ import { Menu } from "@base-ui/react/menu"
 import {
   ArchiveIcon,
   ArrowCounterClockwiseIcon,
+  CalendarBlankIcon,
   CopyIcon,
   PushPinIcon,
   PushPinSlashIcon,
@@ -51,6 +52,16 @@ export function ThreadMenuItems({
         >
           <IoLogoSlack className="size-3.5" />
           Open in Slack
+        </Menu.LinkItem>
+      )}
+      {thread?.automationId && (
+        <Menu.LinkItem
+          href={`/agents/automations/${encodeURIComponent(thread.automationId)}`}
+          closeOnClick
+          className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-xs outline-none select-none data-highlighted:bg-muted"
+        >
+          <CalendarBlankIcon className="size-3.5" />
+          Manage automation
         </Menu.LinkItem>
       )}
       <Menu.Item


### PR DESCRIPTION
Adds a “Manage automation” action to thread menus whenever the thread has an automation ID. The action navigates directly to the automation editor and is available from both the thread header and sidebar context menu.

[Screenshot](https://01a08aa7-fca9-7222-9cf3-51efa77b6a05--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGt3TXpNeE56RXNJbXAwYVNJNklqQXhZVEE0WVdGbUxXTmhZV1V0TnpFMVpTMWlOMlF3TFRZellUa3hOamN6TnpSaU1pSXNJbk5wWkNJNklqQXhZVEE0WVdFM0xXWmpZVGt0TnpJeU1pMDVZMll6TFRVeFpXWmhOemRpTm1Fd05TSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMeTV2Y0dWdUxYTjNaUzloY25ScFptRmpkSE12WVhWMGIyMWhkR2x2YmkxamIyNTBaWGgwTFcxbGJuVXVjRzVuSWl3aVkzUWlPaUpwYldGblpTOXdibWNpTENKalpDSTZJbWx1YkdsdVpTSjkueXRCWUhCSGE3eHJiSnNydkR4enVKWVVMRTVuN1NPQldvUVh2SXZSWUN4b3l0WHhhaWNoTmh1UzMzbm45MktSc1dtZFE4NXRhbTUyeDdwX2xBdFJJQlE)

Made by [Open SWE](https://openswe.vercel.app/agents/76c02819-c6ad-5fee-a166-c8a1e8fed82a) · openai:gpt-5.6-sol (high)