### PR TITLE
fix(sandbox): delete files through async execution

### DIFF
--- a/agent/sandboxes/providers/langsmith.py
+++ b/agent/sandboxes/providers/langsmith.py
@@ -4,12 +4,13 @@ import asyncio
 import base64
 import json
 import logging
+import shlex
 from abc import ABC, abstractmethod
 from typing import Any
 
 import httpx2
 from deepagents.backends import LangSmithSandbox
-from deepagents.backends.protocol import ExecuteResponse, SandboxBackendProtocol
+from deepagents.backends.protocol import DeleteResult, ExecuteResponse, SandboxBackendProtocol
 from langsmith.sandbox import (
     AsyncSandboxClient,
     CommandTimeoutError,
@@ -656,6 +657,18 @@ class TimeoutLangSmithSandbox(LangSmithSandbox):
 
     def execute(self, command: str, *, timeout: int | None = None) -> ExecuteResponse:
         raise NotImplementedError("TimeoutLangSmithSandbox is async-only; use aexecute.")
+
+    async def adelete(self, file_path: str) -> DeleteResult:
+        quoted = shlex.quote(file_path)
+        exists = await self.aexecute(f"test -e {quoted} || test -L {quoted}")
+        if exists.exit_code is not None and exists.exit_code != 0:
+            return DeleteResult(error=f"Error: '{file_path}' not found")
+        result = await self.aexecute(f"rm -rf {quoted}")
+        if result.exit_code == 0:
+            return DeleteResult(path=file_path)
+        return DeleteResult(
+            error=f"Error deleting file '{file_path}': {result.output.strip() or 'unknown error'}"
+        )
 
     async def aexecute(
         self,

--- a/tests/sandbox/test_langsmith_sandbox_timeout.py
+++ b/tests/sandbox/test_langsmith_sandbox_timeout.py
@@ -7,6 +7,8 @@ from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import pytest
+from deepagents.backends.composite import CompositeBackend
+from deepagents.backends.protocol import ExecuteResponse
 from langsmith.sandbox import (
     CommandTimeoutError,
     SandboxConnectionError,
@@ -143,6 +145,27 @@ async def test_aexecute_midstream_ws_drop_falls_back_to_base(
 def test_execute_is_async_only() -> None:
     with pytest.raises(NotImplementedError):
         _backend(_FakeHandle()).execute("echo hi", timeout=5)
+
+
+async def test_composite_backend_deletes_through_async_langsmith_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sb = _backend(_FakeHandle())
+    commands: list[str] = []
+
+    async def execute(command: str, *, timeout: int | None = None) -> ExecuteResponse:
+        commands.append(command)
+        return ExecuteResponse(output="", exit_code=0)
+
+    monkeypatch.setattr(sb, "aexecute", execute)
+    result = await CompositeBackend(default=sb, routes={}).adelete("/workspace/repo/obsolete.txt")
+
+    assert result.path == "/workspace/repo/obsolete.txt"
+    assert result.error is None
+    assert commands == [
+        "test -e /workspace/repo/obsolete.txt || test -L /workspace/repo/obsolete.txt",
+        "rm -rf /workspace/repo/obsolete.txt",
+    ]
 
 
 async def test_aexecute_retries_a_transient_rejection(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
`TimeoutLangSmithSandbox` is async-only, but its inherited deletion implementation falls back through the synchronous `execute()` method and raises `NotImplementedError`. `CompositeBackend` then reports deletion as unsupported for every ordinary sandbox path.

Implement async deletion through `aexecute()` so file and directory removals use the LangSmith sandbox command path, while preserving not-found and command-failure errors. Add coverage through the composite backend used by the agent.

<!-- langsmith-issue {"id":"ea8af47a-9a10-44e8-99b4-7c9440b3d546"} -->

Made by [Open SWE](https://openswe.vercel.app/agents/86835f2a-8296-5e00-9a7d-f45e752dd2d7) · openai:gpt-5.6-sol (high)