### PR TITLE
feat: hide compaction summaries and add conversation offloading

### DIFF
--- a/agent/dashboard/threads/runs.py
+++ b/agent/dashboard/threads/runs.py
@@ -442,7 +442,12 @@ async def _enrich_run_start_command(
         client_configurable.get("agent_effort"),
     )
     plan_mode_requested = client_configurable.get("plan_mode") is True
+    offload_requested = client_configurable.get("offload_conversation") is True
     content = _command_message_content(params)
+    if isinstance(content, str) and content.strip() == "/offload":
+        offload_requested = True
+    if offload_requested and creating:
+        raise HTTPException(400, "offloading requires an existing conversation")
     command_images = _dashboard_images_from_content(content)
     invocation_id = new_invocation_id()
     overrides = with_invocation_id(None, invocation_id)
@@ -617,6 +622,10 @@ async def _enrich_run_start_command(
     if not isinstance(run_metadata, dict):
         run_metadata = {}
     run_metadata = with_invocation_id({**run_metadata, **agent_version_metadata()}, invocation_id)
+
+    if offload_requested:
+        merged_configurable["offload_conversation"] = True
+        params["input"] = {}
 
     params["assistant_id"] = _ASSISTANT_ID
     params.setdefault("stream_mode", list(DASHBOARD_STREAM_MODES))

--- a/agent/middleware/conversation_offloading.py
+++ b/agent/middleware/conversation_offloading.py
@@ -10,6 +10,7 @@ from deepagents.middleware.summarization import (
     compute_summarization_defaults,
 )
 from langchain.agents.middleware.types import (
+    AgentState,
     ExtendedModelResponse,
     ModelRequest,
     ModelResponse,
@@ -93,9 +94,7 @@ class ConversationOffloadingMiddleware(SummarizationMiddleware):
         return response
 
     @hook_config(can_jump_to=["end"])
-    async def abefore_model(
-        self, state: OffloadingState, runtime: Runtime
-    ) -> dict[str, Any] | None:
+    async def abefore_model(self, state: AgentState, runtime: Runtime) -> dict[str, Any] | None:
         if not self.manual:
             return None
 

--- a/agent/middleware/conversation_offloading.py
+++ b/agent/middleware/conversation_offloading.py
@@ -1,0 +1,126 @@
+"""Expose Deep Agents compaction without streaming its internal model output."""
+
+from collections.abc import Awaitable, Callable
+from contextvars import ContextVar
+from typing import Any, NotRequired
+
+from deepagents.middleware.summarization import (
+    SummarizationMiddleware,
+    SummarizationState,
+    compute_summarization_defaults,
+)
+from langchain.agents.middleware.types import (
+    ExtendedModelResponse,
+    ModelRequest,
+    ModelResponse,
+    hook_config,
+)
+from langchain_core.messages import AnyMessage
+from langgraph.config import get_stream_writer
+from langgraph.runtime import Runtime
+
+_manual = ContextVar("manual_offloading", default=False)
+
+
+class OffloadingState(SummarizationState):
+    conversation_offloading: NotRequired[dict[str, Any]]
+
+
+class ConversationOffloadingMiddleware(SummarizationMiddleware):
+    state_schema = OffloadingState
+
+    @property
+    def name(self) -> str:
+        return "SummarizationMiddleware"
+
+    def __init__(self, model: Any, backend: Any, *, manual: bool = False) -> None:
+        summary_model = model.model_copy(
+            update={"tags": [*(model.tags or []), "nostream", "langsmith:hidden"]}
+        )
+        super().__init__(
+            model=summary_model, backend=backend, **compute_summarization_defaults(model)
+        )
+        self.manual = manual
+
+    def _status(self, status: str, **details: Any) -> dict[str, Any]:
+        payload = {
+            "status": status,
+            "trigger": "manual" if _manual.get() else "automatic",
+            **details,
+        }
+        get_stream_writer()({"type": "conversation_offloading", **payload})
+        return payload
+
+    def _should_summarize(self, messages: list[AnyMessage], total_tokens: int) -> bool:
+        return _manual.get() or super()._should_summarize(messages, total_tokens)
+
+    def _determine_cutoff_index(self, messages: list[AnyMessage]) -> int:
+        cutoff = super()._determine_cutoff_index(messages)
+        if not self._filter_summary_messages(messages[:cutoff]):
+            return 0
+        return cutoff
+
+    async def _acreate_summary(self, messages_to_summarize: list[AnyMessage]) -> str:
+        self._status("started")
+        try:
+            return await super()._acreate_summary(messages_to_summarize)
+        except Exception:
+            self._status("failed")
+            raise
+
+    def _build_new_messages_with_path(
+        self, summary: str, file_path: str | None
+    ) -> list[AnyMessage]:
+        messages = super()._build_new_messages_with_path(summary, file_path)
+        self._status("completed", file_path=file_path)
+        return messages
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse | ExtendedModelResponse:
+        response = await super().awrap_model_call(request, handler)
+        if isinstance(response, ExtendedModelResponse) and response.command:
+            update = response.command.update
+            if isinstance(update, dict) and (event := update.get("_summarization_event")):
+                update["conversation_offloading"] = {
+                    "status": "completed",
+                    "trigger": "manual" if _manual.get() else "automatic",
+                    "cutoff_index": event["cutoff_index"],
+                    "file_path": event["file_path"],
+                }
+        return response
+
+    @hook_config(can_jump_to=["end"])
+    async def abefore_model(
+        self, state: OffloadingState, runtime: Runtime
+    ) -> dict[str, Any] | None:
+        if not self.manual:
+            return None
+
+        async def finish(request: ModelRequest) -> ModelResponse:
+            return ModelResponse(result=[])
+
+        token = _manual.set(True)
+        try:
+            response = await self.awrap_model_call(
+                ModelRequest(
+                    model=self.model,
+                    messages=state.get("messages", []),
+                    tools=[],
+                    state=state,
+                    runtime=runtime,
+                ),
+                finish,
+            )
+            update = (
+                response.command.update
+                if isinstance(response, ExtendedModelResponse) and response.command
+                else None
+            )
+            if not isinstance(update, dict):
+                update = {"conversation_offloading": self._status("skipped")}
+            return {**update, "jump_to": "end"}
+        finally:
+            _manual.reset(token)

--- a/agent/run_config.py
+++ b/agent/run_config.py
@@ -99,6 +99,7 @@ class RunConfig(BaseModel):
     run_id: str | None = None
     invocation_id: str | None = None
     prepare_run_id: str | None = None
+    offload_conversation: bool = False
     source: str | None = None
     task: str | None = None
     environment: str | None = None

--- a/agent/server.py
+++ b/agent/server.py
@@ -112,6 +112,7 @@ from agent.middleware import (
     task_on_failure,
     task_retry_on,
 )
+from agent.middleware.conversation_offloading import ConversationOffloadingMiddleware
 from agent.middleware.prepare_run import PrepareRunState
 from agent.middleware.sandbox_circuit_breaker import post_sandbox_unreachable_notification
 from agent.prompt import (
@@ -406,6 +407,7 @@ def _general_purpose_subagent(
     dynamic_tools: DynamicToolMiddleware | None = None,
     *,
     sandbox_file_downloads: bool = False,
+    offloading: ConversationOffloadingMiddleware | None = None,
 ) -> SubAgent:
     subagent: SubAgent = {
         "name": GENERAL_PURPOSE_SUBAGENT["name"],
@@ -421,7 +423,10 @@ def _general_purpose_subagent(
         + GENERAL_PURPOSE_SUBAGENT["system_prompt"],
         "model": model,
         "tools": [tool for tool in tools if not _is_subagent_excluded_tool(tool)],
-        "middleware": _subagent_middleware(dynamic_tools),
+        "middleware": [
+            *_subagent_middleware(dynamic_tools),
+            *([offloading] if offloading else []),
+        ],
     }
     if skills:
         subagent["skills"] = skills
@@ -1197,6 +1202,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                 skills=skill_sources,
                 dynamic_tools=dynamic_tool_middleware,
                 sandbox_file_downloads=sandbox_file_downloads,
+                offloading=ConversationOffloadingMiddleware(subagent_model, agent_backend),
             ),
         ],
         skills=skill_sources,
@@ -1205,6 +1211,9 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         middleware=cast(
             list[AgentMiddleware[Any, Any, Any]],
             [
+                ConversationOffloadingMiddleware(
+                    main_model, agent_backend, manual=cfg.offload_conversation is True
+                ),
                 PrepareAgentRunMiddleware(
                     thread_id=thread_id,
                     config=config,

--- a/tests/middleware/test_conversation_offloading.py
+++ b/tests/middleware/test_conversation_offloading.py
@@ -83,7 +83,7 @@ async def test_automatic_completion_precedes_handler_and_suppresses_tokens(
     middleware._lc_helper.keep = ("messages", 2)
     middleware._lc_helper._trigger_clauses = [{"messages": 4}]
     if not suppress:
-        middleware.model.tags = [tag for tag in middleware.model.tags if tag != "nostream"]
+        middleware.model.tags = [tag for tag in (middleware.model.tags or []) if tag != "nostream"]
     events = []
     original_status = middleware._status
 

--- a/tests/middleware/test_conversation_offloading.py
+++ b/tests/middleware/test_conversation_offloading.py
@@ -1,0 +1,154 @@
+import pytest
+from deepagents.backends import FilesystemBackend
+from deepagents.graph import _apply_custom_middleware
+from deepagents.middleware.summarization import SummarizationMiddleware
+from langchain.agents import create_agent
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
+from langchain_core.language_models.fake_chat_models import FakeListChatModel
+from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.checkpoint.memory import InMemorySaver
+
+from agent.middleware.conversation_offloading import ConversationOffloadingMiddleware
+from agent.middleware.prepare_run import BasePrepareRunMiddleware
+
+
+async def test_manual_offload_preserves_history_and_hides_summary_stream(tmp_path):
+    model = FakeListChatModel(responses=["A private summary of the old conversation."])
+    middleware = ConversationOffloadingMiddleware(
+        model, FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True), manual=True
+    )
+    middleware._lc_helper.keep = ("messages", 2)
+    graph = create_agent(model=model, middleware=[middleware], checkpointer=InMemorySaver())
+    messages = [
+        HumanMessage(content="Remember the deployment decision.", id="human-1"),
+        AIMessage(content="Use the staging environment.", id="ai-1"),
+        HumanMessage(content="What next?", id="human-2"),
+        AIMessage(content="Run the smoke tests.", id="ai-2"),
+    ]
+    config = {"configurable": {"thread_id": "offloading-test"}}
+    chunks = [
+        chunk
+        async for chunk in graph.astream(
+            {"messages": messages}, config, stream_mode=["messages", "custom"]
+        )
+    ]
+    assert not [data for mode, data in chunks if mode == "messages"]
+    statuses = [data for mode, data in chunks if mode == "custom"]
+    assert [event["status"] for event in statuses] == ["started", "completed"]
+    assert statuses[-1]["trigger"] == "manual"
+    state = await graph.aget_state(config)
+    assert state.values["messages"] == messages
+    event = state.values["_summarization_event"]
+    assert event["cutoff_index"] == 2
+    assert "private summary" in event["summary_message"].content
+    assert "deployment decision" in (tmp_path / event["file_path"].lstrip("/")).read_text()
+    assert state.values["conversation_offloading"]["status"] == "completed"
+
+    chunks = [chunk async for chunk in graph.astream({}, config, stream_mode="custom")]
+    assert chunks[-1]["status"] == "skipped"
+    assert (await graph.aget_state(config)).values["_summarization_event"] == event
+
+    normal = ConversationOffloadingMiddleware(
+        model, FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+    )
+    graph = create_agent(model=model, middleware=[normal], checkpointer=graph.checkpointer)
+    chunks = [
+        chunk
+        async for chunk in graph.astream(
+            {"messages": [HumanMessage(content="Continue.")]},
+            config,
+            stream_mode=["messages", "custom"],
+        )
+    ]
+    assert any(mode == "messages" for mode, _ in chunks)
+    assert not any(mode == "custom" for mode, _ in chunks)
+
+
+def test_name_replaces_default_summarization(tmp_path):
+    model = FakeListChatModel(responses=["summary"])
+    backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+    default = SummarizationMiddleware(model=model, backend=backend)
+    replacement = ConversationOffloadingMiddleware(model, backend)
+    assert _apply_custom_middleware([default], [replacement]) == [replacement]
+
+
+@pytest.mark.parametrize("suppress", [True, False])
+async def test_automatic_completion_precedes_handler_and_suppresses_tokens(
+    tmp_path, monkeypatch, suppress
+):
+    model = FakeListChatModel(responses=["PRIVATE SUMMARY"])
+    middleware = ConversationOffloadingMiddleware(
+        model, FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+    )
+    middleware._lc_helper.keep = ("messages", 2)
+    middleware._lc_helper._trigger_clauses = [{"messages": 4}]
+    if not suppress:
+        middleware.model.tags = [tag for tag in middleware.model.tags if tag != "nostream"]
+    events = []
+    original_status = middleware._status
+
+    def status(value, **details):
+        events.append(value)
+        return original_status(value, **details)
+
+    monkeypatch.setattr(middleware, "_status", status)
+
+    async def handler(request: ModelRequest) -> ModelResponse:
+        assert events == ["started", "completed"]
+        assert list(tmp_path.rglob("*.md"))
+        return ModelResponse(result=[AIMessage(content="NORMAL ANSWER")])
+
+    from langchain.agents.middleware import wrap_model_call
+
+    @wrap_model_call
+    async def answer(request, next_handler):
+        return await handler(request)
+
+    graph = create_agent(model=model, middleware=[middleware, answer], checkpointer=InMemorySaver())
+    config = {"configurable": {"thread_id": "automatic"}}
+    chunks = [
+        chunk
+        async for chunk in graph.astream(
+            {
+                "messages": [
+                    HumanMessage(content="old"),
+                    AIMessage(content="old reply"),
+                    HumanMessage(content="recent"),
+                    AIMessage(content="recent reply"),
+                ]
+            },
+            config,
+            stream_mode=["messages", "custom"],
+        )
+    ]
+    streamed = "".join(str(data[0].content) for mode, data in chunks if mode == "messages")
+    assert ("PRIVATE SUMMARY" in streamed) is not suppress
+    assert events == ["started", "completed"]
+    assert (await graph.aget_state(config)).values["conversation_offloading"][
+        "status"
+    ] == "completed"
+
+
+async def test_manual_before_model_runs_after_prepare(tmp_path, monkeypatch):
+    prepared = []
+
+    class Prepare(BasePrepareRunMiddleware):
+        async def _prepare(self, state, runtime):
+            prepared.append(True)
+            return {"work_dir": str(tmp_path)}
+
+    model = FakeListChatModel(responses=["summary"])
+    middleware = ConversationOffloadingMiddleware(
+        model, FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True), manual=True
+    )
+    original_status = middleware._status
+
+    def status(value, **details):
+        assert prepared == [True]
+        return original_status(value, **details)
+
+    monkeypatch.setattr(middleware, "_status", status)
+    graph = create_agent(model=model, middleware=[middleware, Prepare()])
+    state = await graph.ainvoke({"messages": [HumanMessage(content="hello")]})
+    assert state["run_prepared"] is True
+    assert state["conversation_offloading"]["status"] == "skipped"

--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -338,6 +338,7 @@ export function AgentThreadView({
               streamIsLoading={stream.isLoading}
               scrollControlRef={scrollControlRef}
               isThinking={isThinking}
+              isOffloading={stream.isOffloading}
               settingUpSandbox={settingUpSandbox}
               pollWorkflowApprovalsWhileActive={isStreaming}
               contentWidthClass="max-w-3xl"
@@ -373,6 +374,7 @@ export function AgentThreadView({
                     : "Only workspace admins can send messages in this thread"
                 }
                 autoFocus={autoFocusComposer}
+                canOffload={!isStreaming}
                 compact
                 disabled={!canPost}
                 busy={isStreaming}

--- a/ui/src/features/agents/components/composer/ChatComposer.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.tsx
@@ -507,7 +507,13 @@ export const ChatComposer = memo(function ChatComposer({
       if (!trigger) return
 
       if (item.type === "slash-command" && item.command === "offload") {
-        applyPrompt("/offload ", 9)
+        const next = replaceTextRange(
+          value,
+          trigger.rangeStart,
+          trigger.rangeEnd,
+          "/offload "
+        )
+        applyPrompt(next.text, next.cursor)
         return
       }
 

--- a/ui/src/features/agents/components/composer/ChatComposer.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.tsx
@@ -75,6 +75,11 @@ interface SlashCommandSpec {
 
 const SLASH_COMMANDS: Array<SlashCommandSpec> = [
   {
+    command: "offload",
+    label: "/offload",
+    description: "Offload conversation context",
+  },
+  {
     command: "plan",
     label: "/plan",
     description: "Research read-only and propose a plan first",
@@ -97,6 +102,7 @@ export interface ChatComposerProps {
   compact?: boolean
   disabled?: boolean
   busy?: boolean
+  canOffload?: boolean
   /** Enables the stop button for the thread's live run. */
   activeRun?: ActiveRun
   onStop?: () => void | Promise<void>
@@ -167,7 +173,8 @@ export function buildCommandItems(
   trigger: ComposerTrigger,
   mentionPaths: Array<string>,
   skills: Array<Skill>,
-  includeModelCommand = true
+  includeModelCommand = true,
+  includeOffloadCommand = false
 ): Array<ComposerCommandItem> {
   const query = trigger.query.toLowerCase()
 
@@ -189,7 +196,8 @@ export function buildCommandItems(
         (spec) =>
           spec.command.startsWith(query) &&
           !skillNames.has(spec.command) &&
-          (includeModelCommand || spec.command !== "model")
+          (includeModelCommand || spec.command !== "model") &&
+          (includeOffloadCommand || spec.command !== "offload")
       ).map((spec) => ({
         id: `slash:${spec.command}`,
         type: "slash-command" as const,
@@ -225,6 +233,7 @@ export const ChatComposer = memo(function ChatComposer({
   compact = false,
   disabled = false,
   busy = false,
+  canOffload = false,
   activeRun,
   onStop,
   onSubmit,
@@ -351,9 +360,15 @@ export const ChatComposer = memo(function ChatComposer({
   const commandItems = useMemo(
     () =>
       trigger
-        ? buildCommandItems(trigger, mentionPaths, skills, models.length > 0)
+        ? buildCommandItems(
+            trigger,
+            mentionPaths,
+            skills,
+            models.length > 0,
+            canOffload
+          )
         : [],
-    [mentionPaths, models.length, skills, trigger]
+    [mentionPaths, models.length, skills, trigger, canOffload]
   )
   const menuOpen =
     trigger !== null &&
@@ -462,6 +477,15 @@ export const ChatComposer = memo(function ChatComposer({
     const trimmed = (snapshot?.value ?? value).trim()
     if (trimmed.length === 0 && pendingImages.length === 0) return
 
+    if (trimmed === "/offload" && (!canOffload || pendingImages.length)) {
+      setDictationError(
+        pendingImages.length
+          ? "Offloading does not accept attachments."
+          : "Offloading requires an idle, existing conversation."
+      )
+      return
+    }
+
     const images = pendingImages
     submittingRef.current = true
     setIsSubmitting(true)
@@ -476,11 +500,16 @@ export const ChatComposer = memo(function ChatComposer({
       submittingRef.current = false
       setIsSubmitting(false)
     }
-  }, [applyPrompt, disabled, onSubmit, pendingImages, value])
+  }, [applyPrompt, disabled, onSubmit, pendingImages, value, canOffload])
 
   const selectCommandItem = useCallback(
     (item: ComposerCommandItem) => {
       if (!trigger) return
+
+      if (item.type === "slash-command" && item.command === "offload") {
+        applyPrompt("/offload ", 9)
+        return
+      }
 
       if (item.type === "path" || item.type === "skill") {
         const next = replaceTextRange(

--- a/ui/src/features/agents/components/composer/composerTrigger.ts
+++ b/ui/src/features/agents/components/composer/composerTrigger.ts
@@ -9,7 +9,7 @@
 export type ComposerTriggerKind = "path" | "slash-command" | "skill-command"
 
 /** Slash commands open-swe understands. `model` opens the picker rather than editing the prompt. */
-export type ComposerSlashCommand = "plan" | "default" | "model"
+export type ComposerSlashCommand = "plan" | "default" | "model" | "offload"
 
 export interface ComposerTrigger {
   kind: ComposerTriggerKind

--- a/ui/src/features/agents/components/messages/Messages.tsx
+++ b/ui/src/features/agents/components/messages/Messages.tsx
@@ -68,6 +68,7 @@ export const Messages = memo(function MessagesComponent({
   streamIsLoading,
   isThinking,
   settingUpSandbox,
+  isOffloading = false,
   project,
   contentWidthClass = "max-w-[42rem]",
   contentPaddingClass = "px-6",
@@ -147,7 +148,7 @@ export const Messages = memo(function MessagesComponent({
                 <AgentTurn
                   key={message.id}
                   message={message}
-                  isStreaming={messageIsStreaming}
+                  isStreaming={messageIsStreaming && !isOffloading}
                   isMarkdownLive={messageIsMarkdownLive}
                   projectPath={projectPath}
                   activityLabel={messageIsStreaming ? activityLabel : undefined}
@@ -171,15 +172,18 @@ export const Messages = memo(function MessagesComponent({
             {footer}
             <ThinkingSpinner
               isActive={
-                !!(isThinking || streamIsLoading || isStreaming) &&
-                !(
-                  isStreaming &&
-                  lastAgentIndex >= 0 &&
-                  lastAgentIndex === visibleMessages.length - 1
-                )
+                isOffloading ||
+                (!!(isThinking || streamIsLoading || isStreaming) &&
+                  !(
+                    isStreaming &&
+                    lastAgentIndex >= 0 &&
+                    lastAgentIndex === visibleMessages.length - 1
+                  ))
               }
-              settingUpSandbox={settingUpSandbox}
-              label={activityLabel}
+              settingUpSandbox={settingUpSandbox && !isOffloading}
+              label={
+                isOffloading ? "Offloading conversation..." : activityLabel
+              }
             />
           </div>
         </div>

--- a/ui/src/features/agents/components/messages/types.ts
+++ b/ui/src/features/agents/components/messages/types.ts
@@ -33,6 +33,7 @@ export interface MessagesProps extends ApprovalCallbacks {
   /** When set, drives the thinking spinner (stream + pending). Falls back to streamIsLoading/isStreaming. */
   isThinking?: boolean
   settingUpSandbox?: boolean
+  isOffloading?: boolean
   project?: Project | null
   contentWidthClass?: string
   /** Horizontal padding on centered content (scroll track stays edge-to-edge). */

--- a/ui/src/features/agents/lib/provider/useSubmitAgentMessage.test.tsx
+++ b/ui/src/features/agents/lib/provider/useSubmitAgentMessage.test.tsx
@@ -110,6 +110,30 @@ beforeEach(() => {
 })
 
 describe("useSubmitAgentMessage", () => {
+  it("offloads without adding a user message or queuing a prompt", async () => {
+    const { client, result } = setup()
+    await result.current.mutateAsync({ content: "/offload", images: [] })
+    expect(stream.submit).toHaveBeenCalledWith(
+      {},
+      {
+        config: { configurable: { offload_conversation: true } },
+      }
+    )
+    expect(queueMessage).not.toHaveBeenCalled()
+    expect(pendingMessages(client)).toBeUndefined()
+    expect(queuedMessages(client)).toBeUndefined()
+  })
+
+  it("rejects offloading during a live run instead of queuing it", async () => {
+    stream.isLoading = true
+    const { result } = setup()
+    await expect(
+      result.current.mutateAsync({ content: "/offload" })
+    ).rejects.toThrow("Wait for the current run")
+    expect(stream.submit).not.toHaveBeenCalled()
+    expect(queueMessage).not.toHaveBeenCalled()
+  })
+
   it("shows an optimistic user message before the idle probe resolves", async () => {
     let rejectProbe: (error: Error) => void = () => {}
     queueMessage.mockImplementationOnce(

--- a/ui/src/features/agents/lib/provider/useSubmitAgentMessage.ts
+++ b/ui/src/features/agents/lib/provider/useSubmitAgentMessage.ts
@@ -69,6 +69,23 @@ export function useSubmitAgentMessage(threadId: string) {
 
   return useMutation({
     mutationFn: async (vars: SendAgentMessageVariables) => {
+      if (vars.content.trim() === "/offload") {
+        if (stream.isLoading) {
+          throw new Error(
+            "Wait for the current run to finish before offloading."
+          )
+        }
+        if (vars.images?.length) {
+          throw new Error("Offloading does not accept attachments.")
+        }
+        void stream
+          .submit(
+            {},
+            { config: { configurable: { offload_conversation: true } } }
+          )
+          .catch(() => setAgentThreadStatus(queryClient, threadId, "error"))
+        return
+      }
       const createdAt = Date.now()
       const id = vars.client_message_id ?? crypto.randomUUID()
       const queuedMessage = {

--- a/ui/src/features/agents/lib/stream/AgentStreamProvider.test.tsx
+++ b/ui/src/features/agents/lib/stream/AgentStreamProvider.test.tsx
@@ -17,9 +17,17 @@ interface StreamOptions {
 
 const mocks = vi.hoisted(() => ({
   streams: [] as Array<StreamOptions>,
+  onEvent: (_event: unknown) => {},
 }))
 
 vi.mock("@langchain/react", () => ({
+  useChannelEffect: (
+    _stream: unknown,
+    _channels: unknown,
+    options: { onEvent: (event: unknown) => void }
+  ) => {
+    mocks.onEvent = options.onEvent
+  },
   useStream: (options: StreamOptions) => {
     mocks.streams.push(options)
     return { threadId: options.threadId, isLoading: false }
@@ -35,6 +43,12 @@ vi.mock("@/lib/langgraph-client", () => ({
 function Probe() {
   const stream = useAgentStream()
   return <output>{stream.threadId ?? "new"}</output>
+}
+
+function OffloadingProbe() {
+  return (
+    <output>{useAgentStream().isOffloading ? "offloading" : "idle"}</output>
+  )
 }
 
 function wrapper(children: ReactNode) {
@@ -58,6 +72,43 @@ afterEach(() => {
 })
 
 describe("AgentStreamProvider", () => {
+  it("tracks only root offloading events and clears on completion", () => {
+    const view = render(
+      wrapper(
+        <AgentStreamProvider threadId="one">
+          <OffloadingProbe />
+        </AgentStreamProvider>
+      )
+    )
+    const emit = (status: string, namespace: string[] = []) =>
+      act(() =>
+        mocks.onEvent({
+          method: "custom",
+          params: {
+            namespace,
+            data: {
+              payload: {
+                type: "conversation_offloading",
+                status,
+                trigger: "manual",
+              },
+            },
+          },
+        })
+      )
+    emit("started", ["subagent:one"])
+    expect(view.container.textContent).toBe("idle")
+    for (const status of ["completed", "skipped", "failed"]) {
+      emit("started")
+      expect(view.container.textContent).toBe("offloading")
+      emit(status)
+      expect(view.container.textContent).toBe("idle")
+    }
+    emit("started")
+    act(() => mocks.streams.at(-1)?.onCompleted())
+    expect(view.container.textContent).toBe("idle")
+  })
+
   it("serves the stream bound to the requested thread", () => {
     const view = render(
       wrapper(

--- a/ui/src/features/agents/lib/stream/AgentStreamProvider.tsx
+++ b/ui/src/features/agents/lib/stream/AgentStreamProvider.tsx
@@ -4,8 +4,9 @@ import {
   useEffect,
   useLayoutEffect,
   useMemo,
+  useState,
 } from "react"
-import { useStream } from "@langchain/react"
+import { useChannelEffect, useStream } from "@langchain/react"
 import { useQueryClient } from "@tanstack/react-query"
 
 import { agentsApi } from "@/features/agents/lib/api"
@@ -56,6 +57,7 @@ function PooledStream({ entry }: { entry: StreamPoolEntry }) {
     [cloud]
   )
   const pool = useStreamPool.getState
+  const [isOffloading, setIsOffloading] = useState(false)
 
   const stream = useStream({
     client,
@@ -72,10 +74,12 @@ function PooledStream({ entry }: { entry: StreamPoolEntry }) {
     },
     onThreadId: (threadId) => pool().rekey(entry.id, threadId),
     onCreated: () => {
+      setIsOffloading(false)
       pool().runAccepted(entry.id)
       if (cloud) invalidateAgentThreadLists(queryClient)
     },
     onCompleted: () => {
+      setIsOffloading(false)
       if (!cloud) return
       const threadId = pool().entries.find((e) => e.id === entry.id)?.threadId
       if (threadId) {
@@ -87,8 +91,22 @@ function PooledStream({ entry }: { entry: StreamPoolEntry }) {
     },
   })
 
+  useChannelEffect(stream, ["custom"], {
+    onEvent: (event) => {
+      if (event.method !== "custom" || event.params.namespace.length) return
+      const payload = event.params.data.payload
+      if (payload?.type === "conversation_offloading") {
+        setIsOffloading(payload.status === "started")
+      }
+    },
+    onError: () => setIsOffloading(false),
+  })
+
   const publish = useStreamPool((state) => state.publish)
-  useLayoutEffect(() => publish(entry.id, stream), [entry.id, publish, stream])
+  useLayoutEffect(
+    () => publish(entry.id, { ...stream, isOffloading }),
+    [entry.id, publish, stream, isOffloading]
+  )
 
   return null
 }

--- a/ui/src/features/agents/lib/stream/streamPool.ts
+++ b/ui/src/features/agents/lib/stream/streamPool.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand"
 import type { UseStreamReturn } from "@langchain/react"
 
-export type AgentStream = UseStreamReturn
+export type AgentStream = UseStreamReturn & { isOffloading?: boolean }
 
 export type AgentThreadTransport = "cloud" | "local"
 


### PR DESCRIPTION
Hide internal compaction output at the source (the summary model is tagged `nostream` / `langsmith:hidden`) and surface a single "Offloading conversation..." status line in the chat UI instead. Compaction now runs as a first-class, observable event rather than leaking raw summary tokens into the transcript.

- **ConversationOffloadingMiddleware** (`agent/middleware/conversation_offloading.py`): subclasses Deep Agents' `SummarizationMiddleware` to emit typed `conversation_offloading` stream events (`started` / `completed` / `failed` / `skipped`) while suppressing the summary model's streamed output. Manual offloads run through a `abefore_model` hook that skips the conversational reply entirely.
- **`/offload` command** (idle threads only, no attachments): the composer recognizes it, `useSubmitAgentMessage` submits an empty run with `offload_conversation: true`, and `Messages` swaps the activity spinner for an "Offloading conversation..." label so users see deliberate progress instead of a silent stall.
- **Invocation identity** (`agent/invocation.py`): canonical `invocation_id` with rolling compatibility for the legacy `prepare_run_id` name — writes both keys, rejects conflicting values, and renames the usage/telemetry surfaces (`finalize_agent_invocation_usage`, usage leaderboard `invocations` / `avg_invocation_seconds` with deprecated fallbacks).
- Offload state survives the summary event path (`OffloadingState`) so the final state update carries cutoff index and summary file path without exposing summary content.

```mermaid
flowchart LR
    A["/offload or token threshold"] --> B[ConversationOffloadingMiddleware]
    B --> C["summary model (nostream, hidden)"]
    B --> D["stream events: started → completed/failed"]
    D --> E["UI: 'Offloading conversation...' status"]
```

| Before | After |
| --- | --- |
| Compaction summary tokens stream into the transcript as agent output | Summary output suppressed at the model tag level; only typed status events stream |
| No user-visible signal during context offload | "Offloading conversation..." status line with spinner |
| Compaction only triggered by token threshold | Manual `/offload` slash command for idle conversations |
| `prepare_run_id` scattered through metadata | Canonical `invocation_id` helper with legacy fallback |

Screenshot signed in as Alice; the offloading event is mocked for UI capture:

![Offloading conversation status](https://01a08c3a-d40f-7ea2-bcbd-0ec0d6e2aa81--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGt3TmpFME16TXNJbXAwYVNJNklqQXhZVEE0WXpWbUxUQTNaak10Tnprd055MWlPVE00TFdNMFpXSmtaR0ZrT1RBMU5TSXNJbk5wWkNJNklqQXhZVEE0WXpOaExXUTBNR1l0TjJWaE1pMWlZMkprTFRCbFl6QmtObVV5WVdFNE1TSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjltWm14dllXUnBibWN1Y0c1bklpd2lZM1FpT2lKcGJXRm5aUzl3Ym1jaUxDSmpaQ0k2SW1sdWJHbHVaU0o5LlJwVE9zMWQyTEhXR01XYTJsN1JNRXlEcElzeVNPelNMLWdqYWNJNEE1c1F2VFdCSVdxdi1rYi1IQk9hU3c2Y2J0aXotX0pHMkhITEdxSWxUVGJVY0FR)

Made by [Open SWE](https://openswe.vercel.app/agents/2a709d44-1d7d-576d-b11a-46144c352b77) · openai:gpt-5.6-sol (high)
