### PR TITLE
feat: thread long automation notifications

### DIFF
--- a/agent/resources/prompts/tools/notify_automation_channel.md
+++ b/agent/resources/prompts/tools/notify_automation_channel.md
@@ -1,1 +1,1 @@
-Notify the configured automation channel once after a concrete requested action.
+Notify the configured automation channel once after a concrete requested action. Pass the full outcome as `content`. If it exceeds four lines, also pass a summary of at most four lines; the summary is posted to the channel and the full content in its thread.

--- a/agent/tools/notify_automation_channel.py
+++ b/agent/tools/notify_automation_channel.py
@@ -8,6 +8,7 @@ from langgraph_sdk import get_client
 from agent.run_config import RunConfig
 from agent.slack.client import (
     append_slack_web_link_footer,
+    post_slack_thread_reply_with_ts,
     post_slack_top_level_message_with_ts,
 )
 from agent.store import delete_value, get_value, now_iso, put_value
@@ -17,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 _NOTIFICATION_NAMESPACE = ["automation_notifications"]
 _MAX_MESSAGE_CHARS = 3_000
+_MAX_TOP_LEVEL_LINES = 4
 _notification_locks: WeakValueDictionary[str, asyncio.Lock] = WeakValueDictionary()
 
 
@@ -45,7 +47,7 @@ async def _mark_action_posted(thread_id: str, notified_at: str) -> None:
         logger.exception("Failed to mark automation action posted for %s", thread_id)
 
 
-async def notify_automation_channel(message: str) -> dict[str, Any]:
+async def notify_automation_channel(content: str, summary: str = "") -> dict[str, Any]:
     """Implement the `notify_automation_channel` tool."""
     cfg = RunConfig.from_runtime()
     if cfg.source != "schedule":
@@ -70,13 +72,29 @@ async def notify_automation_channel(message: str) -> dict[str, Any]:
     if not thread_id:
         return {"success": False, "error": "Missing scheduled thread ID"}
 
-    clean_message = message.strip()
-    if not clean_message:
-        return {"success": False, "error": "Message cannot be empty"}
-    if len(clean_message) > _MAX_MESSAGE_CHARS:
+    clean_content = content.strip()
+    clean_summary = summary.strip()
+    if not clean_content:
+        return {"success": False, "error": "Content cannot be empty"}
+    if len(clean_content) > _MAX_MESSAGE_CHARS:
         return {
             "success": False,
-            "error": f"Message must be at most {_MAX_MESSAGE_CHARS} characters",
+            "error": f"Content must be at most {_MAX_MESSAGE_CHARS} characters",
+        }
+    if len(clean_content.splitlines()) > _MAX_TOP_LEVEL_LINES and not clean_summary:
+        return {
+            "success": False,
+            "error": f"Summary is required when content exceeds {_MAX_TOP_LEVEL_LINES} lines",
+        }
+    if clean_summary and len(clean_summary.splitlines()) > _MAX_TOP_LEVEL_LINES:
+        return {
+            "success": False,
+            "error": f"Summary must be at most {_MAX_TOP_LEVEL_LINES} lines",
+        }
+    if len(clean_summary) > _MAX_MESSAGE_CHARS:
+        return {
+            "success": False,
+            "error": f"Summary must be at most {_MAX_MESSAGE_CHARS} characters",
         }
 
     async with _notification_lock(thread_id):
@@ -85,9 +103,9 @@ async def notify_automation_channel(message: str) -> dict[str, Any]:
         except Exception:
             logger.exception("Failed to check automation notification for %s", thread_id)
             return {"success": False, "error": "Could not check the Slack notification state"}
-        if existing is not None:
+        if existing is not None and existing.get("status") == "delivered":
             notified_at = existing.get("notified_at")
-            if existing.get("status") == "delivered" and isinstance(notified_at, str):
+            if isinstance(notified_at, str):
                 await _mark_action_posted(thread_id, notified_at)
             return {
                 "success": True,
@@ -95,38 +113,67 @@ async def notify_automation_channel(message: str) -> dict[str, Any]:
                 "message_ts": existing.get("message_ts"),
             }
 
