### PR TITLE
feat(ui): dump page state on a triple Escape press

### DIFF
--- a/ui/src/client.tsx
+++ b/ui/src/client.tsx
@@ -2,7 +2,9 @@ import { StartClient } from "@tanstack/react-start/client"
 import { createRoot, hydrateRoot } from "react-dom/client"
 
 import { initializeDatadogRum } from "./lib/datadog"
+import { installDebugRecorder } from "./lib/debugRecorder"
 
+installDebugRecorder()
 void initializeDatadogRum()
 
 const app = <StartClient />

--- a/ui/src/components/DebugSnapshotHotkey.tsx
+++ b/ui/src/components/DebugSnapshotHotkey.tsx
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useState } from "react"
+import { useQueryClient } from "@tanstack/react-query"
+import { useRouter } from "@tanstack/react-router"
+
+import { captureDebugSnapshot, formatDebugSnapshot } from "@/lib/debugSnapshot"
+import { useRapidKeyRun } from "@/lib/hotkeys"
+
+const STATUS_TIMEOUT_MS = 3500
+
+interface DumpStatus {
+  copied: boolean
+  kb: number
+  errors: number
+}
+
+/** Triple-press Escape to copy a snapshot of the page's state for a bug report. */
+export function DebugSnapshotHotkey() {
+  const router = useRouter()
+  const queryClient = useQueryClient()
+  const [status, setStatus] = useState<DumpStatus | null>(null)
+
+  const dump = useCallback(async () => {
+    const snapshot = captureDebugSnapshot({
+      router,
+      queryClient,
+      trigger: "triple-escape",
+    })
+    const text = formatDebugSnapshot(snapshot)
+    ;(window as Window & { __openSweDebug?: unknown }).__openSweDebug = {
+      snapshot,
+      text,
+    }
+
+    console.groupCollapsed(
+      `Open SWE debug snapshot · ${snapshot.route.pathname} · ${snapshot.meta.atLocal}`
+    )
+    console.log(snapshot)
+    console.log(text)
+    console.log("kept on window.__openSweDebug")
+    console.groupEnd()
+
+    let copied = false
+    try {
+      await navigator.clipboard.writeText(text)
+      copied = true
+    } catch {
+      copied = false
+    }
+    setStatus({
+      copied,
+      kb: Math.max(1, Math.round(text.length / 1024)),
+      errors: snapshot.errors.length,
+    })
+  }, [queryClient, router])
+
+  useRapidKeyRun("Escape", () => void dump())
+
+  useEffect(() => {
+    if (!status) return
+    const timer = window.setTimeout(() => setStatus(null), STATUS_TIMEOUT_MS)
+    return () => window.clearTimeout(timer)
+  }, [status])
+
+  if (!status) return null
+  return (
+    <div
+      role="status"
+      className="pointer-events-none fixed bottom-4 left-1/2 z-100 -translate-x-1/2 rounded-md border border-border bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md"
+    >
+      {status.copied
+        ? `Debug snapshot copied (${status.kb} KB${status.errors ? `, ${status.errors} JS errors` : ""}) — also in the console`
+        : "Debug snapshot logged to the console — clipboard copy was blocked"}
+    </div>
+  )
+}

--- a/ui/src/lib/debugRecorder.ts
+++ b/ui/src/lib/debugRecorder.ts
@@ -2,6 +2,9 @@ const MAX_LOGS = 40
 const MAX_ERRORS = 20
 const MAX_REQUESTS = 60
 const MAX_TEXT = 600
