### PR TITLE
fix(ui): keep sidebar resize responsive

### DIFF
--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -18,6 +18,37 @@ import {
 // Drives the REAL built ui/ app (served same-origin from the harness) for the
 // Slack → web handoff. Only the LLM/GitHub/Slack/token boundaries are faked.
 test.describe("Slack → web handoff (real dashboard UI)", () => {
+  test("resizes the sidebar from its visible edge", async ({
+    page,
+  }, testInfo) => {
+    await loginAs(page, SAME_USER);
+    await page.goto("/agents");
+    await dismissOnboardingIfShown(page);
+
+    const sidebar = page.locator("[data-sidebar-frame]");
+    await expect(sidebar).toBeVisible();
+    const box = await sidebar.boundingBox();
+    expect(box).not.toBeNull();
+    const initialWidth = box!.width;
+    const edge = box!.x + box!.width;
+    await page.mouse.move(edge + 2, box!.y + 100);
+    await page.mouse.down();
+    await page.mouse.move(edge + 82, box!.y + 100, { steps: 5 });
+    await page.mouse.up();
+
+    await expect
+      .poll(() =>
+        sidebar.evaluate((element) => element.getBoundingClientRect().width),
+      )
+      .toBeGreaterThan(initialWidth + 70);
+    const screenshotPath = testInfo.outputPath("resized-sidebar.png");
+    await page.screenshot({ path: screenshotPath, fullPage: true });
+    await testInfo.attach("resized-sidebar", {
+      path: screenshotPath,
+      contentType: "image/png",
+    });
+  });
+
   test("the SAME user continues the conversation in the web app", async ({
     page,
   }) => {

--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -18,12 +18,11 @@ import {
 // Drives the REAL built ui/ app (served same-origin from the harness) for the
 // Slack → web handoff. Only the LLM/GitHub/Slack/token boundaries are faked.
 test.describe("Slack → web handoff (real dashboard UI)", () => {
-  test("resizes the sidebar from its visible edge", async ({
+  test("keeps sidebar resizing responsive with an open chat", async ({
     page,
   }, testInfo) => {
     await loginAs(page, SAME_USER);
-    await page.goto("/agents");
-    await dismissOnboardingIfShown(page);
+    await openThreadViaSlackLink(page);
 
     const sidebar = page.locator("[data-sidebar-frame]");
     await expect(sidebar).toBeVisible();
@@ -31,16 +30,40 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
     expect(box).not.toBeNull();
     const initialWidth = box!.width;
     const edge = box!.x + box!.width;
-    await page.mouse.move(edge + 2, box!.y + 100);
+    let writes = 0;
+    await page.evaluate(() => {
+      const original = Storage.prototype.setItem;
+      Storage.prototype.setItem = function (...args) {
+        if (args[0] === "open-swe.sidebar.width") {
+          document.documentElement.dataset.sidebarWidthWrites = String(
+            Number(document.documentElement.dataset.sidebarWidthWrites ?? 0) +
+              1,
+          );
+        }
+        return original.apply(this, args);
+      };
+    });
+    await page.mouse.move(edge, box!.y + 100);
     await page.mouse.down();
-    await page.mouse.move(edge + 82, box!.y + 100, { steps: 5 });
-    await page.mouse.up();
-
+    await page.mouse.move(edge + 80, box!.y + 100, { steps: 20 });
     await expect
       .poll(() =>
         sidebar.evaluate((element) => element.getBoundingClientRect().width),
       )
       .toBeGreaterThan(initialWidth + 70);
+    writes = await page.evaluate(() =>
+      Number(document.documentElement.dataset.sidebarWidthWrites ?? 0),
+    );
+    expect(writes).toBe(0);
+    await page.mouse.up();
+    await expect
+      .poll(() =>
+        page.evaluate(() =>
+          Number(document.documentElement.dataset.sidebarWidthWrites ?? 0),
+        ),
+      )
+      .toBe(1);
+
     const screenshotPath = testInfo.outputPath("resized-sidebar.png");
     await page.screenshot({ path: screenshotPath, fullPage: true });
     await testInfo.attach("resized-sidebar", {

--- a/ui/src/components/sidebar-layout.tsx
+++ b/ui/src/components/sidebar-layout.tsx
@@ -146,9 +146,7 @@ export function SidebarFrame({
       )}
     >
       {children}
-      <div className="max-md:hidden">
-        <ResizeHandle width={width} onResize={setWidth} />
-      </div>
+      <ResizeHandle width={width} onResize={setWidth} />
     </aside>
   )
 }
@@ -202,7 +200,7 @@ function ResizeHandle({
       onPointerUp={onPointerUp}
       onPointerCancel={onPointerUp}
       className={cn(
-        "absolute top-0 right-0 z-20 h-full w-1 cursor-col-resize touch-none select-none",
+        "absolute top-0 -right-1 z-20 h-full w-2 cursor-col-resize touch-none select-none max-md:hidden",
         "after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-transparent after:transition-colors",
         "hover:after:bg-border",
         dragging && "after:bg-border"

--- a/ui/src/components/sidebar-layout.tsx
+++ b/ui/src/components/sidebar-layout.tsx
@@ -17,12 +17,16 @@ export const SIDEBAR_DEFAULT_WIDTH = 260
 export const SIDEBAR_MIN_WIDTH = 200
 export const SIDEBAR_MAX_WIDTH = 420
 
+function clampWidth(width: number): number {
+  return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, width))
+}
+
 function readStoredWidth(): number {
   if (typeof window === "undefined") return SIDEBAR_DEFAULT_WIDTH
   const raw = window.localStorage.getItem(STORAGE_WIDTH)
   const parsed = raw ? Number(raw) : NaN
   if (!Number.isFinite(parsed)) return SIDEBAR_DEFAULT_WIDTH
-  return Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, parsed))
+  return clampWidth(parsed)
 }
 
 function readStoredCollapsed(): boolean {
@@ -40,10 +44,7 @@ export function useSidebarLayout() {
   )
 
   const setWidth = useCallback((next: number) => {
-    const clamped = Math.min(
-      SIDEBAR_MAX_WIDTH,
-      Math.max(SIDEBAR_MIN_WIDTH, next)
-    )
+    const clamped = clampWidth(next)
     setWidthState(clamped)
     window.localStorage.setItem(STORAGE_WIDTH, String(clamped))
   }, [])
@@ -158,25 +159,36 @@ function ResizeHandle({
   width: number
   onResize: (next: number) => void
 }) {
+  const frameRef = useRef<HTMLElement | null>(null)
   const startRef = useRef<{ x: number; width: number } | null>(null)
   const [dragging, setDragging] = useState(false)
 
+  const finishResize = useCallback(() => {
+    if (!startRef.current) return
+    startRef.current = null
+    setDragging(false)
+    const next = frameRef.current?.getBoundingClientRect().width
+    if (next !== undefined) onResize(next)
+  }, [onResize])
+
   const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     e.preventDefault()
+    frameRef.current = e.currentTarget.closest("aside")
     startRef.current = { x: e.clientX, width }
     setDragging(true)
     e.currentTarget.setPointerCapture(e.pointerId)
   }
 
   const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
-    if (!startRef.current) return
-    const next = startRef.current.width + (e.clientX - startRef.current.x)
-    onResize(next)
+    if (!startRef.current || !frameRef.current) return
+    const next = clampWidth(
+      startRef.current.width + (e.clientX - startRef.current.x)
+    )
+    frameRef.current.style.width = `${next}px`
   }
 
   const onPointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
-    startRef.current = null
-    setDragging(false)
+    finishResize()
     if (e.currentTarget.hasPointerCapture(e.pointerId)) {
       e.currentTarget.releasePointerCapture(e.pointerId)
     }
@@ -186,10 +198,12 @@ function ResizeHandle({
     if (!dragging) return
     const prev = document.body.style.cursor
     document.body.style.cursor = "col-resize"
+    window.addEventListener("blur", finishResize)
     return () => {
+      window.removeEventListener("blur", finishResize)
       document.body.style.cursor = prev
     }
-  }, [dragging])
+  }, [dragging, finishResize])
 
   return (
     <div
@@ -198,7 +212,8 @@ function ResizeHandle({
       onPointerDown={onPointerDown}
       onPointerMove={onPointerMove}
       onPointerUp={onPointerUp}
-      onPointerCancel={onPointerUp}
+      onPointerCancel={finishResize}
+      onLostPointerCapture={finishResize}
       className={cn(
         "absolute top-0 -right-1 z-20 h-full w-2 cursor-col-resize touch-none select-none max-md:hidden",
         "after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-transparent after:transition-colors",


### PR DESCRIPTION
Dragging the sidebar rerendered and persisted the entire agents shell for every pointer movement, which made open chats unresponsive and could leave Chrome's pointer capture stuck.

Resize the sidebar DOM directly while dragging, commit the width once when the drag ends, and clean up lost capture or window blur. Keep the wider edge hit target and cover the open-chat flow in Playwright.

Screenshot: [resized sidebar with an open chat](https://01a08c31-6c6c-7c48-bb04-434b31619456--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGt3TmpBME56Y3NJbXAwYVNJNklqQXhZVEE0WXpVd0xUY3lZbVV0TjJFM01TMDVOREk0TFRBd1pESTRZalF3T1dGall5SXNJbk5wWkNJNklqQXhZVEE0WXpNeExUWmpObU10TjJNME9DMWlZakEwTFRRek5HSXpNVFl4T1RRMU5pSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMM1JsYzNSekwyVXlaUzkwWlhOMExYSmxjM1ZzZEhNdlpHRnphR0p2WVhKa0xWTnNZV05yTGVLR2tpMTNaV0l0YUdGdVpDMWlOVFkxWXkxbGMzQnZibk5wZG1VdGQybDBhQzFoYmkxdmNHVnVMV05vWVhRdFkyaHliMjFwZFcwdmNtVnphWHBsWkMxemFXUmxZbUZ5TG5CdVp5SXNJbU4wSWpvaWFXMWhaMlV2Y0c1bklpd2lZMlFpT2lKcGJteHBibVVpZlEuNUpJaElyajJXdHZXMHFtUXVuY19ZSEJ1U3ppQlVmT29qanZkTUZsY1plVG5oUFhweFUzNk9iYktYR2t2bXpkU1ExdDBkSmMxeDFZNVZPMDNjOUtKRFE)

Made by [Open SWE](https://openswe.vercel.app/agents/852bc506-2852-5460-a647-2ae86da25c8b) · openai:gpt-5.6-sol (high)
