### PR TITLE
fix(slack): interrupt for passive follow-ups

### DIFF
--- a/agent/slack/webhook.py
+++ b/agent/slack/webhook.py
@@ -77,20 +77,18 @@ def _interrupts_active_run(
     text: str,
     bot_user_id: str,
     *,
-    treat_all_messages_as_mentions: bool,
     code_channel: bool,
     message_update: bool,
     explicit_request: bool,
-    untagged_reply: bool,
 ) -> bool:
-    return (
-        explicit_request
-        or untagged_reply
+    return not message_update and (
+        not code_channel
+        or explicit_request
         or _is_explicit_slack_request(
             text,
             bot_user_id,
-            treat_all_messages_as_mentions=treat_all_messages_as_mentions and not code_channel,
-            message_update=message_update,
+            treat_all_messages_as_mentions=False,
+            message_update=False,
         )
     )
 
@@ -841,11 +839,9 @@ async def _process_slack_mention_impl(request: SlackRequest, repo: Repo | None) 
     interrupt_active_run = _interrupts_active_run(
         text,
         bot_user_id,
-        treat_all_messages_as_mentions=treat_all_messages_as_mentions,
         code_channel=code_channel,
         message_update=message_update,
         explicit_request=request.explicit_request,
-        untagged_reply=untagged_reply,
     )
     run_input = _slack_context_input(
         context_messages,

--- a/agent/slack/webhook.py
+++ b/agent/slack/webhook.py
@@ -59,16 +59,9 @@ def _slack_request_heading(untagged_reply: bool, message_update: bool = False) -
     return "## Untagged Message" if untagged_reply else "## Latest Mention Request"
 
 
-def _is_explicit_slack_request(
-    text: str,
-    bot_user_id: str,
-    *,
-    treat_all_messages_as_mentions: bool,
-    message_update: bool,
-) -> bool:
-    return not message_update and bool(
-        treat_all_messages_as_mentions
-        or (bot_user_id and f"<@{bot_user_id}>" in text)
+def _mentions_bot(text: str, bot_user_id: str) -> bool:
+    return bool(
+        (bot_user_id and f"<@{bot_user_id}>" in text)
         or (common.SLACK_BOT_USERNAME and f"@{common.SLACK_BOT_USERNAME}" in text)
     )
 
@@ -81,16 +74,11 @@ def _interrupts_active_run(
     message_update: bool,
     explicit_request: bool,
 ) -> bool:
-    return not message_update and (
-        not code_channel
-        or explicit_request
-        or _is_explicit_slack_request(
-            text,
-            bot_user_id,
-            treat_all_messages_as_mentions=False,
-            message_update=False,
-        )
-    )
+    if message_update:
+        return False
+    if not code_channel:
+        return True
+    return explicit_request or _mentions_bot(text, bot_user_id)
 
 
 async def slack_thread_allows_untagged_reply(

--- a/agent/slack/webhook.py
+++ b/agent/slack/webhook.py
@@ -81,12 +81,17 @@ def _interrupts_active_run(
     code_channel: bool,
     message_update: bool,
     explicit_request: bool,
+    untagged_reply: bool,
 ) -> bool:
-    return explicit_request or _is_explicit_slack_request(
-        text,
-        bot_user_id,
-        treat_all_messages_as_mentions=treat_all_messages_as_mentions and not code_channel,
-        message_update=message_update,
+    return (
+        explicit_request
+        or untagged_reply
+        or _is_explicit_slack_request(
+            text,
+            bot_user_id,
+            treat_all_messages_as_mentions=treat_all_messages_as_mentions and not code_channel,
+            message_update=message_update,
+        )
     )
 
 
@@ -176,9 +181,9 @@ async def _dispatch_or_queue_slack_run(
     run_input: RunInput | list[dict[str, Any]],
     configurable: dict[str, Any],
     *,
-    explicitly_tagged: bool,
+    interrupt_active_run: bool,
 ) -> dict[str, Any]:
-    """Dispatch explicit requests immediately and enqueue other Slack follow-ups."""
+    """Dispatch active requests immediately and enqueue other Slack follow-ups."""
     if isinstance(run_input, list):
         run_input = {"messages": cast(list[Any], run_input)}
     return as_json_object(
@@ -190,7 +195,7 @@ async def _dispatch_or_queue_slack_run(
             input=run_input,
             metadata=common.AGENT_VERSION_METADATA,
             client=client,
-            multitask_strategy="interrupt" if explicitly_tagged else "enqueue",
+            multitask_strategy="interrupt" if interrupt_active_run else "enqueue",
         )
     )
 
@@ -833,13 +838,14 @@ async def _process_slack_mention_impl(request: SlackRequest, repo: Repo | None) 
         common.logger.info("Queued Slack message edit for thread %s", thread_id)
         return
 
-    explicitly_tagged = _interrupts_active_run(
+    interrupt_active_run = _interrupts_active_run(
         text,
         bot_user_id,
         treat_all_messages_as_mentions=treat_all_messages_as_mentions,
         code_channel=code_channel,
         message_update=message_update,
         explicit_request=request.explicit_request,
+        untagged_reply=untagged_reply,
     )
     run_input = _slack_context_input(
         context_messages,
@@ -869,7 +875,7 @@ async def _process_slack_mention_impl(request: SlackRequest, repo: Repo | None) 
             thread_id,
             run_input,
             configurable,
-            explicitly_tagged=explicitly_tagged,
+            interrupt_active_run=interrupt_active_run,
         )
     except Exception:
         # No run means no completion webhook, so nothing else would ever clear

--- a/tests/e2e/tests/slack_debounce.spec.ts
+++ b/tests/e2e/tests/slack_debounce.spec.ts
@@ -7,7 +7,7 @@ import { test, expect, type APIRequestContext } from "@playwright/test";
 type SendResult = {
   thread_ts: string;
   thread_id: string;
-  webhook: { status: string; reason?: string };
+  webhook: { status: string };
 };
 
 async function send(
@@ -78,7 +78,7 @@ test.describe("Slack busy-thread follow-ups", () => {
       channel,
       thread_ts: threadTs,
     });
-    expect(busy.webhook.status, busy.webhook.reason).toBe("accepted");
+    expect(busy.webhook.status).toBe("accepted");
     await expect
       .poll(() => threadStatus(request, threadId), { timeout: 30_000 })
       .toBe("busy");

--- a/tests/e2e/tests/slack_debounce.spec.ts
+++ b/tests/e2e/tests/slack_debounce.spec.ts
@@ -1,16 +1,13 @@
 import { test, expect, type APIRequestContext } from "@playwright/test";
 
-// Feature: while Open SWE is busy, *untagged* follow-ups are debounced —
-// coalesced onto the thread's message queue (for the active run to drain at its
-// next model call) instead of each halting and resuming the run. An explicit
-// @-mention is NOT debounced (it keeps interrupting immediately). Driven through
-// the real webhook + real agent; the LLM is faked and holds a run open so
-// follow-ups land mid-run.
+// Feature: while Open SWE is busy, an untagged two-party follow-up interrupts
+// the active run just like an explicit mention. Driven through the real webhook +
+// real agent; the LLM is faked and holds a run open so the follow-up lands mid-run.
 
 type SendResult = {
   thread_ts: string;
   thread_id: string;
-  webhook: { status: string };
+  webhook: { status: string; reason?: string };
 };
 
 async function send(
@@ -40,17 +37,29 @@ async function threadStatus(
   return thread.status ?? "";
 }
 
-test.describe("Slack busy-thread follow-up queueing", () => {
-  test("untagged follow-ups on a busy thread queue behind the active run", async ({
+async function runStatuses(
+  request: APIRequestContext,
+  threadId: string,
+): Promise<string[]> {
+  const res = await request.get(`/threads/${threadId}/runs`);
+  if (!res.ok()) return [];
+  const runs = (await res.json()) as Array<{ status?: string }>;
+  return runs.flatMap((run) => (run.status ? [run.status] : []));
+}
+
+test.describe("Slack busy-thread follow-ups", () => {
+  test("an untagged two-party follow-up interrupts the active run", async ({
     request,
   }) => {
     await request.post("/control/reset");
+    const channel = `C_INTERRUPT_${Date.now()}`;
 
     // Phase 1: open a two-party thread so Open SWE has participated (a
     // prerequisite for untagged follow-ups to be accepted).
     const opened = await send(request, {
       text: "<@U0BOT> please add a greet() helper and open a PR",
       mention_bot: true,
+      channel,
     });
     const threadId = opened.thread_id;
     const threadTs = opened.thread_ts;
@@ -66,9 +75,10 @@ test.describe("Slack busy-thread follow-up queueing", () => {
     const busy = await send(request, {
       text: "<@U0BOT> now also tweak it E2E_BUSY_HOLD",
       mention_bot: true,
+      channel,
       thread_ts: threadTs,
     });
-    expect(busy.webhook.status).toBe("accepted");
+    expect(busy.webhook.status, busy.webhook.reason).toBe("accepted");
     await expect
       .poll(() => threadStatus(request, threadId), { timeout: 30_000 })
       .toBe("busy");
@@ -76,11 +86,12 @@ test.describe("Slack busy-thread follow-up queueing", () => {
     const followUp = await send(request, {
       text: "also rename it to hello()",
       mention_bot: false,
+      channel,
       thread_ts: threadTs,
     });
     expect(followUp.webhook.status).toBe("accepted");
     await expect
-      .poll(() => threadStatus(request, threadId), { timeout: 30_000 })
-      .toBe("busy");
+      .poll(() => runStatuses(request, threadId), { timeout: 30_000 })
+      .toContain("interrupted");
   });
 });

--- a/tests/slack/test_slack_code_channels.py
+++ b/tests/slack/test_slack_code_channels.py
@@ -170,41 +170,33 @@ def test_untagged_code_channel_message_does_not_interrupt_active_work() -> None:
     assert not slack_service._interrupts_active_run(
         "talking to a teammate",
         "BOT",
-        treat_all_messages_as_mentions=True,
         code_channel=True,
         message_update=False,
         explicit_request=False,
-        untagged_reply=False,
     )
     assert slack_service._interrupts_active_run(
         "<@BOT> stop and do this",
         "BOT",
-        treat_all_messages_as_mentions=True,
         code_channel=True,
         message_update=False,
         explicit_request=False,
-        untagged_reply=False,
     )
     assert slack_service._interrupts_active_run(
         "/run-tests",
         "BOT",
-        treat_all_messages_as_mentions=True,
         code_channel=True,
         message_update=False,
         explicit_request=True,
-        untagged_reply=False,
     )
 
 
-def test_untagged_two_party_follow_up_interrupts_active_work() -> None:
+def test_regular_slack_follow_up_interrupts_active_work() -> None:
     assert slack_service._interrupts_active_run(
         "follow-up in a two-party thread",
         "BOT",
-        treat_all_messages_as_mentions=False,
         code_channel=False,
         message_update=False,
         explicit_request=False,
-        untagged_reply=True,
     )
 
 

--- a/tests/slack/test_slack_code_channels.py
+++ b/tests/slack/test_slack_code_channels.py
@@ -174,6 +174,7 @@ def test_untagged_code_channel_message_does_not_interrupt_active_work() -> None:
         code_channel=True,
         message_update=False,
         explicit_request=False,
+        untagged_reply=False,
     )
     assert slack_service._interrupts_active_run(
         "<@BOT> stop and do this",
@@ -182,6 +183,7 @@ def test_untagged_code_channel_message_does_not_interrupt_active_work() -> None:
         code_channel=True,
         message_update=False,
         explicit_request=False,
+        untagged_reply=False,
     )
     assert slack_service._interrupts_active_run(
         "/run-tests",
@@ -190,6 +192,19 @@ def test_untagged_code_channel_message_does_not_interrupt_active_work() -> None:
         code_channel=True,
         message_update=False,
         explicit_request=True,
+        untagged_reply=False,
+    )
+
+
+def test_untagged_two_party_follow_up_interrupts_active_work() -> None:
+    assert slack_service._interrupts_active_run(
+        "follow-up in a two-party thread",
+        "BOT",
+        treat_all_messages_as_mentions=False,
+        code_channel=False,
+        message_update=False,
+        explicit_request=False,
+        untagged_reply=True,
     )
 
 

--- a/tests/slack/test_slack_webhook_errors.py
+++ b/tests/slack/test_slack_webhook_errors.py
@@ -288,12 +288,13 @@ async def test_dispatch_or_queue_interrupts_for_explicit_mention(
     assert await_args.kwargs["multitask_strategy"] == "interrupt"
 
 
-def test_message_update_is_non_explicit_even_when_original_mention_remains() -> None:
-    assert not slack_webhook._is_explicit_slack_request(
+def test_message_update_does_not_interrupt_even_when_the_mention_remains() -> None:
+    assert not slack_webhook._interrupts_active_run(
         "<@BOT> corrected request",
         "BOT",
-        treat_all_messages_as_mentions=False,
+        code_channel=False,
         message_update=True,
+        explicit_request=False,
     )
 
 

--- a/tests/slack/test_slack_webhook_errors.py
+++ b/tests/slack/test_slack_webhook_errors.py
@@ -244,7 +244,7 @@ async def test_untagged_reply_blocked_when_only_third_party_bot_present(
 
 
 @pytest.mark.asyncio
-async def test_dispatch_or_queue_enqueues_untagged_follow_up(
+async def test_dispatch_or_queue_enqueues_non_interrupting_follow_up(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     dispatch = AsyncMock(return_value={"run_id": "run-1"})
@@ -256,7 +256,7 @@ async def test_dispatch_or_queue_enqueues_untagged_follow_up(
         "t1",
         blocks,
         {},
-        explicitly_tagged=False,
+        interrupt_active_run=False,
     )
 
     assert run == {"run_id": "run-1"}
@@ -279,7 +279,7 @@ async def test_dispatch_or_queue_interrupts_for_explicit_mention(
         "t1",
         [{"type": "text", "text": "<@BOT> stop and do this instead"}],
         {},
-        explicitly_tagged=True,
+        interrupt_active_run=True,
     )
 
     assert run == {"run_id": "run-1"}
@@ -524,7 +524,7 @@ async def test_message_update_dispatches_a_new_message_without_old_context(
     assert "new corrected text" in serialized
     assert "old text" not in serialized
     assert "## Conversation Context" not in serialized
-    assert await_args.kwargs["explicitly_tagged"] is False
+    assert await_args.kwargs["interrupt_active_run"] is False
     thinking.assert_not_awaited()
     store_args = store_mapping.await_args
     assert store_args is not None


### PR DESCRIPTION
Untagged messages accepted from active two-party Slack threads now use the same interrupt strategy as explicit mentions, so the agent consumes them immediately instead of enqueueing them behind active work.

Code-channel chatter and message edits retain their existing non-interrupting behavior. The busy-thread E2E now verifies that an accepted untagged follow-up interrupts the active run.

Made by [Open SWE](https://openswe.vercel.app/agents/7444b0a4-7906-5fd4-ac9e-795162497eaf) · openai:gpt-5.6-sol (high)