### PR TITLE
fix(slack): show only the last path component of model names in the footer

### DIFF
--- a/agent/slack/client.py
+++ b/agent/slack/client.py
@@ -460,7 +460,8 @@ def _format_token_count(count: int) -> str:
 
 
 def _safe_model_label(model: str) -> str:
-    return re.sub(r"[^A-Za-z0-9._:/+\-]", "-", model)[:48].strip("-")
+    sanitized = re.sub(r"[^A-Za-z0-9._:/+\-]", "-", model)
+    return sanitized.rsplit("/", 1)[-1][:48].strip("-")
 
 
 def format_slack_run_usage(usage: RunUsageSummary | None) -> str:

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -667,6 +667,17 @@ def test_format_slack_web_link_footer_prefers_session_cost() -> None:
     assert footer == "<https://app.example/agents/t1|Open in Web> • model-a • $0.42"
 
 
+def test_format_slack_run_usage_shortens_model_paths() -> None:
+    usage = RunUsageSummary(
+        models=("accounts/fireworks/models/glm-5p3-flash", "openai:gpt-5.6-sol"),
+        total_tokens=12_345,
+    )
+
+    footer = slack_utils.format_slack_run_usage(usage)
+
+    assert footer == "glm-5p3-flash + openai:gpt-5.6-sol • 12.3K main-agent tokens"
+
+
 def test_with_slack_session_cost_preserves_blocks_and_is_idempotent() -> None:
     text = "Done <https://app.example/agents/t1|Open in Web> • model-a • 110 main-agent tokens"
     blocks = [


### PR DESCRIPTION
## Summary

The Slack footer's usage segment can show long fully-qualified model IDs like `accounts/fireworks/models/glm-5p3-flash`. This shortens each label to just the last path component, so the footer reads `glm-5p3-flash` instead.

## Why this approach

The shortening happens in `_safe_model_label` in `agent/slack/client.py`, which is the single place model labels are built for both `format_slack_run_usage` and the live footer updater (`with_slack_session_cost`), so posted messages and later cost edits stay consistent. Collapsing to the final `/` component is more general than stripping a hardcoded `accounts/fireworks/models/` prefix (the approach used in dcode's status bar, `PROVIDER_PREFIX_STRIPS` in deepagents-code) and still handles any provider with nested IDs. The 48-char sanitization cap and character sanitization are unchanged. Models without slashes (e.g. `openai:gpt-5.6-sol`) are unaffected.

Covered by a new test asserting `accounts/fireworks/models/glm-5p3-flash` renders as `glm-5p3-flash`.

Made by [Open SWE](https://openswe.vercel.app/agents/54270103-31df-5eb8-ae0d-5ea5e3be84ba) · openai:gpt-5.6-sol (high)