### PR TITLE
fix: hide live compaction summaries

### DIFF
--- a/tests/e2e/tests/dashboard_transcript.spec.ts
+++ b/tests/e2e/tests/dashboard_transcript.spec.ts
@@ -277,6 +277,12 @@ test.describe("transcript rendering", () => {
               id: "legacy-e2e",
               content: "Legacy stays visible",
             },
+            {
+              type: "ai",
+              id: "live-compaction-summary",
+              content: "SESSION INTENT: internal context must stay hidden",
+              additional_kwargs: { lc_source: "summarization" },
+            },
             ...messages,
           ],
         };
@@ -295,6 +301,9 @@ test.describe("transcript rendering", () => {
     await systemChip.click();
     await expect(page.getByText("Automation checks CI")).toBeVisible();
     await expect(page.getByText("Legacy stays visible")).toBeVisible();
+    await expect(
+      page.getByText("SESSION INTENT: internal context must stay hidden"),
+    ).toHaveCount(0);
     await expect(page.getByText("github:alice", { exact: false })).toHaveCount(
       0,
     );

--- a/ui/src/features/agents/lib/streamMessagesToUi.test.ts
+++ b/ui/src/features/agents/lib/streamMessagesToUi.test.ts
@@ -76,8 +76,13 @@ describe("streamMessagesToUi", () => {
     const messages = streamMessagesToUi([
       new HumanMessage({ id: "user-1", content: "Fix the bug" }),
       new AIMessage({ id: "ai-1", content: "Working" }),
+      new AIMessage({
+        id: "live-summary",
+        content: "SESSION INTENT: secret context",
+        additional_kwargs: { lc_source: "summarization" },
+      }),
       new HumanMessage({
-        id: "summary",
+        id: "persisted-summary",
         content:
           "Here is a summary of the conversation to date: secret context",
         additional_kwargs: { lc_source: "summarization" },

--- a/ui/src/features/agents/lib/streamMessagesToUi.ts
+++ b/ui/src/features/agents/lib/streamMessagesToUi.ts
@@ -427,6 +427,7 @@ export function streamMessagesToUi(
     }
 
     if (AIMessage.isInstance(raw)) {
+      if (raw.additional_kwargs.lc_source === "summarization") return
       const chunks: Array<Chunk> = []
       const reasoning = reasoningText(raw)
       if (reasoning) chunks.push({ kind: "reasoning", text: reasoning })


### PR DESCRIPTION
Hides compaction summaries streamed back from Deep Agents.
These are hidden on refresh but appear in the live stream.

### Screenshot

Logged in as Alice; the injected `SESSION INTENT` compaction output is absent while surrounding transcript messages remain visible.

![Dashboard transcript with compaction output hidden](https://01a08b97-6a86-7231-a9b9-2807ba771c51--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGt3TkRrNE9ERXNJbXAwYVNJNklqQXhZVEE0WW1GbExXTXlOelF0TnpZeU5DMDVaVEZpTFRjNE9HSTBZMk01TlRRNU1pSXNJbk5wWkNJNklqQXhZVEE0WWprM0xUWmhPRFl0TnpJek1TMWhPV0k1TFRJNE1EZGlZVGMzTVdNMU1TSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMeTV2Y0dWdUxYTjNaUzloY25ScFptRmpkSE12YUdsa1pTMXNhWFpsTFdOdmJYQmhZM1JwYjI0dGMzVnRiV0Z5ZVM1d2JtY2lMQ0pqZENJNkltbHRZV2RsTDNCdVp5SXNJbU5rSWpvaWFXNXNhVzVsSW4wLkk5WEFqTEpySjJRTFJnc0N1OExra0MwYzlXUXdBbzZxZWFCOUtUNmpzbWR0TEVoVkZsNW96OXd5ajBZcFFQTHVmbkl0QkdyOTRFUlBWOGM5R3Mxc0Nn)

Made by [Open SWE](https://openswe.vercel.app/agents/31edf4cc-4c59-5d7b-b925-3aa73f96e0b8) · openai:gpt-5.6-sol (high)