-        pending = {
+        pending = existing or {
             "status": "pending",
             "channel_id": channel_id,
             "schedule_id": schedule_id,
         }
-        try:
-            await put_value(_NOTIFICATION_NAMESPACE, thread_id, pending)
-        except Exception:
-            logger.exception("Failed to reserve automation notification for %s", thread_id)
-            return {"success": False, "error": "Could not reserve the Slack notification"}
+        if existing is None:
+            try:
+                await put_value(_NOTIFICATION_NAMESPACE, thread_id, pending)
+            except Exception:
+                logger.exception("Failed to reserve automation notification for %s", thread_id)
+                return {"success": False, "error": "Could not reserve the Slack notification"}
 
-        title = (notification.schedule_name or "").strip()
-        text = f"*Open SWE automation:* {title or 'Scheduled agent'}\n\n{clean_message}"
-        text = append_slack_web_link_footer(text, dashboard_thread_url(thread_id))
-        try:
-            message_ts, slack_error = await post_slack_top_level_message_with_ts(
-                channel_id,
-                text,
-                unfurl_links=False,
-                unfurl_media=False,
-            )
-        except Exception:
-            logger.exception("Automation Slack post raised for %s", thread_id)
-            await _release_reservation(thread_id)
-            return {"success": False, "error": "Slack post failed unexpectedly"}
-        if message_ts is None:
-            await _release_reservation(thread_id)
-            return {
-                "success": False,
-                "error": f"Slack post failed: {slack_error or 'unknown error'}",
-                "slack_error": slack_error,
-            }
+        message_ts = pending.get("message_ts")
+        if not isinstance(message_ts, str) or not message_ts:
+            title = (notification.schedule_name or "").strip()
+            channel_message = clean_summary or clean_content
+            text = f"*Open SWE automation:* {title or 'Scheduled agent'}\n\n{channel_message}"
+            text = append_slack_web_link_footer(text, dashboard_thread_url(thread_id))
+            try:
+                message_ts, slack_error = await post_slack_top_level_message_with_ts(
+                    channel_id,
+                    text,
+                    unfurl_links=False,
+                    unfurl_media=False,
+                )
+            except Exception:
+                logger.exception("Automation Slack post raised for %s", thread_id)
+                await _release_reservation(thread_id)
+                return {"success": False, "error": "Slack post failed unexpectedly"}
+            if message_ts is None:
+                await _release_reservation(thread_id)
+                return {
+                    "success": False,
+                    "error": f"Slack post failed: {slack_error or 'unknown error'}",
+                    "slack_error": slack_error,
+                }
+            if clean_summary:
+                pending = {**pending, "status": "pending_reply", "message_ts": message_ts}
+                try:
+                    await put_value(_NOTIFICATION_NAMESPACE, thread_id, pending)
+                except Exception:
+                    logger.exception("Failed to save automation thread state for %s", thread_id)
+
+        if clean_summary:
+            try:
+                reply_ts, slack_error = await post_slack_thread_reply_with_ts(
+                    channel_id,
+                    message_ts,
+                    clean_content,
+                    unfurl_links=False,
+                    unfurl_media=False,
+                )
+            except Exception:
+                logger.exception("Automation Slack reply raised for %s", thread_id)
+                return {"success": False, "error": "Slack thread reply failed unexpectedly"}
+            if reply_ts is None:
+                return {
+                    "success": False,
+                    "error": f"Slack thread reply failed: {slack_error or 'unknown error'}",
+                    "slack_error": slack_error,
+                }
 
         delivered = {
             **pending,

--- a/tests/slack/test_notify_automation_channel_tool.py
+++ b/tests/slack/test_notify_automation_channel_tool.py
@@ -111,11 +111,23 @@ async def test_notify_automation_channel_validates_message(
 
     empty = await notification_tool.notify_automation_channel("   ")
     oversized = await notification_tool.notify_automation_channel("x" * 3_001)
+    missing_summary = await notification_tool.notify_automation_channel("1\n2\n3\n4\n5")
+    oversized_summary = await notification_tool.notify_automation_channel(
+        "Details", summary="1\n2\n3\n4\n5"
+    )
 
-    assert empty == {"success": False, "error": "Message cannot be empty"}
+    assert empty == {"success": False, "error": "Content cannot be empty"}
     assert oversized == {
         "success": False,
-        "error": "Message must be at most 3000 characters",
+        "error": "Content must be at most 3000 characters",
+    }
+    assert missing_summary == {
+        "success": False,
+        "error": "Summary is required when content exceeds 4 lines",
+    }
+    assert oversized_summary == {
+        "success": False,
+        "error": "Summary must be at most 4 lines",
     }
     assert fake_client.store.items == {}
 
@@ -150,6 +162,76 @@ async def test_notify_automation_channel_posts_to_trusted_destination(
             "metadata": {"automation_action_posted_at": stored["notified_at"]},
         }
     ]
+
+
+async def test_notify_automation_channel_posts_long_content_in_thread(
+    fake_client: _FakeClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    channel_posts: list[str] = []
+    thread_posts: list[tuple[str, str]] = []
+
+    async def fake_channel_post(channel_id: str, text: str, **kwargs: Any) -> tuple[str, None]:
+        channel_posts.append(text)
+        return "1786504009.596419", None
+
+    async def fake_thread_post(
+        channel_id: str, thread_ts: str, text: str, **kwargs: Any
+    ) -> tuple[str, None]:
+        thread_posts.append((thread_ts, text))
+        return "1786504010.000001", None
+
+    monkeypatch.setattr("agent.run_config.get_config", _config)
+    monkeypatch.setattr(
+        notification_tool, "post_slack_top_level_message_with_ts", fake_channel_post
+    )
+    monkeypatch.setattr(notification_tool, "post_slack_thread_reply_with_ts", fake_thread_post)
+
+    content = "First\nSecond\nThird\nFourth\nFifth"
+    result = await notification_tool.notify_automation_channel(
+        content, summary="Updated five dependencies."
+    )
+
+    assert result == {"success": True, "message_ts": "1786504009.596419"}
+    assert "Updated five dependencies." in channel_posts[0]
+    assert "First" not in channel_posts[0]
+    assert thread_posts == [("1786504009.596419", content)]
+
+
+async def test_notify_automation_channel_retries_only_thread_reply_after_failure(
+    fake_client: _FakeClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    channel_post_count = 0
+    thread_responses: list[tuple[str | None, str | None]] = [
+        (None, "rate_limited"),
+        ("1786504010.000001", None),
+    ]
+
+    async def fake_channel_post(*args: Any, **kwargs: Any) -> tuple[str, None]:
+        nonlocal channel_post_count
+        channel_post_count += 1
+        return "1786504009.596419", None
+
+    async def fake_thread_post(*args: Any, **kwargs: Any) -> tuple[str | None, str | None]:
+        return thread_responses.pop(0)
+
+    monkeypatch.setattr("agent.run_config.get_config", _config)
+    monkeypatch.setattr(
+        notification_tool, "post_slack_top_level_message_with_ts", fake_channel_post
+    )
+    monkeypatch.setattr(notification_tool, "post_slack_thread_reply_with_ts", fake_thread_post)
+
+    content = "First\nSecond\nThird\nFourth\nFifth"
+    first = await notification_tool.notify_automation_channel(content, summary="Summary")
+    second = await notification_tool.notify_automation_channel(content, summary="Summary")
+
+    assert first == {
+        "success": False,
+        "error": "Slack thread reply failed: rate_limited",
+        "slack_error": "rate_limited",
+    }
+    assert second == {"success": True, "message_ts": "1786504009.596419"}
+    assert channel_post_count == 1
+    assert thread_responses == []
 
 
 async def test_notify_automation_channel_suppresses_duplicate_posts(


### PR DESCRIPTION
Automation notifications longer than four lines now require a short summary. The summary is posted at channel level and the full content is posted as its threaded reply, while shorter notifications retain the existing single-message behavior.

Thread-reply failures preserve the channel post state so retries do not duplicate the top-level message.

Made by [Open SWE](https://openswe.vercel.app/agents/e67b7b24-e1c4-5451-9a91-c6321a76bf06) · openai:gpt-5.6-sol (high)