### PR TITLE
fix: allow cross-repo baby-sit watches

### DIFF
--- a/agent/baby_sit.py
+++ b/agent/baby_sit.py
@@ -294,14 +294,25 @@ async def _notify_watch(watch: BabySitWatch, message: str) -> bool:
         if issue_number is None:
             configured_number = watch.run_config.get("pr_number")
             issue_number = configured_number if isinstance(configured_number, int) else None
-        token = await _watch_token(watch)
-        if issue_number is not None and token:
-            return await post_github_comment(
-                {"owner": watch.owner, "name": watch.repo},
-                issue_number,
-                message,
-                token=token,
+        source_repo = watch.run_config.get("source_repo")
+        repo = (
+            source_repo
+            if isinstance(source_repo, dict)
+            else {
+                "owner": watch.owner,
+                "name": watch.repo,
+            }
+        )
+        source_installation_id = watch.run_config.get("source_installation_id")
+        token = await get_github_app_installation_token(
+            installation_id=(
+                source_installation_id
+                if isinstance(source_installation_id, int)
+                else watch.installation_id
             )
+        )
+        if issue_number is not None and token:
+            return await post_github_comment(repo, issue_number, message, token=token)
     except Exception:
         logger.warning("Failed to notify source for %s", watch.key, exc_info=True)
         return False

--- a/agent/bundled_skills/baby-sit/SKILL.md
+++ b/agent/bundled_skills/baby-sit/SKILL.md
@@ -10,7 +10,7 @@ Use this skill when the user invokes `/baby-sit`, asks in natural language to mo
 ## Inputs
 
 - `/baby-sit`: infer the open PR from the current branch with `gh pr view`.
-- `/baby-sit <PR URL|number>`: monitor that PR in the thread's configured repository.
+- `/baby-sit <PR URL|number>`: monitor that PR; a full canonical URL may target a different repository than the thread default.
 - `/baby-sit stop [PR URL|number]`: stop its active watch.
 - `/baby-sit --continue <PR URL>`: process an automated failure wakeup; do not register a second watch.
 

--- a/agent/tools/manage_baby_sit.py
+++ b/agent/tools/manage_baby_sit.py
@@ -19,14 +19,6 @@ def _configurable() -> tuple[RunConfig, Mapping[str, Any]]:
     return RunConfig.from_config(config), config if isinstance(config, Mapping) else {}
 
 
-def _matches_configured_repo(cfg: RunConfig, owner: str, repo: str) -> bool:
-    if cfg.repo is None:
-        return True
-    if not cfg.repo.owner or not cfg.repo.name:
-        return False
-    return cfg.repo.owner.lower() == owner.lower() and cfg.repo.name.lower() == repo.lower()
-
-
 def _run_config(cfg: RunConfig, thread_id: str) -> dict[str, Any]:
     allowed = (
         "source",
@@ -74,9 +66,6 @@ async def manage_baby_sit(
     thread_id = cfg.thread_id
     if not thread_id:
         return {"success": False, "error": "No executable agent thread is available"}
-    if not _matches_configured_repo(cfg, pr_ref.owner, pr_ref.repo):
-        return {"success": False, "error": "Pull request does not match this thread's repository"}
-
     key = watch_key(pr_ref.owner, pr_ref.repo, pr_ref.number)
     if action == "stop":
         from agent.baby_sit import WATCHES

--- a/agent/tools/manage_baby_sit.py
+++ b/agent/tools/manage_baby_sit.py
@@ -19,7 +19,9 @@ def _configurable() -> tuple[RunConfig, Mapping[str, Any]]:
     return RunConfig.from_config(config), config if isinstance(config, Mapping) else {}
 
 
-def _run_config(cfg: RunConfig, thread_id: str) -> dict[str, Any]:
+def _run_config(
+    cfg: RunConfig, thread_id: str, source_installation_id: int | None
+) -> dict[str, Any]:
     allowed = (
         "source",
         "slack_thread",
@@ -34,6 +36,10 @@ def _run_config(cfg: RunConfig, thread_id: str) -> dict[str, Any]:
     )
     dumped = cfg.dump()
     result = {key: dumped[key] for key in allowed if dumped.get(key) is not None}
+    if cfg.github_issue and isinstance(dumped.get("repo"), Mapping):
+        result["source_repo"] = dumped["repo"]
+        if source_installation_id is not None:
+            result["source_installation_id"] = source_installation_id
     result["thread_id"] = thread_id
     return result
 
@@ -119,6 +125,11 @@ async def manage_baby_sit(
             "success": False,
             "error": "GitHub App installation is unavailable for this repository",
         }
+    source_installation_id = installation_id
+    if cfg.github_issue and cfg.repo:
+        source_installation_id = await get_github_app_installation_id_for_repo(
+            cfg.repo.owner, cfg.repo.name
+        )
     try:
         watch = await start_watch(
             pr_ref=pr_ref,
@@ -126,7 +137,7 @@ async def manage_baby_sit(
             head_ref=pr_head_ref,
             installation_id=installation_id,
             thread_id=thread_id,
-            run_config=_run_config(cfg, thread_id),
+            run_config=_run_config(cfg, thread_id, source_installation_id),
             source_context=_source_context(cfg),
         )
     except Exception as exc:

--- a/tests/agent/test_baby_sit.py
+++ b/tests/agent/test_baby_sit.py
@@ -296,6 +296,32 @@ async def test_success_waits_for_stable_check_set_before_notifying(
     assert watch_client.store.values == {}
 
 
+async def test_github_notification_uses_source_repository(
+    watch_client: _Client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    watch = await _start_watch(watch_client)
+    watch.source_context = SourceContext.parse(
+        {
+            "github_issue": {
+                "number": 12,
+                "url": "https://github.com/acme/default/issues/12",
+            }
+        }
+    )
+    watch.run_config = {
+        "source_repo": {"owner": "acme", "name": "default"},
+        "source_installation_id": 84,
+    }
+    token = AsyncMock(return_value="t")
+    post = AsyncMock(return_value=True)
+    monkeypatch.setattr(baby_sit, "get_github_app_installation_token", token)
+    monkeypatch.setattr(baby_sit, "post_github_comment", post)
+
+    assert await baby_sit._notify_watch(watch, "done") is True
+    token.assert_awaited_once_with(installation_id=84)
+    post.assert_awaited_once_with({"owner": "acme", "name": "default"}, 12, "done", token="t")
+
+
 async def test_terminal_notification_falls_back_to_originating_agent_thread(
     watch_client: _Client, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/tools/test_manage_baby_sit.py
+++ b/tests/tools/test_manage_baby_sit.py
@@ -8,24 +8,25 @@ from agent.baby_sit import BabySitWatch
 manage_tool = importlib.import_module("agent.tools.manage_baby_sit")
 
 
-async def test_manage_baby_sit_starts_cross_repo_watch_from_current_thread(
+async def test_manage_baby_sit_starts_cross_repo_watch_from_github_issue(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     configurable = {
         "thread_id": "thread-1",
-        "source": "slack",
+        "source": "github",
         "github_login": "octocat",
         "repo": {"owner": "acme", "name": "default"},
-        "slack_thread": {"channel_id": "C1", "thread_ts": "1.2"},
+        "github_issue": {"number": 12, "url": "https://github.com/acme/default/issues/12"},
     }
     monkeypatch.setattr(manage_tool, "get_config", lambda: {"configurable": configurable})
     monkeypatch.setattr(
         manage_tool, "resolve_github_token", AsyncMock(return_value=("token", None))
     )
+    installation = AsyncMock(side_effect=[42, 84])
     monkeypatch.setattr(
         manage_tool,
         "get_github_app_installation_id_for_repo",
-        AsyncMock(return_value=42),
+        installation,
     )
     monkeypatch.setattr(
         manage_tool,
@@ -50,6 +51,16 @@ async def test_manage_baby_sit_starts_cross_repo_watch_from_current_thread(
     assert start.await_args.kwargs["installation_id"] == 42
     assert start.await_args.kwargs["pr_ref"].owner == "acme"
     assert start.await_args.kwargs["pr_ref"].repo == "repo"
-    assert start.await_args.kwargs["source_context"].dump() == {
-        "slack_thread": {"channel_id": "C1", "thread_ts": "1.2"}
+    assert start.await_args.kwargs["run_config"]["source_repo"] == {
+        "owner": "acme",
+        "name": "default",
     }
+    assert start.await_args.kwargs["run_config"]["source_installation_id"] == 84
+    assert start.await_args.kwargs["source_context"].dump() == {
+        "github_issue": {
+            "number": 12,
+            "url": "https://github.com/acme/default/issues/12",
+        }
+    }
+    assert installation.await_args_list[0].args == ("acme", "repo")
+    assert installation.await_args_list[1].args == ("acme", "default")

--- a/tests/tools/test_manage_baby_sit.py
+++ b/tests/tools/test_manage_baby_sit.py
@@ -8,14 +8,14 @@ from agent.baby_sit import BabySitWatch
 manage_tool = importlib.import_module("agent.tools.manage_baby_sit")
 
 
-async def test_manage_baby_sit_starts_watch_from_current_thread(
+async def test_manage_baby_sit_starts_cross_repo_watch_from_current_thread(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     configurable = {
         "thread_id": "thread-1",
         "source": "slack",
         "github_login": "octocat",
-        "repo": {"owner": "acme", "name": "repo"},
+        "repo": {"owner": "acme", "name": "default"},
         "slack_thread": {"channel_id": "C1", "thread_ts": "1.2"},
     }
     monkeypatch.setattr(manage_tool, "get_config", lambda: {"configurable": configurable})
@@ -48,26 +48,8 @@ async def test_manage_baby_sit_starts_watch_from_current_thread(
     assert start.await_args is not None
     assert start.await_args.kwargs["thread_id"] == "thread-1"
     assert start.await_args.kwargs["installation_id"] == 42
+    assert start.await_args.kwargs["pr_ref"].owner == "acme"
+    assert start.await_args.kwargs["pr_ref"].repo == "repo"
     assert start.await_args.kwargs["source_context"].dump() == {
         "slack_thread": {"channel_id": "C1", "thread_ts": "1.2"}
-    }
-
-
-async def test_manage_baby_sit_rejects_other_repository(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(
-        manage_tool,
-        "get_config",
-        lambda: {
-            "configurable": {
-                "thread_id": "thread-1",
-                "repo": {"owner": "acme", "name": "repo"},
-            }
-        },
-    )
-
-    result = await manage_tool.manage_baby_sit("https://github.com/other/repo/pull/7")
-
-    assert result == {
-        "success": False,
-        "error": "Pull request does not match this thread's repository",
     }


### PR DESCRIPTION
The thread repository is a default workspace hint, not an authorization boundary. A canonical pull request URL already identifies the watch target, while GitHub token resolution and installation lookup enforce access to that repository.

Remove the default-repository equality guard, retain thread ownership checks for existing watches, and cover a cross-repository target in the tool test. The bundled skill now documents that canonical URLs may target another repository.

<!-- langsmith-issue {"id":"d9c43cd4-0bed-4d35-8dd0-e076000252ef"} -->

Made by [Open SWE](https://openswe.vercel.app/agents/68961e6f-3340-5cc7-9f80-b2d86ccd9492) · openai:gpt-5.6-sol (high)