### PR TITLE
feat(ui): collapse repeated file edits

### DIFF
--- a/tests/e2e/fake_llm.py
+++ b/tests/e2e/fake_llm.py
@@ -63,6 +63,22 @@ def greet(name):
 
 def farewell(name):
     return f"Goodbye, {{name}}!"
+
+def welcome(name):
+    return f"Welcome, {{name}}!"
+
+def thank(name):
+    return f"Thanks, {{name}}!"
+
+def invite(name):
+    return f"Come in, {{name}}!"
+EOF
+cat > helpers.py <<'EOF'
+def display_name(name):
+    return name
+EOF
+cat > notes.md <<'EOF'
+Greeting helpers are available.
 EOF
 """.strip()
 
@@ -814,6 +830,16 @@ SCRIPT_LIBRARY: dict[str, tuple[StepSpec, ...]] = {
             "call-setup",
         ),
         _tool_step(
+            "Preparing the display helper.",
+            "edit_file",
+            {
+                "file_path": "/repo/helpers.py",
+                "old_string": "return name",
+                "new_string": "return name.strip()",
+            },
+            "call-edit-helper",
+        ),
+        _tool_step(
             "Implementing the greeting.",
             "edit_file",
             {
@@ -832,6 +858,66 @@ SCRIPT_LIBRARY: dict[str, tuple[StepSpec, ...]] = {
                 "new_string": 'return f"Hello, {name.strip()}!"',
             },
             "call-edit-refine",
+        ),
+        _tool_step(
+            "Polishing the greeting.",
+            "edit_file",
+            {
+                "file_path": f"/repo/{FEATURE_FILE}",
+                "old_string": 'return f"Hello, {name.strip()}!"',
+                "new_string": 'return f"Hello, {name.strip().title()}!"',
+            },
+            "call-edit-polish",
+        ),
+        _tool_step(
+            "Making the farewell consistent.",
+            "edit_file",
+            {
+                "file_path": f"/repo/{FEATURE_FILE}",
+                "old_string": 'return f"Goodbye, {name}!"',
+                "new_string": 'return f"Goodbye, {name.strip().title()}!"',
+            },
+            "call-edit-farewell",
+        ),
+        _tool_step(
+            "Making the welcome consistent.",
+            "edit_file",
+            {
+                "file_path": f"/repo/{FEATURE_FILE}",
+                "old_string": 'return f"Welcome, {name}!"',
+                "new_string": 'return f"Welcome, {name.strip().title()}!"',
+            },
+            "call-edit-welcome",
+        ),
+        _tool_step(
+            "Making thanks consistent.",
+            "edit_file",
+            {
+                "file_path": f"/repo/{FEATURE_FILE}",
+                "old_string": 'return f"Thanks, {name}!"',
+                "new_string": 'return f"Thanks, {name.strip().title()}!"',
+            },
+            "call-edit-thank",
+        ),
+        _tool_step(
+            "Making the invitation consistent.",
+            "edit_file",
+            {
+                "file_path": f"/repo/{FEATURE_FILE}",
+                "old_string": 'return f"Come in, {name}!"',
+                "new_string": 'return f"Come in, {name.strip().title()}!"',
+            },
+            "call-edit-invite",
+        ),
+        _tool_step(
+            "Updating the notes.",
+            "edit_file",
+            {
+                "file_path": "/repo/notes.md",
+                "old_string": "Greeting helpers are available.",
+                "new_string": "Greeting helpers normalize display names.",
+            },
+            "call-edit-notes",
         ),
         _tool_step(
             "Committing and pushing the change.",

--- a/tests/e2e/fake_llm.py
+++ b/tests/e2e/fake_llm.py
@@ -830,6 +830,12 @@ SCRIPT_LIBRARY: dict[str, tuple[StepSpec, ...]] = {
             "call-setup",
         ),
         _tool_step(
+            "Reading the greeting helpers.",
+            "read_file",
+            {"file_path": f"/repo/{FEATURE_FILE}"},
+            "call-read-first",
+        ),
+        _tool_step(
             "Preparing the display helper.",
             "edit_file",
             {
@@ -870,6 +876,12 @@ SCRIPT_LIBRARY: dict[str, tuple[StepSpec, ...]] = {
             "call-edit-polish",
         ),
         _tool_step(
+            "Checking the greeting helpers again.",
+            "read_file",
+            {"file_path": f"/repo/{FEATURE_FILE}"},
+            "call-read-second",
+        ),
+        _tool_step(
             "Making the farewell consistent.",
             "edit_file",
             {
@@ -898,6 +910,12 @@ SCRIPT_LIBRARY: dict[str, tuple[StepSpec, ...]] = {
                 "new_string": 'return f"Thanks, {name.strip().title()}!"',
             },
             "call-edit-thank",
+        ),
+        _tool_step(
+            "Verifying the greeting helpers.",
+            "read_file",
+            {"file_path": f"/repo/{FEATURE_FILE}"},
+            "call-read-third",
         ),
         _tool_step(
             "Making the invitation consistent.",

--- a/tests/e2e/fake_llm.py
+++ b/tests/e2e/fake_llm.py
@@ -824,6 +824,16 @@ SCRIPT_LIBRARY: dict[str, tuple[StepSpec, ...]] = {
             "call-edit",
         ),
         _tool_step(
+            "Refining the greeting.",
+            "edit_file",
+            {
+                "file_path": f"/repo/{FEATURE_FILE}",
+                "old_string": 'return f"Hello, {name}!"',
+                "new_string": 'return f"Hello, {name.strip()}!"',
+            },
+            "call-edit-refine",
+        ),
+        _tool_step(
             "Committing and pushing the change.",
             "execute",
             {"command": _COMMIT_SCRIPT},

--- a/tests/e2e/tests/dashboard_transcript.spec.ts
+++ b/tests/e2e/tests/dashboard_transcript.spec.ts
@@ -50,7 +50,7 @@ test.describe("finished transcript (shared fixture thread)", () => {
     await page.unroute("**/stream/events");
   });
 
-  test("folds the agent's work and expands an Edit into an inline diff", async () => {
+  test("folds repeated edits into one expandable combined diff", async () => {
     await page.goto(`/agents/${threadId}`);
     await expectTranscriptVisible(page);
 
@@ -66,7 +66,7 @@ test.describe("finished transcript (shared fixture thread)", () => {
     await expect(edit).toHaveCount(0);
 
     await worked.click();
-    await expect(edit).toBeVisible();
+    await expect(edit).toHaveCount(1);
     await expect(acknowledgement).toBeVisible();
     expect(
       await acknowledgement.evaluate(
@@ -90,7 +90,8 @@ test.describe("finished transcript (shared fixture thread)", () => {
     ).toContainText('return "Hello!"');
     await expect(
       inlineDiff.locator('[data-line][data-line-type="change-addition"]'),
-    ).toContainText('return f"Hello, {name}!"');
+    ).toContainText('return f"Hello, {name.strip()}!"');
+    await expect(inlineDiff).not.toContainText('return f"Hello, {name}!"');
     await expect(inlineDiff).toHaveAttribute("data-disable-line-numbers");
     await expect(inlineDiff).not.toContainText("normalize");
   });

--- a/tests/e2e/tests/dashboard_transcript.spec.ts
+++ b/tests/e2e/tests/dashboard_transcript.spec.ts
@@ -58,7 +58,9 @@ test.describe("finished transcript (shared fixture thread)", () => {
       name: /^Worked(?: for .+)? · \d+ actions?$/,
     });
     const acknowledgement = page.getByText("On it!", { exact: true });
+    const helperEdit = page.getByRole("button", { name: "Edited helpers.py" });
     const edit = page.getByRole("button", { name: "Edited greet.py" });
+    const notesEdit = page.getByRole("button", { name: "Edited notes.md" });
 
     // Folded: the acknowledgement shows, the individual tool calls do not.
     await expect(worked).toBeVisible();
@@ -66,7 +68,9 @@ test.describe("finished transcript (shared fixture thread)", () => {
     await expect(edit).toHaveCount(0);
 
     await worked.click();
+    await expect(helperEdit).toHaveCount(1);
     await expect(edit).toHaveCount(1);
+    await expect(notesEdit).toHaveCount(1);
     await expect(acknowledgement).toBeVisible();
     expect(
       await acknowledgement.evaluate(
@@ -79,19 +83,53 @@ test.describe("finished transcript (shared fixture thread)", () => {
       ),
     ).toBe(true);
 
+    expect(
+      await helperEdit.evaluate(
+        (helper, entries) => {
+          const [greeting, notes] = entries;
+          return Boolean(
+            greeting &&
+            notes &&
+            helper.compareDocumentPosition(greeting) &
+              Node.DOCUMENT_POSITION_FOLLOWING &&
+            greeting.compareDocumentPosition(notes) &
+              Node.DOCUMENT_POSITION_FOLLOWING,
+          );
+        },
+        await Promise.all([edit.elementHandle(), notesEdit.elementHandle()]),
+      ),
+    ).toBe(true);
+
     await expect(edit).toHaveAttribute("aria-expanded", "false");
     await edit.click();
     await expect(edit).toHaveAttribute("aria-expanded", "true");
 
     const inlineDiff = edit.locator("[data-diff]");
     await expect(inlineDiff).toBeVisible();
-    await expect(
-      inlineDiff.locator('[data-line][data-line-type="change-deletion"]'),
-    ).toContainText('return "Hello!"');
-    await expect(
-      inlineDiff.locator('[data-line][data-line-type="change-addition"]'),
-    ).toContainText('return f"Hello, {name.strip()}!"');
+    const deletions = inlineDiff.locator(
+      '[data-line][data-line-type="change-deletion"]',
+    );
+    await expect(deletions).toContainText([
+      'return "Hello!"',
+      'return f"Goodbye, {name}!"',
+      'return f"Welcome, {name}!"',
+      'return f"Thanks, {name}!"',
+      'return f"Come in, {name}!"',
+    ]);
+    const additions = inlineDiff.locator(
+      '[data-line][data-line-type="change-addition"]',
+    );
+    await expect(additions).toContainText([
+      'return f"Hello, {name.strip().title()}!"',
+      'return f"Goodbye, {name.strip().title()}!"',
+      'return f"Welcome, {name.strip().title()}!"',
+      'return f"Thanks, {name.strip().title()}!"',
+      'return f"Come in, {name.strip().title()}!"',
+    ]);
     await expect(inlineDiff).not.toContainText('return f"Hello, {name}!"');
+    await expect(inlineDiff).not.toContainText(
+      'return f"Hello, {name.strip()}!"',
+    );
     await expect(inlineDiff).toHaveAttribute("data-disable-line-numbers");
     await expect(inlineDiff).not.toContainText("normalize");
   });

--- a/tests/e2e/tests/dashboard_transcript.spec.ts
+++ b/tests/e2e/tests/dashboard_transcript.spec.ts
@@ -59,7 +59,8 @@ test.describe("finished transcript (shared fixture thread)", () => {
     });
     const acknowledgement = page.getByText("On it!", { exact: true });
     const helperEdit = page.getByRole("button", { name: "Edited helpers.py" });
-    const edit = page.getByRole("button", { name: "Edited greet.py" });
+    const read = page.getByText("Read (x3)", { exact: true });
+    const edit = page.getByRole("button", { name: "Edited (x7) greet.py" });
     const notesEdit = page.getByRole("button", { name: "Edited notes.md" });
 
     // Folded: the acknowledgement shows, the individual tool calls do not.
@@ -69,6 +70,7 @@ test.describe("finished transcript (shared fixture thread)", () => {
 
     await worked.click();
     await expect(helperEdit).toHaveCount(1);
+    await expect(read).toHaveCount(1);
     await expect(edit).toHaveCount(1);
     await expect(notesEdit).toHaveCount(1);
     await expect(acknowledgement).toBeVisible();

--- a/ui/src/features/agents/components/messages/renderItems.test.ts
+++ b/ui/src/features/agents/components/messages/renderItems.test.ts
@@ -6,7 +6,27 @@ import {
   selectCollapsedTurnItems,
   splitWorkAndReply,
 } from "./renderItems"
-import type { Chunk, ToolExecutionChunk } from "@/features/agents/lib/types"
+import type {
+  Chunk,
+  DiffData,
+  ToolExecutionChunk,
+} from "@/features/agents/lib/types"
+
+function diff(
+  filePath: string,
+  originalContent: string,
+  newContent: string
+): DiffData {
+  return {
+    filePath,
+    originalContent,
+    newContent,
+    isNewFile: false,
+    isBinary: false,
+    isTruncated: false,
+    totalLines: 1,
+  }
+}
 
 function iframeChunk(): ToolExecutionChunk {
   return {
@@ -35,6 +55,42 @@ describe("buildRenderItems", () => {
         key: "tool-call-1",
         chunk: iframeChunk(),
       },
+    ])
+  })
+
+  it("groups repeated edits to the same file without expanding individual calls", () => {
+    const first: ToolExecutionChunk = {
+      kind: "tool-execution",
+      toolCallId: "edit-1",
+      title: "edit_file /workspace/app.ts",
+      toolKind: "edit",
+      status: "completed",
+      diffData: diff("/workspace/app.ts", "a\n", "b\n"),
+    }
+    const other: ToolExecutionChunk = {
+      kind: "tool-execution",
+      toolCallId: "edit-2",
+      title: "edit_file /workspace/other.ts",
+      toolKind: "edit",
+      status: "completed",
+      diffData: diff("/workspace/other.ts", "x\n", "y\n"),
+    }
+    const second: ToolExecutionChunk = {
+      kind: "tool-execution",
+      toolCallId: "edit-3",
+      title: "edit_file /workspace/app.ts",
+      toolKind: "edit",
+      status: "completed",
+      diffData: diff("/workspace/app.ts", "b\n", "c\n"),
+    }
+
+    expect(buildRenderItems([first, other, second])).toEqual([
+      {
+        type: "edit-group",
+        key: "edit-group-edit-1",
+        chunks: [first, second],
+      },
+      { type: "edit-item", key: "tool-edit-2", chunk: other },
     ])
   })
 

--- a/ui/src/features/agents/components/messages/renderItems.test.ts
+++ b/ui/src/features/agents/components/messages/renderItems.test.ts
@@ -94,6 +94,43 @@ describe("buildRenderItems", () => {
     ])
   })
 
+  it("groups repeated reads to the same file while preserving other exploration", () => {
+    const first: ToolExecutionChunk = {
+      kind: "tool-execution",
+      toolCallId: "read-1",
+      title: "read_file",
+      toolKind: "read",
+      input: { file_path: "/workspace/app.ts" },
+      status: "completed",
+    }
+    const search: ToolExecutionChunk = {
+      kind: "tool-execution",
+      toolCallId: "search-1",
+      title: "search",
+      toolKind: "search",
+      input: { pattern: "render" },
+      status: "completed",
+    }
+    const second: ToolExecutionChunk = {
+      ...first,
+      toolCallId: "read-2",
+    }
+
+    expect(buildRenderItems([first, search, second])).toEqual([
+      {
+        type: "read-group",
+        key: "read-group-read-1",
+        chunks: [first, second],
+      },
+      {
+        type: "explored-group",
+        key: "explored-read-1-search-1",
+        id: "explored-read-1-search-1",
+        chunks: [search],
+      },
+    ])
+  })
+
   it("keeps sent replies visible when later work runs", () => {
     const sentReply: ToolExecutionChunk = {
       kind: "tool-execution",

--- a/ui/src/features/agents/components/messages/renderItems.ts
+++ b/ui/src/features/agents/components/messages/renderItems.ts
@@ -20,6 +20,11 @@ export type RenderItem =
       chunks: Array<ToolExecutionChunk>
     }
   | { type: "edit-item"; key: string; chunk: ToolExecutionChunk }
+  | {
+      type: "edit-group"
+      key: string
+      chunks: Array<ToolExecutionChunk>
+    }
   | { type: "shell-item"; key: string; chunk: ToolExecutionChunk }
   | { type: "reply-item"; key: string; chunk: ToolExecutionChunk }
   | { type: "iframe-item"; key: string; chunk: ToolExecutionChunk }
@@ -72,6 +77,14 @@ function attentionItems(
   item: RenderItem,
   includeUnfinished: boolean
 ): Array<RenderItem> {
+  if (item.type === "edit-group") {
+    return item.chunks.some((chunk) =>
+      toolNeedsAttention(chunk, includeUnfinished)
+    )
+      ? [item]
+      : []
+  }
+
   if (item.type === "explored-group" || item.type === "subagent-group") {
     return item.chunks
       .filter((chunk) => toolNeedsAttention(chunk, includeUnfinished))
@@ -114,6 +127,7 @@ export function countWorkActions(items: Array<RenderItem>): number {
     if (item.type === "explored-group" || item.type === "subagent-group") {
       return count + item.chunks.length
     }
+    if (item.type === "edit-group") return count + item.chunks.length
     if (
       item.type === "edit-item" ||
       item.type === "shell-item" ||
@@ -177,6 +191,45 @@ function isReplyTool(chunk: ToolExecutionChunk): boolean {
  */
 function isSubagentTool(chunk: ToolExecutionChunk): boolean {
   return chunk.toolKind === "task"
+}
+
+function editFilePath(chunk: ToolExecutionChunk): string | null {
+  const diff = chunk.diffs?.length
+    ? chunk.diffs[chunk.diffs.length - 1]
+    : chunk.diffData
+  if (diff?.filePath) return diff.filePath
+  const path =
+    chunk.input?.file_path ?? chunk.input?.path ?? chunk.input?.target_file
+  return typeof path === "string" && path.trim() ? path.trim() : null
+}
+
+function collapseRepeatedEdits(items: Array<RenderItem>): Array<RenderItem> {
+  const groups = new Map<string, Array<ToolExecutionChunk>>()
+  for (const item of items) {
+    if (item.type !== "edit-item") continue
+    const path = editFilePath(item.chunk)
+    if (!path) continue
+    const group = groups.get(path) ?? []
+    group.push(item.chunk)
+    groups.set(path, group)
+  }
+
+  const renderedGroups = new Set<string>()
+  return items.flatMap<RenderItem>((item) => {
+    if (item.type !== "edit-item") return [item]
+    const path = editFilePath(item.chunk)
+    const chunks = path ? groups.get(path) : undefined
+    if (!path || !chunks || chunks.length === 1) return [item]
+    if (renderedGroups.has(path)) return []
+    renderedGroups.add(path)
+    return [
+      {
+        type: "edit-group" as const,
+        key: `edit-group-${item.chunk.toolCallId}`,
+        chunks,
+      },
+    ]
+  })
 }
 
 export function buildRenderItems(
@@ -306,7 +359,7 @@ export function buildRenderItems(
   }
 
   flushGroups()
-  return items
+  return collapseRepeatedEdits(items)
 }
 
 export function summarizeExploration(

--- a/ui/src/features/agents/components/messages/renderItems.ts
+++ b/ui/src/features/agents/components/messages/renderItems.ts
@@ -25,6 +25,11 @@ export type RenderItem =
       key: string
       chunks: Array<ToolExecutionChunk>
     }
+  | {
+      type: "read-group"
+      key: string
+      chunks: Array<ToolExecutionChunk>
+    }
   | { type: "shell-item"; key: string; chunk: ToolExecutionChunk }
   | { type: "reply-item"; key: string; chunk: ToolExecutionChunk }
   | { type: "iframe-item"; key: string; chunk: ToolExecutionChunk }
@@ -77,7 +82,7 @@ function attentionItems(
   item: RenderItem,
   includeUnfinished: boolean
 ): Array<RenderItem> {
-  if (item.type === "edit-group") {
+  if (item.type === "edit-group" || item.type === "read-group") {
     return item.chunks.some((chunk) =>
       toolNeedsAttention(chunk, includeUnfinished)
     )
@@ -127,7 +132,9 @@ export function countWorkActions(items: Array<RenderItem>): number {
     if (item.type === "explored-group" || item.type === "subagent-group") {
       return count + item.chunks.length
     }
-    if (item.type === "edit-group") return count + item.chunks.length
+    if (item.type === "edit-group" || item.type === "read-group") {
+      return count + item.chunks.length
+    }
     if (
       item.type === "edit-item" ||
       item.type === "shell-item" ||
@@ -193,7 +200,7 @@ function isSubagentTool(chunk: ToolExecutionChunk): boolean {
   return chunk.toolKind === "task"
 }
 
-function editFilePath(chunk: ToolExecutionChunk): string | null {
+function toolFilePath(chunk: ToolExecutionChunk): string | null {
   const diff = chunk.diffs?.length
     ? chunk.diffs[chunk.diffs.length - 1]
     : chunk.diffData
@@ -207,7 +214,7 @@ function collapseRepeatedEdits(items: Array<RenderItem>): Array<RenderItem> {
   const groups = new Map<string, Array<ToolExecutionChunk>>()
   for (const item of items) {
     if (item.type !== "edit-item") continue
-    const path = editFilePath(item.chunk)
+    const path = toolFilePath(item.chunk)
     if (!path) continue
     const group = groups.get(path) ?? []
     group.push(item.chunk)
@@ -217,7 +224,7 @@ function collapseRepeatedEdits(items: Array<RenderItem>): Array<RenderItem> {
   const renderedGroups = new Set<string>()
   return items.flatMap<RenderItem>((item) => {
     if (item.type !== "edit-item") return [item]
-    const path = editFilePath(item.chunk)
+    const path = toolFilePath(item.chunk)
     const chunks = path ? groups.get(path) : undefined
     if (!path || !chunks || chunks.length === 1) return [item]
     if (renderedGroups.has(path)) return []
@@ -229,6 +236,58 @@ function collapseRepeatedEdits(items: Array<RenderItem>): Array<RenderItem> {
         chunks,
       },
     ]
+  })
+}
+
+function collapseRepeatedReads(items: Array<RenderItem>): Array<RenderItem> {
+  const groups = new Map<string, Array<ToolExecutionChunk>>()
+  for (const item of items) {
+    if (item.type !== "explored-group") continue
+    for (const chunk of item.chunks) {
+      if (chunk.toolKind !== "read") continue
+      const path = toolFilePath(chunk)
+      if (!path) continue
+      const group = groups.get(path) ?? []
+      group.push(chunk)
+      groups.set(path, group)
+    }
+  }
+
+  const renderedGroups = new Set<string>()
+  return items.flatMap<RenderItem>((item) => {
+    if (item.type !== "explored-group") return [item]
+    const replacement: Array<RenderItem> = []
+    let remaining: Array<ToolExecutionChunk> = []
+    const flushRemaining = () => {
+      if (remaining.length === 0) return
+      const first = remaining[0]
+      replacement.push({
+        type: "explored-group",
+        key: `${item.key}-${first?.toolCallId ?? replacement.length}`,
+        id: `${item.id}-${first?.toolCallId ?? replacement.length}`,
+        chunks: remaining,
+      })
+      remaining = []
+    }
+
+    for (const chunk of item.chunks) {
+      const path = chunk.toolKind === "read" ? toolFilePath(chunk) : null
+      const chunks = path ? groups.get(path) : undefined
+      if (!path || !chunks || chunks.length === 1) {
+        remaining.push(chunk)
+        continue
+      }
+      if (renderedGroups.has(path)) continue
+      flushRemaining()
+      renderedGroups.add(path)
+      replacement.push({
+        type: "read-group",
+        key: `read-group-${chunk.toolCallId}`,
+        chunks,
+      })
+    }
+    flushRemaining()
+    return replacement
   })
 }
 
@@ -359,7 +418,7 @@ export function buildRenderItems(
   }
 
   flushGroups()
-  return collapseRepeatedEdits(items)
+  return collapseRepeatedReads(collapseRepeatedEdits(items))
 }
 
 export function summarizeExploration(

--- a/ui/src/features/agents/components/messages/timeline/AgentTurn.tsx
+++ b/ui/src/features/agents/components/messages/timeline/AgentTurn.tsx
@@ -12,7 +12,12 @@ import {
 } from "../renderItems"
 import { MessageCopyButton } from "./MessageCopyButton"
 import { WorkEntryRow } from "./WorkEntryRow"
-import { describeWorkEntry, latestDiff } from "./workEntry"
+import {
+  combinedEditDiff,
+  describeEditGroup,
+  describeWorkEntry,
+  latestDiff,
+} from "./workEntry"
 import { TurnFoldRow, WorkGroupToggleRow } from "./foldRows"
 import { ShellEntryBody } from "./entryBodies"
 import type { ReactNode } from "react"
@@ -31,11 +36,6 @@ import { formatElapsed } from "@/lib/utils"
  */
 const MAX_VISIBLE_WORK_LOG_ENTRIES = 1
 
-/**
- * One row per edit call, showing only what the call targeted. The diff lives in
- * the turn's changed-files card and the side panel, both of which read git —
- * rendering a per-call diff here made repeated edits of one file look duplicated.
- */
 function EditWorkEntry({
   chunk,
   projectPath,
@@ -50,6 +50,25 @@ function EditWorkEntry({
       timestamp={chunk.timestamp}
       body={diff ? <DiffView diffData={diff} snippet /> : undefined}
       defaultExpanded={chunk.status === "pending"}
+    />
+  )
+}
+
+function EditWorkGroup({
+  chunks,
+  projectPath,
+}: {
+  chunks: Array<ToolExecutionChunk>
+  projectPath?: string
+}) {
+  const diff = combinedEditDiff(chunks)
+  const latestChunk = chunks[chunks.length - 1]
+  return (
+    <WorkEntryRow
+      entry={describeEditGroup(chunks, projectPath)}
+      timestamp={latestChunk?.timestamp}
+      body={diff ? <DiffView diffData={diff} snippet /> : undefined}
+      defaultExpanded={chunks.some((chunk) => chunk.status === "pending")}
     />
   )
 }
@@ -220,6 +239,15 @@ export function AgentTurn({
           <EditWorkEntry
             key={item.key}
             chunk={item.chunk}
+            projectPath={projectPath}
+          />
+        )
+
+      case "edit-group":
+        return (
+          <EditWorkGroup
+            key={item.key}
+            chunks={item.chunks}
             projectPath={projectPath}
           />
         )

--- a/ui/src/features/agents/components/messages/timeline/AgentTurn.tsx
+++ b/ui/src/features/agents/components/messages/timeline/AgentTurn.tsx
@@ -15,6 +15,7 @@ import { WorkEntryRow } from "./WorkEntryRow"
 import {
   combinedEditDiff,
   describeEditGroup,
+  describeReadGroup,
   describeWorkEntry,
   latestDiff,
 } from "./workEntry"
@@ -69,6 +70,22 @@ function EditWorkGroup({
       timestamp={latestChunk?.timestamp}
       body={diff ? <DiffView diffData={diff} snippet /> : undefined}
       defaultExpanded={chunks.some((chunk) => chunk.status === "pending")}
+    />
+  )
+}
+
+function ReadWorkGroup({
+  chunks,
+  projectPath,
+}: {
+  chunks: Array<ToolExecutionChunk>
+  projectPath?: string
+}) {
+  const latestChunk = chunks[chunks.length - 1]
+  return (
+    <WorkEntryRow
+      entry={describeReadGroup(chunks, projectPath)}
+      timestamp={latestChunk?.timestamp}
     />
   )
 }
@@ -246,6 +263,15 @@ export function AgentTurn({
       case "edit-group":
         return (
           <EditWorkGroup
+            key={item.key}
+            chunks={item.chunks}
+            projectPath={projectPath}
+          />
+        )
+
+      case "read-group":
+        return (
+          <ReadWorkGroup
             key={item.key}
             chunks={item.chunks}
             projectPath={projectPath}

--- a/ui/src/features/agents/components/messages/timeline/workEntry.test.ts
+++ b/ui/src/features/agents/components/messages/timeline/workEntry.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
   combinedEditDiff,
   describeEditGroup,
+  describeReadGroup,
   describeWorkEntry,
   liveActivityLabel,
 } from "./workEntry"
@@ -54,6 +55,25 @@ describe("describeWorkEntry", () => {
     expect(entry.icon).toBe("eye")
   })
 
+  it("labels repeated reads with their call count", () => {
+    const reads = [
+      chunk({
+        toolCallId: "read-1",
+        input: { file_path: `${projectPath}/ui/src/AGENTS.md` },
+      }),
+      chunk({
+        toolCallId: "read-2",
+        input: { file_path: `${projectPath}/ui/src/AGENTS.md` },
+      }),
+    ]
+
+    expect(describeReadGroup(reads, projectPath)).toMatchObject({
+      heading: "Read (x2)",
+      preview: "AGENTS.md",
+      status: "completed",
+    })
+  })
+
   it("describes a completed edit from its diff rather than the raw tool title", () => {
     const entry = describeWorkEntry(
       chunk({ title: "edit_file", toolKind: "edit", diffData: diff() }),
@@ -88,7 +108,7 @@ describe("describeWorkEntry", () => {
       newContent: "c\nd\n",
     })
     expect(describeEditGroup(chunks, projectPath)).toMatchObject({
-      heading: "Edited",
+      heading: "Edited (x2)",
       preview: "app.tsx",
       diffStats: { additions: 2, deletions: 1 },
       status: "completed",

--- a/ui/src/features/agents/components/messages/timeline/workEntry.test.ts
+++ b/ui/src/features/agents/components/messages/timeline/workEntry.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest"
 
-import { describeWorkEntry, liveActivityLabel } from "./workEntry"
+import {
+  combinedEditDiff,
+  describeEditGroup,
+  describeWorkEntry,
+  liveActivityLabel,
+} from "./workEntry"
 import type {
   Chunk,
   DiffData,
@@ -62,6 +67,52 @@ describe("describeWorkEntry", () => {
     expect(entry.icon).toBe("square-pen")
     // The diff is rendered as the row body, so there is no text fallback.
     expect(entry.expandedText).toBeNull()
+  })
+
+  it("describes repeated edits from their combined before and after state", () => {
+    const chunks = [
+      chunk({
+        toolCallId: "edit-1",
+        toolKind: "edit",
+        diffData: diff({ originalContent: "a\n", newContent: "b\n" }),
+      }),
+      chunk({
+        toolCallId: "edit-2",
+        toolKind: "edit",
+        diffData: diff({ originalContent: "b\n", newContent: "c\nd\n" }),
+      }),
+    ]
+
+    expect(combinedEditDiff(chunks)).toMatchObject({
+      originalContent: "a\n",
+      newContent: "c\nd\n",
+    })
+    expect(describeEditGroup(chunks, projectPath)).toMatchObject({
+      heading: "Edited",
+      preview: "app.tsx",
+      diffStats: { additions: 2, deletions: 1 },
+      status: "completed",
+    })
+  })
+
+  it("combines edits whose snippets do not include the previous edit", () => {
+    const chunks = [
+      chunk({
+        toolCallId: "edit-1",
+        toolKind: "edit",
+        diffData: diff({ originalContent: "a\n", newContent: "b\n" }),
+      }),
+      chunk({
+        toolCallId: "edit-2",
+        toolKind: "edit",
+        diffData: diff({ originalContent: "x\n", newContent: "y\n" }),
+      }),
+    ]
+
+    expect(combinedEditDiff(chunks)).toMatchObject({
+      originalContent: "a\n\nx\n",
+      newContent: "b\n\ny\n",
+    })
   })
 
   it("distinguishes a created file from an edited one", () => {

--- a/ui/src/features/agents/components/messages/timeline/workEntry.ts
+++ b/ui/src/features/agents/components/messages/timeline/workEntry.ts
@@ -2,6 +2,7 @@ import { formatJsonToolResult } from "./toolResultJson"
 import type {
   AcpToolStatus,
   Chunk,
+  DiffData,
   ToolExecutionChunk,
 } from "@/features/agents/lib/types"
 import {
@@ -135,6 +136,84 @@ export function latestDiff(chunk: ToolExecutionChunk) {
   return chunk.diffs?.length
     ? chunk.diffs[chunk.diffs.length - 1]
     : chunk.diffData
+}
+
+export function combinedEditDiff(
+  chunks: Array<ToolExecutionChunk>
+): DiffData | undefined {
+  const diffs = chunks.flatMap((chunk) => {
+    const diff = latestDiff(chunk)
+    return diff ? [diff] : []
+  })
+  const first = diffs[0]
+  const last = diffs[diffs.length - 1]
+  if (!first || !last) return undefined
+
+  let originalContent = first.originalContent
+  let newContent = first.newContent
+  for (const diff of diffs.slice(1)) {
+    if (diff.originalContent === null) {
+      newContent = diff.newContent
+      continue
+    }
+    const index = newContent.indexOf(diff.originalContent)
+    if (index >= 0) {
+      newContent =
+        newContent.slice(0, index) +
+        diff.newContent +
+        newContent.slice(index + diff.originalContent.length)
+      continue
+    }
+    originalContent = [originalContent, diff.originalContent]
+      .filter((content): content is string => content !== null)
+      .join("\n")
+    newContent = [newContent, diff.newContent].join("\n")
+  }
+
+  return { ...last, originalContent, newContent, isNewFile: first.isNewFile }
+}
+
+export function describeEditGroup(
+  chunks: Array<ToolExecutionChunk>,
+  projectPath?: string
+): WorkEntryView {
+  const latestChunk = chunks[chunks.length - 1]
+  const diff = combinedEditDiff(chunks)
+  if (!latestChunk) {
+    return {
+      icon: "square-pen",
+      heading: "Edited",
+      preview: null,
+      tone: "tool",
+      status: "completed",
+      expandedText: null,
+    }
+  }
+  if (!diff) return describeWorkEntry(latestChunk, projectPath)
+  return {
+    ...describeWorkEntry(
+      { ...latestChunk, diffData: diff, diffs: undefined },
+      projectPath
+    ),
+    heading: chunks.some((chunk) => chunk.status === "error")
+      ? "Failed to edit"
+      : chunks.some(
+            (chunk) =>
+              chunk.status === "pending" || chunk.status === "in_progress"
+          )
+        ? "Editing"
+        : diff.isNewFile
+          ? "Created"
+          : "Edited",
+    status: chunks.some((chunk) => chunk.status === "error")
+      ? "error"
+      : chunks.some((chunk) => chunk.status === "pending")
+        ? "pending"
+        : chunks.some((chunk) => chunk.status === "in_progress")
+          ? "in_progress"
+          : "completed",
+    tone: chunks.some((chunk) => chunk.status === "error") ? "error" : "tool",
+  }
 }
 
 export function describeWorkEntry(

--- a/ui/src/features/agents/components/messages/timeline/workEntry.ts
+++ b/ui/src/features/agents/components/messages/timeline/workEntry.ts
@@ -195,16 +195,48 @@ export function describeEditGroup(
       { ...latestChunk, diffData: diff, diffs: undefined },
       projectPath
     ),
-    heading: chunks.some((chunk) => chunk.status === "error")
-      ? "Failed to edit"
-      : chunks.some(
-            (chunk) =>
-              chunk.status === "pending" || chunk.status === "in_progress"
-          )
-        ? "Editing"
-        : diff.isNewFile
-          ? "Created"
-          : "Edited",
+    heading: `${
+      chunks.some((chunk) => chunk.status === "error")
+        ? "Failed to edit"
+        : chunks.some(
+              (chunk) =>
+                chunk.status === "pending" || chunk.status === "in_progress"
+            )
+          ? "Editing"
+          : diff.isNewFile
+            ? "Created"
+            : "Edited"
+    } (x${chunks.length})`,
+    status: chunks.some((chunk) => chunk.status === "error")
+      ? "error"
+      : chunks.some((chunk) => chunk.status === "pending")
+        ? "pending"
+        : chunks.some((chunk) => chunk.status === "in_progress")
+          ? "in_progress"
+          : "completed",
+    tone: chunks.some((chunk) => chunk.status === "error") ? "error" : "tool",
+  }
+}
+
+export function describeReadGroup(
+  chunks: Array<ToolExecutionChunk>,
+  projectPath?: string
+): WorkEntryView {
+  const latestChunk = chunks[chunks.length - 1]
+  if (!latestChunk) {
+    return {
+      icon: "eye",
+      heading: "Read",
+      preview: null,
+      tone: "tool",
+      status: "completed",
+      expandedText: null,
+    }
+  }
+  const entry = describeWorkEntry(latestChunk, projectPath)
+  return {
+    ...entry,
+    heading: `${entry.heading} (x${chunks.length})`,
     status: chunks.some((chunk) => chunk.status === "error")
       ? "error"
       : chunks.some((chunk) => chunk.status === "pending")


### PR DESCRIPTION
Repeated edit and read tool calls targeting the same file now render as one transcript row with their call count, such as `Edited (x7)` and `Read (x3)`. Expanding an edit row shows a single cumulative diff from the first edit’s original content to the final edit result, without exposing the individual calls.

The grouping preserves action counts and pending/error status. The browser scenario exercises seven edits and three reads of `greet.py`, with edits to `helpers.py` before and `notes.md` after the group.

![Grouped edits and reads](https://01a08bda-a667-7c27-bab2-a5c3ad06d546--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGt3TlRVMU56RXNJbXAwYVNJNklqQXhZVEE0WXpBMUxUazNZV010TnpaaU55MDRPREE1TFdZeVl6UTFZV000WldOaVpTSXNJbk5wWkNJNklqQXhZVEE0WW1SaExXRTJOamN0TjJNeU55MWlZV0l5TFdFMVl6TmhaREEyWkRVME5pSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMeTV2Y0dWdUxYTjNaUzloY25ScFptRmpkSE12Ym1WM0xURTNPRGt3TlRVME5qazNOekF1YW5Cbklpd2lZM1FpT2lKcGJXRm5aUzlxY0dWbklpd2lZMlFpT2lKcGJteHBibVVpZlEubmFxT1ZRS1lrcm1ISUh2U2pPS3BuZnVZZGEtRUtQalA1ek1fMG9TM1lLUVJLYXZvdU9aTlpJcTlvSG00WkZtU1dQOWU3ZWZicEZsTl9NT2NhTy1nQ0E)

Made by [Open SWE](https://openswe.vercel.app/agents/7ef2debc-fbd4-57ec-bc18-ed991ea81e67) · openai:gpt-5.6-sol (high)
