### PR TITLE
fix(slack): accept legacy feedback controls

### DIFF
--- a/agent/slack/thread_feedback.py
+++ b/agent/slack/thread_feedback.py
@@ -32,7 +32,11 @@ logger = logging.getLogger(__name__)
 _FEEDBACK_ACTION = "open_swe_feedback"
 _NOTE_ACTION = "open_swe_feedback_note"
 _DISMISS_ACTION = "open_swe_feedback_dismiss"
+_LEGACY_SELECT_PREFIX = "open_swe_feedback_select_"
+_LEGACY_SUBMIT_ACTION = "open_swe_feedback_submit"
+_LEGACY_RATING_ACTION = "open_swe_feedback_rating"
 _COMMENT_BLOCK = "feedback_comment"
+_LEGACY_RATING_BLOCK = "feedback_rating"
 
 
 class ThreadFeedback(BaseModel):
@@ -220,7 +224,16 @@ def _action(payload: dict[str, Any]) -> dict[str, Any]:
         for value in actions:
             action = _object(value)
             action_id = action.get("action_id")
-            if isinstance(action_id, str) and action_id in {_FEEDBACK_ACTION, _DISMISS_ACTION}:
+            if isinstance(action_id, str) and (
+                action_id.startswith(_LEGACY_SELECT_PREFIX)
+                or action_id
+                in {
+                    _FEEDBACK_ACTION,
+                    _DISMISS_ACTION,
+                    _LEGACY_SUBMIT_ACTION,
+                    _LEGACY_RATING_ACTION,
+                }
+            ):
                 return action
     return {}
 
@@ -376,6 +389,47 @@ def _comment_error(text: str) -> FeedbackResponse:
     return {"response_action": "errors", "errors": {_COMMENT_BLOCK: text}}
 
 
+def _legacy_submission(payload: dict[str, Any]) -> tuple[str, str] | None:
+    action = _action(payload)
+    action_id = str(action.get("action_id") or "")
+    if action_id.startswith(_LEGACY_SELECT_PREFIX):
+        choice = action_id.removeprefix(_LEGACY_SELECT_PREFIX)
+        return (str(action.get("value") or ""), choice) if choice in {"good", "bad"} else None
+    if action_id != _LEGACY_SUBMIT_ACTION:
+        return None
+    run_id = str(action.get("value") or "")
+    choice = ""
+    if run_id.startswith("{"):
+        selection = _object(json.loads(run_id))
+        run_id = str(selection.get("run_id") or "")
+        choice = str(selection.get("choice") or "")
+        rating = selection.get("rating")
+        if not choice and rating in {1, 5}:
+            choice = "good" if rating == 5 else "bad"
+    if not choice:
+        selected = _object(
+            _object(
+                _object(_object(payload.get("state")).get("values")).get(_LEGACY_RATING_BLOCK)
+            ).get(_LEGACY_RATING_ACTION)
+        ).get("selected_option")
+        value = str(_object(selected).get("value") or "")
+        choice = value if value in {"good", "bad"} else {"1": "bad", "5": "good"}.get(value, "")
+    return (run_id, choice) if run_id and choice else None
+
+
+def _native_rating_payload(payload: dict[str, Any], run_id: str, choice: str) -> dict[str, Any]:
+    return {
+        **payload,
+        "actions": [
+            {
+                **_action(payload),
+                "action_id": _FEEDBACK_ACTION,
+                "value": json.dumps({"run_id": run_id, "choice": choice}),
+            }
+        ],
+    }
+
+
 async def _record_rating(payload: dict[str, Any], background_tasks: BackgroundTasks) -> None:
     try:
         async with asyncio.timeout(2.5):
@@ -450,4 +504,13 @@ async def handle_slack_feedback_interaction(
     if action_id == _DISMISS_ACTION:
         background_tasks.add_task(_dismiss_feedback, payload)
         return {}
+    if action_id == _LEGACY_RATING_ACTION:
+        return {}
+    try:
+        legacy = _legacy_submission(payload)
+    except Exception:
+        logger.warning("Could not parse legacy Slack feedback rating", exc_info=True)
+        return {}
+    if legacy is not None:
+        await _record_rating(_native_rating_payload(payload, *legacy), background_tasks)
     return {}

--- a/tests/slack/test_slack_thread_feedback.py
+++ b/tests/slack/test_slack_thread_feedback.py
@@ -117,6 +117,24 @@ def _rating(choice: str = "good", run_id: str = "run-1") -> dict[str, Any]:
     return _action("open_swe_feedback", json.dumps({"run_id": run_id, "choice": choice}))
 
 
+def _legacy_submission(choice: str = "good", *, inline_state: bool = False) -> dict[str, Any]:
+    payload = _action(
+        "open_swe_feedback_submit",
+        "run-1"
+        if inline_state
+        else json.dumps({"run_id": "run-1", "choice": choice, "selection_ts": "3.0"}),
+    )
+    if inline_state:
+        payload["state"] = {
+            "values": {
+                "feedback_rating": {
+                    "open_swe_feedback_rating": {"selected_option": {"value": choice}}
+                }
+            }
+        }
+    return payload
+
+
 async def _submit_rating(choice: str = "good") -> None:
     tasks = BackgroundTasks()
     assert await routes.slack_interactivity(_request(_rating(choice)), tasks) == {}
@@ -159,6 +177,27 @@ def test_feedback_http_response_preserves_modal_errors_and_empty_ack(
     else:
         assert response.json()["response_action"] == "errors"
         assert response.json()["errors"]["feedback_comment"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("choice", ["good", "bad"])
+@pytest.mark.parametrize("mode", ["selection", "submit", "inline"])
+async def test_legacy_feedback_prompt_submits_after_deploy(
+    context: Any, fake_store: Any, choice: str, mode: str
+) -> None:
+    payload = (
+        _action(f"open_swe_feedback_select_{choice}")
+        if mode == "selection"
+        else _legacy_submission(choice, inline_state=mode == "inline")
+    )
+    tasks = BackgroundTasks()
+    assert await routes.slack_interactivity(_request(payload), tasks) == {}
+    await tasks()
+    saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
+    assert saved["completed"] and saved["choice"] == choice
+    feedback.respond_to_slack_interaction.assert_awaited_once_with(
+        _RESPONSE_URL, {"delete_original": True}
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Summary

Accept feedback actions from prompts posted before the Good/Bad UI deployment and translate their Good/Bad selections into the current submission path. This lets already-visible ephemeral prompts save feedback and remove themselves instead of being ignored after a deploy.

Legacy Other and intermediate rating-only actions remain non-submitting because the current feedback model only supports Good and Bad.

Made by [Open SWE](https://openswe.vercel.app/agents/1f5824f1-6e70-5d95-b08f-a422fe31f58e) · openai:gpt-5.6-sol (high)