### PR TITLE
feat(ui): label the environment selector in the composer

### DIFF
--- a/ui/src/features/agents/components/composer/EnvironmentSelector.tsx
+++ b/ui/src/features/agents/components/composer/EnvironmentSelector.tsx
@@ -51,6 +51,7 @@ export function EnvironmentSelector({
         onClick={() => setOpen((value) => !value)}
         className="flex max-w-[220px] cursor-pointer items-center gap-1 text-muted-foreground transition-opacity hover:opacity-80 disabled:cursor-default disabled:opacity-60"
       >
+        <span className="shrink-0">Environment:</span>
         <StackIcon className="size-3.5 shrink-0" />
         <span className="flex-1 truncate text-left">
           {selected?.name ?? "No environment"}

--- a/ui/src/features/agents/components/composer/EnvironmentSelector.tsx
+++ b/ui/src/features/agents/components/composer/EnvironmentSelector.tsx
@@ -51,7 +51,6 @@ export function EnvironmentSelector({
         onClick={() => setOpen((value) => !value)}
         className="flex max-w-[220px] cursor-pointer items-center gap-1 text-muted-foreground transition-opacity hover:opacity-80 disabled:cursor-default disabled:opacity-60"
       >
-        <span className="shrink-0">Environment:</span>
         <StackIcon className="size-3.5 shrink-0" />
         <span className="flex-1 truncate text-left">
           {selected?.name ?? "No environment"}
@@ -60,6 +59,9 @@ export function EnvironmentSelector({
       </button>
       {open && (
         <div className="absolute top-full left-0 z-50 mt-1 flex max-h-72 w-64 flex-col overflow-y-auto rounded border border-border bg-popover text-xs text-popover-foreground shadow-lg">
+          <div className="px-2 pt-2 pb-1 text-[10px] tracking-wide text-muted-foreground uppercase">
+            Environment
+          </div>
           {environments.map((env) => {
             const isSelected = env.slug === selectedSlug
             return (

--- a/ui/src/features/agents/components/composer/EnvironmentSelector.tsx
+++ b/ui/src/features/agents/components/composer/EnvironmentSelector.tsx
@@ -59,7 +59,7 @@ export function EnvironmentSelector({
       </button>
       {open && (
         <div className="absolute top-full left-0 z-50 mt-1 flex max-h-72 w-64 flex-col overflow-y-auto rounded border border-border bg-popover text-xs text-popover-foreground shadow-lg">
-          <div className="px-2 pt-2 pb-1 text-[10px] tracking-wide text-muted-foreground uppercase">
+          <div className="px-2 pt-2 pb-1 text-muted-foreground">
             Environment
           </div>
           {environments.map((env) => {


### PR DESCRIPTION
The environment dropdown now titles itself "Environment" so users learn what the stack-icon selector does when they open it. Keeps the trigger compact for narrow viewports (right panel expanded, mobile).

![Dropdown open with an "Environment" heading above default / open-swe](https://01a08c7e-d87a-76f0-92ea-516dda848ca6--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGt3TmpVeE1qWXNJbXAwYVNJNklqQXhZVEE0WXprM0xUWXdZbUV0TjJVNE1TMDRZekF3TFdNelptUmtNalkxTURObFlTSXNJbk5wWkNJNklqQXhZVEE0WXpkbExXUTROMkV0TnpabU1DMDVNbVZoTFRVeE5tUmtZVGcwT0dOaE5pSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkRzF3TDJWdWRpMWtjbTl3Wkc5M2JqSXVjRzVuSWl3aVkzUWlPaUpwYldGblpTOXdibWNpTENKalpDSTZJbWx1YkdsdVpTSjkubjdmZVR3MXdXRnlOelUtaW1Nd180VVZjWlE0UzJVamZVZ3QxMXQ1TGdETU1KM21qNU51VjF4ME9UQjdlNUJacTkxU3dBNXAzZTduUVB3QmVoYlZ2RHc)

Made by [Open SWE](https://openswe.vercel.app/agents/23c863fd-c0a4-5ac2-8319-381c52b932ff) · openai:gpt-5.6-sol (high)