+const MAX_DETAIL = 1024
+/** Past this the body is summarized rather than buffered. */
+const MAX_DETAIL_SOURCE_BYTES = 256 * 1024
 
 export interface RecordedLog {
   at: number
@@ -24,6 +27,8 @@ export interface RecordedRequest {
   status: number | null
   ms: number
   error?: string
+  /** Response body of a 4xx/5xx, filled in once the clone has been read. */
+  detail?: string
 }
 
 function ring<T>(max: number) {
@@ -70,6 +75,39 @@ function requestMethod(input: RequestInfo | URL, init?: RequestInit): string {
 
 function requestUrl(input: RequestInfo | URL): string {
   return input instanceof Request ? input.url : String(input)
+}
+
+/**
+ * Read a failed response's body off a clone, so a 500 carries its reason
+ * rather than just its status. Never awaited: the caller's response must not
+ * wait on the recorder, so the entry is filled in late.
+ */
+function recordFailureDetail(entry: RecordedRequest, response: Response): void {
+  if (response.status < 400) return
+  const declared = Number(response.headers.get("content-length"))
+  if (declared > MAX_DETAIL_SOURCE_BYTES) {
+    entry.detail = `[${declared} byte body not captured]`
+    return
+  }
+  let clone: Response
+  try {
+    clone = response.clone()
+  } catch (error) {
+    entry.detail = `[body unreadable: ${describeUnknown(error).slice(0, 120)}]`
+    return
+  }
+  void clone.text().then(
+    (body) => {
+      if (!body) return
+      entry.detail =
+        body.length > MAX_DETAIL
+          ? `${body.slice(0, MAX_DETAIL)}…(${body.length})`
+          : body
+    },
+    (error) => {
+      entry.detail = `[body unreadable: ${describeUnknown(error).slice(0, 120)}]`
+    }
+  )
 }
 
 let installed = false
@@ -122,12 +160,14 @@ export function installDebugRecorder(): void {
     const entry = { method: requestMethod(input, init), url: requestUrl(input) }
     try {
       const response = await originalFetch(input, init)
-      requests.push({
+      const recorded: RecordedRequest = {
         at: Date.now(),
         ...entry,
         status: response.status,
         ms: Math.round(performance.now() - started),
-      })
+      }
+      requests.push(recorded)
+      recordFailureDetail(recorded, response)
       return response
     } catch (error) {
       requests.push({

--- a/ui/src/lib/debugRecorder.ts
+++ b/ui/src/lib/debugRecorder.ts
@@ -1,0 +1,143 @@
+const MAX_LOGS = 40
+const MAX_ERRORS = 20
+const MAX_REQUESTS = 60
+const MAX_TEXT = 600
+
+export interface RecordedLog {
+  at: number
+  level: "warn" | "error"
+  text: string
+}
+
+export interface RecordedError {
+  at: number
+  kind: "error" | "unhandledrejection"
+  message: string
+  source?: string
+  stack?: string
+}
+
+export interface RecordedRequest {
+  at: number
+  method: string
+  url: string
+  status: number | null
+  ms: number
+  error?: string
+}
+
+function ring<T>(max: number) {
+  const items: Array<T> = []
+  return {
+    push(item: T) {
+      items.push(item)
+      if (items.length > max) items.splice(0, items.length - max)
+    },
+    all: (): Array<T> => [...items],
+  }
+}
+
+const logs = ring<RecordedLog>(MAX_LOGS)
+const errors = ring<RecordedError>(MAX_ERRORS)
+const requests = ring<RecordedRequest>(MAX_REQUESTS)
+
+export const recordedLogs = (): Array<RecordedLog> => logs.all()
+export const recordedErrors = (): Array<RecordedError> => errors.all()
+export const recordedRequests = (): Array<RecordedRequest> => requests.all()
+
+export function describeUnknown(value: unknown): string {
+  if (typeof value === "string") return value
+  if (value instanceof Error)
+    return value.stack
+      ? `${value.name}: ${value.message}\n${value.stack}`
+      : `${value.name}: ${value.message}`
+  try {
+    return JSON.stringify(value) ?? String(value)
+  } catch {
+    return String(value)
+  }
+}
+
+function joinArgs(args: Array<unknown>): string {
+  return args.map(describeUnknown).join(" ").slice(0, MAX_TEXT)
+}
+
+function requestMethod(input: RequestInfo | URL, init?: RequestInit): string {
+  const method =
+    init?.method ?? (input instanceof Request ? input.method : "GET")
+  return method.toUpperCase()
+}
+
+function requestUrl(input: RequestInfo | URL): string {
+  return input instanceof Request ? input.url : String(input)
+}
+
+let installed = false
+
+/**
+ * Buffer console noise, uncaught errors and fetch traffic so a snapshot taken
+ * after something breaks still has the run-up to it.
+ */
+export function installDebugRecorder(): void {
+  if (installed || typeof window === "undefined") return
+  installed = true
+
+  for (const level of ["warn", "error"] as const) {
+    const original = console[level].bind(console)
+    console[level] = (...args: Array<unknown>) => {
+      logs.push({ at: Date.now(), level, text: joinArgs(args) })
+      original(...args)
+    }
+  }
+
+  window.addEventListener("error", (event) => {
+    errors.push({
+      at: Date.now(),
+      kind: "error",
+      message: event.message || "unknown error",
+      source: event.filename
+        ? `${event.filename}:${event.lineno}:${event.colno}`
+        : undefined,
+      stack:
+        event.error instanceof Error
+          ? event.error.stack?.slice(0, MAX_TEXT)
+          : undefined,
+    })
+  })
+
+  window.addEventListener("unhandledrejection", (event) => {
+    const reason: unknown = event.reason
+    errors.push({
+      at: Date.now(),
+      kind: "unhandledrejection",
+      message: describeUnknown(reason).slice(0, MAX_TEXT),
+      stack:
+        reason instanceof Error ? reason.stack?.slice(0, MAX_TEXT) : undefined,
+    })
+  })
+
+  const originalFetch = window.fetch.bind(window)
+  window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    const started = performance.now()
+    const entry = { method: requestMethod(input, init), url: requestUrl(input) }
+    try {
+      const response = await originalFetch(input, init)
+      requests.push({
+        at: Date.now(),
+        ...entry,
+        status: response.status,
+        ms: Math.round(performance.now() - started),
+      })
+      return response
+    } catch (error) {
+      requests.push({
+        at: Date.now(),
+        ...entry,
+        status: null,
+        ms: Math.round(performance.now() - started),
+        error: describeUnknown(error).slice(0, 200),
+      })
+      throw error
+    }
+  }
+}

--- a/ui/src/lib/debugSnapshot.test.ts
+++ b/ui/src/lib/debugSnapshot.test.ts
@@ -1,0 +1,43 @@
+/** @vitest-environment jsdom */
+
+import { describe, expect, it } from "vitest"
+
+import { redactStorage, redactUrl } from "./debugSnapshot"
+
+describe("debug snapshot redaction", () => {
+  it("redacts credential-shaped query parameters and keeps the rest", () => {
+    expect(
+      redactUrl("https://openswe.dev/login?code=abc123&state=xyz&next=/agents")
+    ).toBe(
+      "https://openswe.dev/login?code=%5Bredacted%5D&state=%5Bredacted%5D&next=%2Fagents"
+    )
+    expect(redactUrl("https://openswe.dev/agents?page=1")).toBe(
+      "https://openswe.dev/agents?page=1"
+    )
+  })
+
+  it("keeps relative request urls relative", () => {
+    expect(redactUrl("/dashboard/api/threads?access_token=secret")).toBe(
+      "/dashboard/api/threads?access_token=%5Bredacted%5D"
+    )
+  })
+
+  it("redacts secret-looking storage keys and truncates the rest", () => {
+    const storage = new Map([
+      ["open-swe-theme", "dark"],
+      ["open-swe.github-token", "ghp_realtoken"],
+      ["open-swe.notes", "n".repeat(400)],
+    ])
+    const keys = [...storage.keys()]
+    const fake = {
+      length: keys.length,
+      key: (index: number) => keys[index] ?? null,
+      getItem: (key: string) => storage.get(key) ?? null,
+    } as Storage
+
+    const redacted = redactStorage(fake)
+    expect(redacted["open-swe-theme"]).toBe("dark")
+    expect(redacted["open-swe.github-token"]).toBe("[redacted]")
+    expect(redacted["open-swe.notes"]).toBe(`${"n".repeat(200)}…(400)`)
+  })
+})

--- a/ui/src/lib/debugSnapshot.ts
+++ b/ui/src/lib/debugSnapshot.ts
@@ -454,6 +454,19 @@ export function captureDebugSnapshot({
   }
 }
 
+function requestPath(url: string): string {
+  try {
+    const parsed = new URL(url, window.location.origin)
+    return `${parsed.pathname}${parsed.search}`
+  } catch {
+    return url
+  }
+}
+
+function oneLine(value: string, max: number): string {
+  return truncate(value.replace(/\s+/g, " ").trim(), max)
+}
+
 export function formatDebugSnapshot(snapshot: DebugSnapshot): string {
   const failedRequests = snapshot.requests.filter(
     (request) => request.status === null || request.status >= 400
@@ -470,6 +483,10 @@ export function formatDebugSnapshot(snapshot: DebugSnapshot): string {
     snapshot.app.datadog.sessionLink
       ? `- datadog: ${snapshot.app.datadog.sessionLink}`
       : "- datadog: no session",
+    ...failedRequests.slice(-3).map((request) => {
+      const reason = request.detail ?? request.error ?? ""
+      return `- failed: ${request.method} ${requestPath(request.url)} → ${request.status ?? "network"}${reason ? ` ${oneLine(reason, 160)}` : ""}`
+    }),
   ]
   return `${header.join("\n")}\n\n\`\`\`json\n${JSON.stringify(snapshot, null, 2)}\n\`\`\`\n`
 }

--- a/ui/src/lib/debugSnapshot.ts
+++ b/ui/src/lib/debugSnapshot.ts
@@ -1,0 +1,475 @@
+import { useStreamPool } from "@/features/agents/lib/stream/streamPool"
+import { dashboardApiBase } from "@/lib/api-base"
+import { getDatadogSessionLink, isDatadogRumInitialized } from "@/lib/datadog"
+import {
+  describeUnknown,
+  recordedErrors,
+  recordedLogs,
+  recordedRequests,
+} from "@/lib/debugRecorder"
+import { THEME_STORAGE_KEY } from "@/lib/theme"
+import type { QueryClient } from "@tanstack/react-query"
+import type { AnyRouter } from "@tanstack/react-router"
+import type { SessionUser } from "@/lib/api"
+import type {
+  RecordedError,
+  RecordedLog,
+  RecordedRequest,
+} from "@/lib/debugRecorder"
+
+const SENSITIVE_PARAM_RE =
+  /(token|secret|password|signature|^code$|^state$|^key$|apikey|api[-_]key|auth)/i
+const SENSITIVE_STORAGE_RE =
+  /(token|secret|password|credential|bearer|cookie|apikey|api[-_]key|authorization)/i
+const REDACTED = "[redacted]"
+const MAX_VALUE = 400
+const MAX_QUERIES = 60
+
+export interface DebugSnapshot {
+  meta: {
+    schema: number
+    trigger: string
+    at: string
+    atLocal: string
+    timeZone: string
+    uptimeMs: number
+  }
+  app: {
+    url: string
+    referrer: string
+    apiBase: string
+    basePath: string
+    mode: string
+    desktop: boolean
+    datadog: { initialized: boolean; sessionLink: string | null }
+  }
+  user: { login: string; email: string | null; isAdmin: boolean } | null
+  route: {
+    status: string
+    isLoading: boolean
+    resolvedPathname: string | null
+    pathname: string
+    search: unknown
+    hash: string
+    matches: Array<{
+      routeId: string
+      status: string
+      params: unknown
+      error: string | null
+    }>
+  }
+  environment: {
+    userAgent: string
+    platform: string
+    language: string
+    online: boolean
+    viewport: { width: number; height: number; dpr: number }
+    screen: { width: number; height: number }
+    prefersColorScheme: "dark" | "light"
+    theme: string
+    visibility: string
+    hasFocus: boolean
+    connection: Record<string, unknown> | null
+    memoryMb: Record<string, number> | null
+  }
+  dom: {
+    activeElement: string
+    openDialogs: number
+    rootClasses: string
+    scrollY: number
+  }
+  navigationTiming: Record<string, number> | null
+  queries: Array<{
+    key: string
+    status: string
+    fetchStatus: string
+    isInvalidated: boolean
+    updatedAt: string | null
+    observers: number
+    error: string | null
+    data: string
+  }>
+  mutations: Array<{
+    key: string
+    status: string
+    submittedAt: string | null
+    error: string | null
+  }>
+  streams: {
+    activeId: string | null
+    binding: unknown
+    createdThreadId: string | null
+    entries: Array<{
+      id: string
+      transport: string
+      threadId: string | null
+      awaitingCreation: boolean
+      generation: number
+      lastActiveAt: string
+      isLoading: boolean | null
+      isThreadLoading: boolean | null
+      messages: number | null
+      interrupts: number | null
+      error: string | null
+    }>
+  }
+  requests: Array<RecordedRequest & { atLocal: string }>
+  logs: Array<RecordedLog & { atLocal: string }>
+  errors: Array<RecordedError & { atLocal: string }>
+  storage: { local: Record<string, string>; sessionKeys: Array<string> }
+  failures: Array<string>
+}
+
+function localTime(at: number): string {
+  return new Date(at).toLocaleString(undefined, { hour12: false })
+}
+
+function truncate(value: string, max = MAX_VALUE): string {
+  return value.length > max ? `${value.slice(0, max)}…(${value.length})` : value
+}
+
+function errorText(error: unknown): string | null {
+  if (error === null || error === undefined) return null
+  return truncate(describeUnknown(error))
+}
+
+/** Strip credential-shaped query parameters so a snapshot is safe to paste. */
+export function redactUrl(url: string): string {
+  try {
+    const parsed = new URL(url, "http://localhost")
+    let changed = false
+    for (const name of Array.from(parsed.searchParams.keys())) {
+      if (!SENSITIVE_PARAM_RE.test(name)) continue
+      parsed.searchParams.set(name, REDACTED)
+      changed = true
+    }
+    if (!changed) return url
+    return url.startsWith("/")
+      ? `${parsed.pathname}${parsed.search}`
+      : parsed.toString()
+  } catch {
+    return url
+  }
+}
+
+export function redactStorage(storage: Storage): Record<string, string> {
+  const values: Record<string, string> = {}
+  for (let index = 0; index < storage.length; index += 1) {
+    const key = storage.key(index)
+    if (!key) continue
+    const value = storage.getItem(key) ?? ""
+    values[key] = SENSITIVE_STORAGE_RE.test(key)
+      ? REDACTED
+      : truncate(value, 200)
+  }
+  return values
+}
+
+function describeData(data: unknown): string {
+  if (data === undefined) return "undefined"
+  if (data === null) return "null"
+  if (Array.isArray(data)) return `Array(${data.length})`
+  if (data instanceof Map) return `Map(${data.size})`
+  if (typeof data === "object")
+    return `{${Object.keys(data).slice(0, 12).join(", ")}}`
+  return truncate(String(data), 80)
+}
+
+function stringifyKey(key: unknown): string {
+  try {
+    return truncate(JSON.stringify(key) ?? String(key), 200)
+  } catch {
+    return String(key)
+  }
+}
+
+function describeElement(element: Element | null): string {
+  if (!element) return "none"
+  const id = element.id ? `#${element.id}` : ""
+  const classes = element.className
+    ? `.${String(element.className).trim().split(/\s+/).slice(0, 3).join(".")}`
+    : ""
+  return `${element.tagName.toLowerCase()}${id}${classes}`
+}
+
+function connectionInfo(): Record<string, unknown> | null {
+  const connection = (
+    navigator as Navigator & {
+      connection?: {
+        effectiveType?: string
+        downlink?: number
+        rtt?: number
+        saveData?: boolean
+      }
+    }
+  ).connection
+  if (!connection) return null
+  return {
+    effectiveType: connection.effectiveType,
+    downlink: connection.downlink,
+    rtt: connection.rtt,
+    saveData: connection.saveData,
+  }
+}
+
+function memoryInfo(): Record<string, number> | null {
+  const memory = (
+    performance as Performance & {
+      memory?: {
+        usedJSHeapSize: number
+        totalJSHeapSize: number
+        jsHeapSizeLimit: number
+      }
+    }
+  ).memory
+  if (!memory) return null
+  const mb = (bytes: number) => Math.round(bytes / 1024 / 1024)
+  return {
+    used: mb(memory.usedJSHeapSize),
+    total: mb(memory.totalJSHeapSize),
+    limit: mb(memory.jsHeapSizeLimit),
+  }
+}
+
+function navigationTiming(): Record<string, number> | null {
+  const [entry] = performance.getEntriesByType(
+    "navigation"
+  ) as Array<PerformanceNavigationTiming>
+  if (!entry) return null
+  const round = (value: number) => Math.round(value)
+  return {
+    ttfbMs: round(entry.responseStart),
+    domContentLoadedMs: round(entry.domContentLoadedEventEnd),
+    loadMs: round(entry.loadEventEnd),
+    transferSizeKb: Math.round(entry.transferSize / 1024),
+    resources: performance.getEntriesByType("resource").length,
+  }
+}
+
+function streamsSnapshot(): DebugSnapshot["streams"] {
+  const pool = useStreamPool.getState()
+  return {
+    activeId: pool.activeId,
+    binding: pool.binding,
+    createdThreadId: pool.createdThreadId,
+    entries: pool.entries.map((entry) => {
+      const handle = pool.handles[entry.id]
+      return {
+        id: entry.id,
+        transport: entry.transport,
+        threadId: entry.threadId,
+        awaitingCreation: entry.awaitingCreation,
+        generation: entry.generation,
+        lastActiveAt: localTime(entry.lastActiveAt),
+        isLoading: handle?.isLoading ?? null,
+        isThreadLoading: handle?.isThreadLoading ?? null,
+        messages: handle?.messages.length ?? null,
+        interrupts: handle?.interrupts.length ?? null,
+        error: handle ? errorText(handle.error) : null,
+      }
+    }),
+  }
+}
+
+function routeSnapshot(router: AnyRouter): DebugSnapshot["route"] {
+  const state = router.state
+  return {
+    status: state.status,
+    isLoading: state.isLoading,
+    resolvedPathname: state.resolvedLocation?.pathname ?? null,
+    pathname: state.location.pathname,
+    search: state.location.search,
+    hash: state.location.hash,
+    matches: state.matches.map((match) => ({
+      routeId: String(match.routeId),
+      status: match.status,
+      params: match.params,
+      error: errorText(match.error),
+    })),
+  }
+}
+
+function queriesSnapshot(queryClient: QueryClient): DebugSnapshot["queries"] {
+  return queryClient
+    .getQueryCache()
+    .getAll()
+    .slice(0, MAX_QUERIES)
+    .map((query) => ({
+      key: stringifyKey(query.queryKey),
+      status: query.state.status,
+      fetchStatus: query.state.fetchStatus,
+      isInvalidated: query.state.isInvalidated,
+      updatedAt: query.state.dataUpdatedAt
+        ? localTime(query.state.dataUpdatedAt)
+        : null,
+      observers: query.getObserversCount(),
+      error: errorText(query.state.error),
+      data: describeData(query.state.data),
+    }))
+}
+
+function mutationsSnapshot(
+  queryClient: QueryClient
+): DebugSnapshot["mutations"] {
+  return queryClient
+    .getMutationCache()
+    .getAll()
+    .map((mutation) => ({
+      key: stringifyKey(mutation.options.mutationKey ?? "anonymous"),
+      status: mutation.state.status,
+      submittedAt: mutation.state.submittedAt
+        ? localTime(mutation.state.submittedAt)
+        : null,
+      error: errorText(mutation.state.error),
+    }))
+}
+
+/**
+ * Sections are collected independently: a snapshot taken while the page is
+ * half-broken should still carry everything that did read cleanly, with the
+ * rest named in `failures`.
+ */
+export function captureDebugSnapshot({
+  router,
+  queryClient,
+  trigger,
+}: {
+  router: AnyRouter
+  queryClient: QueryClient
+  trigger: string
+}): DebugSnapshot {
+  const failures: Array<string> = []
+  const section = <T>(name: string, read: () => T, fallback: T): T => {
+    try {
+      return read()
+    } catch (error) {
+      failures.push(`${name}: ${describeUnknown(error).slice(0, 200)}`)
+      return fallback
+    }
+  }
+
+  const now = Date.now()
+  const user = section<SessionUser | null>(
+    "user",
+    () => queryClient.getQueryData<SessionUser | null>(["session"]) ?? null,
+    null
+  )
+  const theme = section(
+    "theme",
+    () => window.localStorage.getItem(THEME_STORAGE_KEY) ?? "system",
+    "unknown"
+  )
+
+  return {
+    meta: {
+      schema: 1,
+      trigger,
+      at: new Date(now).toISOString(),
+      atLocal: localTime(now),
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      uptimeMs: Math.round(performance.now()),
+    },
+    app: {
+      url: redactUrl(window.location.href),
+      referrer: redactUrl(document.referrer),
+      apiBase: dashboardApiBase(),
+      basePath: import.meta.env.BASE_URL,
+      mode: import.meta.env.MODE,
+      desktop: Boolean(window.openSweDesktop),
+      datadog: {
+        initialized: isDatadogRumInitialized(),
+        sessionLink: getDatadogSessionLink() ?? null,
+      },
+    },
+    user: user
+      ? { login: user.login, email: user.email, isAdmin: user.is_admin }
+      : null,
+    route: section("route", () => routeSnapshot(router), {
+      status: "unknown",
+      isLoading: false,
+      resolvedPathname: null,
+      pathname: window.location.pathname,
+      search: {},
+      hash: "",
+      matches: [],
+    }),
+    environment: {
+      userAgent: navigator.userAgent,
+      platform: navigator.platform,
+      language: navigator.language,
+      online: navigator.onLine,
+      viewport: {
+        width: window.innerWidth,
+        height: window.innerHeight,
+        dpr: window.devicePixelRatio,
+      },
+      screen: { width: window.screen.width, height: window.screen.height },
+      prefersColorScheme: window.matchMedia("(prefers-color-scheme: dark)")
+        .matches
+        ? "dark"
+        : "light",
+      theme,
+      visibility: document.visibilityState,
+      hasFocus: document.hasFocus(),
+      connection: section("connection", connectionInfo, null),
+      memoryMb: section("memory", memoryInfo, null),
+    },
+    dom: {
+      activeElement: describeElement(document.activeElement),
+      openDialogs: document.querySelectorAll('[role="dialog"]').length,
+      rootClasses: document.documentElement.className,
+      scrollY: Math.round(window.scrollY),
+    },
+    navigationTiming: section("navigationTiming", navigationTiming, null),
+    queries: section("queries", () => queriesSnapshot(queryClient), []),
+    mutations: section("mutations", () => mutationsSnapshot(queryClient), []),
+    streams: section("streams", streamsSnapshot, {
+      activeId: null,
+      binding: null,
+      createdThreadId: null,
+      entries: [],
+    }),
+    requests: recordedRequests().map((entry) => ({
+      ...entry,
+      url: redactUrl(entry.url),
+      atLocal: localTime(entry.at),
+    })),
+    logs: recordedLogs().map((entry) => ({
+      ...entry,
+      atLocal: localTime(entry.at),
+    })),
+    errors: recordedErrors().map((entry) => ({
+      ...entry,
+      atLocal: localTime(entry.at),
+    })),
+    storage: section(
+      "storage",
+      () => ({
+        local: redactStorage(window.localStorage),
+        sessionKeys: Object.keys(window.sessionStorage),
+      }),
+      { local: {}, sessionKeys: [] }
+    ),
+    failures,
+  }
+}
+
+export function formatDebugSnapshot(snapshot: DebugSnapshot): string {
+  const failedRequests = snapshot.requests.filter(
+    (request) => request.status === null || request.status >= 400
+  )
+  const header = [
+    "### Open SWE debug snapshot",
+    `- when: ${snapshot.meta.atLocal} (${snapshot.meta.timeZone})`,
+    `- url: ${snapshot.app.url}`,
+    `- route: ${snapshot.route.pathname} (${snapshot.route.status})`,
+    `- user: ${snapshot.user ? snapshot.user.login : "signed out"}`,
+    `- build: ${snapshot.app.mode}${snapshot.app.desktop ? " desktop" : ""}`,
+    `- viewport: ${snapshot.environment.viewport.width}×${snapshot.environment.viewport.height} @${snapshot.environment.viewport.dpr}x, theme ${snapshot.environment.theme}`,
+    `- errors: ${snapshot.errors.length}, failed requests: ${failedRequests.length}`,
+    snapshot.app.datadog.sessionLink
+      ? `- datadog: ${snapshot.app.datadog.sessionLink}`
+      : "- datadog: no session",
+  ]
+  return `${header.join("\n")}\n\n\`\`\`json\n${JSON.stringify(snapshot, null, 2)}\n\`\`\`\n`
+}

--- a/ui/src/lib/hotkeys.test.ts
+++ b/ui/src/lib/hotkeys.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  createRapidKeyRun,
   eventMatchesShortcut,
   formatShortcut,
   isHotkeySuppressed,
@@ -105,5 +106,31 @@ describe("keyboard shortcut utilities", () => {
     expect(shouldIgnoreHotkey(composing)).toBe(true)
     expect(shouldIgnoreHotkey(repeated)).toBe(true)
     expect(shouldIgnoreHotkey(prevented)).toBe(true)
+  })
+})
+
+describe("rapid key runs", () => {
+  it("fires on the third press inside the window", () => {
+    const completesRun = createRapidKeyRun({ count: 3, windowMs: 750 })
+    expect(completesRun(0)).toBe(false)
+    expect(completesRun(200)).toBe(false)
+    expect(completesRun(400)).toBe(true)
+  })
+
+  it("drops presses older than the window", () => {
+    const completesRun = createRapidKeyRun({ count: 3, windowMs: 750 })
+    expect(completesRun(0)).toBe(false)
+    expect(completesRun(100)).toBe(false)
+    expect(completesRun(900)).toBe(false)
+    expect(completesRun(1000)).toBe(false)
+    expect(completesRun(1100)).toBe(true)
+  })
+
+  it("starts a fresh run after firing", () => {
+    const completesRun = createRapidKeyRun({ count: 3, windowMs: 750 })
+    for (const at of [0, 100, 200]) completesRun(at)
+    expect(completesRun(300)).toBe(false)
+    expect(completesRun(400)).toBe(false)
+    expect(completesRun(500)).toBe(true)
   })
 })

--- a/ui/src/lib/hotkeys.ts
+++ b/ui/src/lib/hotkeys.ts
@@ -167,6 +167,56 @@ export function shouldIgnoreHotkey(
 }
 
 /**
+ * Tracks presses of one key, reporting true on the press that completes
+ * `count` of them inside `windowMs`. Completing resets the run, so six
+ * presses fire twice rather than four times.
+ */
+export function createRapidKeyRun({
+  count,
+  windowMs,
+}: {
+  count: number
+  windowMs: number
+}): (at: number) => boolean {
+  let presses: Array<number> = []
+  return (at: number) => {
+    presses = presses.filter((previous) => at - previous < windowMs)
+    presses.push(at)
+    if (presses.length < count) return false
+    presses = []
+    return true
+  }
+}
+
+/**
+ * Fire when a bare key is pressed several times in quick succession. Listens
+ * in the capture phase and never prevents the default, so the key keeps its
+ * normal job (Escape still closes dialogs) and the run is still counted while
+ * a text field has focus.
+ */
+export function useRapidKeyRun(
+  key: string,
+  handler: () => void,
+  { count = 3, windowMs = 750 }: { count?: number; windowMs?: number } = {}
+) {
+  const handlerRef = useRef(handler)
+  useEffect(() => {
+    handlerRef.current = handler
+  }, [handler])
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    const completesRun = createRapidKeyRun({ count, windowMs })
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== key || event.repeat || event.isComposing) return
+      if (completesRun(Date.now())) handlerRef.current()
+    }
+    window.addEventListener("keydown", onKeyDown, true)
+    return () => window.removeEventListener("keydown", onKeyDown, true)
+  }, [key, count, windowMs])
+}
+
+/**
  * Register a global keyboard shortcut. Use "mod" for the platform meta key
  * (Cmd on macOS, Ctrl elsewhere). Accepts one combo or several aliases.
  */

--- a/ui/src/routes/__root.tsx
+++ b/ui/src/routes/__root.tsx
@@ -13,6 +13,7 @@ import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
 
 import appCss from "../styles.css?url"
 import type { QueryClient } from "@tanstack/react-query"
+import { DebugSnapshotHotkey } from "@/components/DebugSnapshotHotkey"
 import { AppCommandProvider } from "@/lib/appCommands"
 import { resolveSessionOnServer } from "@/lib/session-ssr"
 import { ThemeSync } from "@/lib/ThemeSync"
@@ -81,6 +82,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         <ThemeSync />
         <QueryClientProvider client={queryClient}>
           <AppCommandProvider>{children ?? <Outlet />}</AppCommandProvider>
+          <DebugSnapshotHotkey />
           {import.meta.env.VITE_DEVTOOLS !== "false" && (
             <>
               <TanStackDevtools


### PR DESCRIPTION
Triple-press Escape (three presses within 750ms) to capture the page's current state, copy it to the clipboard as markdown, and log it to the console. Also kept on `window.__openSweDebug` for poking at interactively.

Escape keeps working normally — the run is counted in the capture phase and never calls `preventDefault`, and it counts while a text field has focus.

What the snapshot carries:

- route status, location, and every match with its params and error
- react-query cache (keys, status, staleness, observer counts, errors, data shape only) and the mutation cache
- agent stream pool: entries, transports, thread ids, loading flags, message/interrupt counts, stream errors
- recent fetch traffic with status and duration, flagged when it failed
- buffered `console.warn`/`console.error`, uncaught errors and unhandled rejections from before the dump
- browser, viewport, theme, connection, heap and navigation timing
- `localStorage` contents and `sessionStorage` keys
- Datadog RUM session link, so a server-side trace is one click away

Credential-shaped query parameters and storage keys are redacted, values are truncated, and each section is collected independently so a snapshot taken on a half-broken page still carries whatever read cleanly (the rest is named under `failures`).