### PR TITLE
fix: normalize missing run source before preparation

### DIFF
--- a/agent/server.py
+++ b/agent/server.py
@@ -1015,6 +1015,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         logger.info("Configured model fallback %s -> %s", model_id, fallback_model_id)
 
     source = cfg.source or "dashboard"
+    configurable["source"] = source
     user_email = cfg.user_email or ""
 
     # Plan mode is entered only when the model decides to (the `enter_plan_mode`

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -304,6 +304,17 @@ async def test_desktop_agent_honors_gateway_environment(
 
 
 @pytest.mark.asyncio
+async def test_agent_defaults_missing_run_source_before_prepare() -> None:
+    config = _base_config()
+
+    await _capture_create_deep_agent_kwargs(config)
+
+    configurable = config.get("configurable")
+    assert isinstance(configurable, dict)
+    assert configurable["source"] == "dashboard"
+
+
+@pytest.mark.asyncio
 async def test_agent_does_not_add_custom_repair_middleware() -> None:
     captured = await _capture_create_deep_agent_kwargs()
     middleware = captured["middleware"]


### PR DESCRIPTION
A missing run `source` was already interpreted as `dashboard` while assembling the agent, but that resolved value was not written back to the config consumed by prepare middleware. GitHub token resolution then reparsed the original config and failed before any model or tool call.

Persist the resolved source in the run configurable before middleware construction so preparation and downstream config consumers use the same source. Add regression coverage for source-less run configs.

<!-- langsmith-issue {"id":"64266620-b2fc-4c0e-9553-514575253cd1"} -->

Made by [Open SWE](https://openswe.vercel.app/agents/7c00a588-58ec-5a90-bcd6-9aaff0765f81) · openai:gpt-5.6-sol (high)