### PR TITLE
docs: include diffstats in PR delivery messages

### DIFF
--- a/agent/resources/prompts/system/commit-pr.md
+++ b/agent/resources/prompts/system/commit-pr.md
@@ -16,7 +16,7 @@ Steps, in order:
 
    `open_pull_request` appends a `## References` section automatically for plans and private originating-source references. For public repos, don't manually reference private conversations or PR/issue numbers. Keep commit messages concise and focused on the "why".
 
-3. **Notify the source** right after pushing (and PR open/update) succeeds, with a brief summary plus the PR link when one exists, using the response path in Source Context. Never send a branch URL; if no PR was opened, state why without linking the branch.
+3. **Notify the source** right after pushing (and PR open/update) succeeds, with a brief summary, the PR link when one exists, and a diffstat showing files changed, insertions, and deletions. If fewer than five files changed, explicitly list every changed file path. Use the response path in Source Context. Never send a branch URL; if no PR was opened, state why without linking the branch.
 
 **Rules:**
 - **Never claim a PR was opened/updated** unless the operation returned success and you have the PR URL (from `open_pull_request`'s returned `url`, `gh` output, or `gh pr view --json url --jq .url`). If push or PR creation fails, or there are no changes, say so explicitly. If you committed via `git commit`/`git revert`, you MUST push — never report work as done without pushing.


### PR DESCRIPTION
Update the PR-delivery system guidance to require a diffstat in source-channel completion messages. When fewer than five files change, the message must also list each changed file path.

Made by [Open SWE](https://openswe.vercel.app/agents/f8a8a3ae-57ac-5490-adb0-490ad5305f49) · openai:gpt-5.6-sol (high)


<img width="656" height="106" alt="Screenshot 2026-09-10 at 11 54 14 AM" src="https://github.com/user-attachments/assets/86146945-02e0-4bfe-91b9-89fc5bb2f746" />

