### PR TITLE
fix(ui): move terminal actions into panel header

### DIFF
--- a/ui/src/features/agents/components/TerminalPanel.tsx
+++ b/ui/src/features/agents/components/TerminalPanel.tsx
@@ -12,6 +12,7 @@ import {
 
 import type { TerminalGroupsController } from "@/features/agents/lib/terminalGroups"
 import type { TerminalTarget } from "@/features/agents/lib/terminalSession"
+import type { TerminalSplitDirection } from "@/features/agents/lib/terminalState"
 import { MAX_TERMINALS_PER_GROUP } from "@/features/agents/lib/terminalState"
 import { cn } from "@/lib/utils"
 import { useAttachedTerminal } from "@/features/agents/lib/terminalSession"
@@ -286,19 +287,25 @@ export function TerminalActions({
     : (terminalIds[0] ?? "")
   const atSplitLimit = terminalIds.length >= MAX_TERMINALS_PER_GROUP
 
+  // Splits follow the focused group, which can differ from the visible tab.
+  const split = (direction: TerminalSplitDirection) => {
+    if (activeTerminalId) terminals.focus(activeTerminalId)
+    terminals.split(direction)
+  }
+
   return (
     <div className="flex shrink-0 items-center">
       <ActionButton
         label={`Split horizontally${atSplitLimit ? " (maximum 4)" : ""}`}
         disabled={atSplitLimit}
-        onClick={() => terminals.split("horizontal")}
+        onClick={() => split("horizontal")}
       >
         <SquareSplitHorizontal className="size-3.5" />
       </ActionButton>
       <ActionButton
         label={`Split vertically${atSplitLimit ? " (maximum 4)" : ""}`}
         disabled={atSplitLimit}
-        onClick={() => terminals.split("vertical")}
+        onClick={() => split("vertical")}
       >
         <SquareSplitVertical className="size-3.5" />
       </ActionButton>

--- a/ui/src/features/agents/components/TerminalPanel.tsx
+++ b/ui/src/features/agents/components/TerminalPanel.tsx
@@ -269,6 +269,63 @@ function ActionButton({
   )
 }
 
+export function TerminalActions({
+  groupId,
+  terminals,
+}: {
+  groupId: string
+  terminals: TerminalGroupsController
+}) {
+  const terminalIds =
+    terminals.state.terminalGroups.find((group) => group.id === groupId)
+      ?.terminalIds ?? []
+  const activeTerminalId = terminalIds.includes(
+    terminals.state.activeTerminalId
+  )
+    ? terminals.state.activeTerminalId
+    : (terminalIds[0] ?? "")
+  const atSplitLimit = terminalIds.length >= MAX_TERMINALS_PER_GROUP
+
+  return (
+    <div className="flex shrink-0 items-center">
+      <ActionButton
+        label={`Split horizontally${atSplitLimit ? " (maximum 4)" : ""}`}
+        disabled={atSplitLimit}
+        onClick={() => terminals.split("horizontal")}
+      >
+        <SquareSplitHorizontal className="size-3.5" />
+      </ActionButton>
+      <ActionButton
+        label={`Split vertically${atSplitLimit ? " (maximum 4)" : ""}`}
+        disabled={atSplitLimit}
+        onClick={() => terminals.split("vertical")}
+      >
+        <SquareSplitVertical className="size-3.5" />
+      </ActionButton>
+      <ActionButton
+        label="Clear terminal"
+        onClick={() => terminals.clear(activeTerminalId)}
+      >
+        <Trash2 className="size-3.5" />
+      </ActionButton>
+      <ActionButton
+        label="Restart terminal"
+        onClick={() => terminals.restart(activeTerminalId)}
+      >
+        <RefreshCw className="size-3.5" />
+      </ActionButton>
+      {terminalIds.length > 1 ? (
+        <ActionButton
+          label="Close terminal"
+          onClick={() => terminals.closeTerminal(activeTerminalId)}
+        >
+          <X className="size-3.5" />
+        </ActionButton>
+      ) : null}
+    </div>
+  )
+}
+
 export function TerminalPanel({
   target,
   cwd,
@@ -287,50 +344,12 @@ export function TerminalPanel({
   )
     ? terminals.state.activeTerminalId
     : (terminalIds[0] ?? "")
-  const atSplitLimit = terminalIds.length >= MAX_TERMINALS_PER_GROUP
 
   return (
     <div
-      className="group/terminal relative flex h-full min-h-0 flex-col"
+      className="relative flex h-full min-h-0 flex-col"
       data-hotkeys="ignore"
     >
-      <div className="absolute top-1 right-2 z-10 flex items-center rounded-md border border-border bg-background/95 opacity-0 shadow-sm transition-opacity group-hover/terminal:opacity-100 focus-within:opacity-100">
-        <ActionButton
-          label={`Split horizontally${atSplitLimit ? " (maximum 4)" : ""}`}
-          disabled={atSplitLimit}
-          onClick={() => terminals.split("horizontal")}
-        >
-          <SquareSplitHorizontal className="size-3.5" />
-        </ActionButton>
-        <ActionButton
-          label={`Split vertically${atSplitLimit ? " (maximum 4)" : ""}`}
-          disabled={atSplitLimit}
-          onClick={() => terminals.split("vertical")}
-        >
-          <SquareSplitVertical className="size-3.5" />
-        </ActionButton>
-        <ActionButton
-          label="Clear terminal"
-          onClick={() => terminals.clear(activeTerminalId)}
-        >
-          <Trash2 className="size-3.5" />
-        </ActionButton>
-        <ActionButton
-          label="Restart terminal"
-          onClick={() => terminals.restart(activeTerminalId)}
-        >
-          <RefreshCw className="size-3.5" />
-        </ActionButton>
-        {terminalIds.length > 1 && (
-          <ActionButton
-            label="Close terminal"
-            onClick={() => terminals.closeTerminal(activeTerminalId)}
-          >
-            <X className="size-3.5" />
-          </ActionButton>
-        )}
-      </div>
-
       {terminals.error && (
         <div className="absolute inset-x-2 top-2 z-10 rounded-md border border-destructive/40 bg-background/95 px-3 py-2 text-xs text-destructive shadow-sm">
           {terminals.error}

--- a/ui/src/features/agents/components/TerminalPanel.tsx
+++ b/ui/src/features/agents/components/TerminalPanel.tsx
@@ -87,6 +87,14 @@ function TerminalViewport({
   useEffect(() => {
     latestStateRef.current = state
   }, [state])
+  // Read through refs: naming these as dependencies would tear down and
+  // recreate the surface whenever the parent re-renders.
+  const onOpenFileRef = useRef(onOpenFile)
+  const activeRef = useRef(active)
+  useEffect(() => {
+    onOpenFileRef.current = onOpenFile
+    activeRef.current = active
+  }, [onOpenFile, active])
 
   useEffect(() => {
     const mount = mountRef.current
@@ -125,12 +133,13 @@ function TerminalViewport({
           else window.open(text, "_blank", "noopener,noreferrer")
           return
         }
-        if (target.kind !== "local" || !onOpenFile) return
+        const openFile = onOpenFileRef.current
+        if (target.kind !== "local" || !openFile) return
         const path = text.replace(/:\d+(?::\d+)?$/, "")
         void window.openSweDesktop
-          ?.resolveLocalProjectPath({ localSessionId: target.sessionId, path })
+          ?.resolveLocalProjectPath({ localSessionId: targetId, path })
           .then((relativePath) => {
-            if (relativePath) onOpenFile(relativePath)
+            if (relativePath) openFile(relativePath)
           })
           .catch(() => {})
       },
@@ -148,7 +157,7 @@ function TerminalViewport({
           version: latestState.version,
         }
         if (latestState.buffer) created.resetAndWrite(latestState.buffer)
-        if (active) created.focus()
+        if (activeRef.current) created.focus()
       })
       .catch((cause: unknown) => {
         if (!disposed) {

--- a/ui/src/features/agents/components/panel/AgentRightPanel.tsx
+++ b/ui/src/features/agents/components/panel/AgentRightPanel.tsx
@@ -13,7 +13,10 @@ import type {
 import type { TerminalGroupsController } from "@/features/agents/lib/terminalGroups"
 import type { TerminalTarget } from "@/features/agents/lib/terminalSession"
 import { Tooltip, TooltipPopup, TooltipTrigger } from "@/components/ui/tooltip"
-import { TerminalPanel } from "@/features/agents/components/TerminalPanel"
+import {
+  TerminalActions,
+  TerminalPanel,
+} from "@/features/agents/components/TerminalPanel"
 import { RightPanelTabs } from "@/features/agents/components/panel/RightPanelTabs"
 import { RightPanelSheet } from "@/features/agents/components/panel/RightPanelSheet"
 import { RIGHT_PANEL_INLINE_LAYOUT_MEDIA_QUERY } from "@/features/agents/components/panel/rightPanelLayout"
@@ -266,6 +269,12 @@ export function AgentRightPanel(props: AgentRightPanelProps) {
 
   const layoutControls = (
     <div className="flex shrink-0 items-center">
+      {activeSurface?.kind === "terminal" ? (
+        <TerminalActions
+          groupId={activeSurface.resourceId}
+          terminals={terminals}
+        />
+      ) : null}
       {narrow ? null : (
         <PanelControl
           label={maximized ? "Exit full screen" : "Expand panel"}


### PR DESCRIPTION
Moves the split, clear, restart, and close controls from an overlay inside the terminal to the existing panel header. This keeps the first terminal line unobstructed while preserving the actions for the active terminal group.

![Terminal actions in panel header](https://01a08acb-23d2-7d1e-84aa-0759848adba8--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGt3TXpVME56VXNJbXAwYVNJNklqQXhZVEE0WVdReUxXWXpaVFl0TjJJd1lTMDVaRGMwTFRFMk1XTTNOV1JsWWpVek1pSXNJbk5wWkNJNklqQXhZVEE0WVdOaUxUSXpaREl0TjJReFpTMDROR0ZoTFRBM05UazRORGhoWkdKaE9DSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMeTV2Y0dWdUxYTjNaUzloY25ScFptRmpkSE12ZEdWeWJXbHVZV3d0WVdOMGFXOXVjeTEwYjNCaVlYSXVjRzVuSWl3aVkzUWlPaUpwYldGblpTOXdibWNpTENKalpDSTZJbWx1YkdsdVpTSjkuVVhmMFBIOGtYcnl4VXF1eGFkVDFaUEZaSUFJREpSUVFiTFE0dG9BOUlVdUx1YjdKRmllcjQzSjVQNExzSGR4cFNHNTVoMEpUaTNzYW5vOUR3MExzQnc)

Made by [Open SWE](https://openswe.vercel.app/agents/9b05316c-6ac1-50b7-9b42-f75d8584b576) · openai:gpt-5.6-sol (high)