### PR TITLE
feat: org-level default for adaptive model routing on Slack runs

### DIFF
--- a/agent/dashboard/agent_overrides.py
+++ b/agent/dashboard/agent_overrides.py
@@ -98,6 +98,12 @@ def profile_model_routing_enabled(profile: dict[str, Any] | None) -> bool:
     return value if isinstance(value, bool) else False
 
 
+def profile_model_routing_override(profile: dict[str, Any] | None) -> bool | None:
+    """The user's explicit routing preference, or ``None`` to use the org default."""
+    value = profile.get("model_routing_override") if isinstance(profile, dict) else None
+    return value if isinstance(value, bool) else None
+
+
 def _normalize_profile_model_pair(
     profile: dict[str, Any],
     *,

--- a/agent/dashboard/profiles.py
+++ b/agent/dashboard/profiles.py
@@ -48,6 +48,9 @@ class ProfileUpdate(BaseModel):
     branch_prefix: str | None = None
     auto_fix_ci: bool = True
     model_routing_enabled: bool | None = None
+    # Tri-state user override of the org-wide routing default: True/False forces a
+    # preference; None falls back to "team-default".
+    model_routing_override: bool | None = None
     draft_prs: bool | None = None
     review_draft_prs: bool | None = None
 
@@ -156,6 +159,7 @@ async def upsert_profile(login: str, email: str, update: ProfileUpdate) -> dict[
             if update.model_routing_enabled is not None
             else existing.get("model_routing_enabled", False)
         ),
+        "model_routing_override": update.model_routing_override,
         "draft_prs": (
             update.draft_prs if update.draft_prs is not None else existing.get("draft_prs", True)
         ),

--- a/agent/dashboard/team_settings.py
+++ b/agent/dashboard/team_settings.py
@@ -86,6 +86,9 @@ class TeamSettingsUpdate(TranscriptionSettingsUpdate):
     default_chat_reasoning_effort: str | None = None
     default_thread_title_model: str | None = None
     default_thread_title_reasoning_effort: str | None = None
+    # Org-wide adaptive model routing default for Slack-triggered runs. True/False
+    # is authoritative; users may still override on their own profile.
+    model_routing_enabled: bool | None = None
 
     @field_validator("org_guidelines", mode="before")
     @classmethod
@@ -332,6 +335,7 @@ def _default_settings() -> dict[str, Any]:
         "default_chat_reasoning_effort": None,
         "default_thread_title_model": DEFAULT_THREAD_TITLE_MODEL,
         "default_thread_title_reasoning_effort": DEFAULT_THREAD_TITLE_REASONING_EFFORT,
+        "model_routing_enabled": None,
         "updated_at": None,
     }
 
@@ -397,6 +401,7 @@ async def upsert_team_settings(update: TeamSettingsUpdate) -> dict[str, Any]:
         "default_chat_reasoning_effort": update.default_chat_reasoning_effort,
         "default_thread_title_model": update.default_thread_title_model,
         "default_thread_title_reasoning_effort": update.default_thread_title_reasoning_effort,
+        "model_routing_enabled": update.model_routing_enabled,
         "updated_at": now_iso(),
     }
     await put_value(TEAM_SETTINGS_NAMESPACE, TEAM_SETTINGS_KEY, value)
@@ -585,6 +590,13 @@ async def get_team_fable_enabled() -> bool:
     settings = await get_team_settings()
     value = settings.get("fable_enabled")
     return bool(value) if isinstance(value, bool) else False
+
+
+async def get_team_model_routing_enabled() -> bool | None:
+    """Return the org-wide adaptive model routing default (``None`` = inherit users)."""
+    settings = await get_team_settings()
+    value = settings.get("model_routing_enabled")
+    return value if isinstance(value, bool) else None
 
 
 async def get_effective_gateway_enabled() -> bool:

--- a/agent/server.py
+++ b/agent/server.py
@@ -52,6 +52,7 @@ from agent.dashboard.agent_overrides import (
     normalize_profile_subagent_overrides,
     profile_draft_prs,
     profile_model_routing_enabled,
+    profile_model_routing_override,
     resolve_github_login,
 )
 from agent.dashboard.agent_usage import record_agent_invocation_usage
@@ -72,6 +73,7 @@ from agent.dashboard.team_settings import (
     get_team_default_repo,
     get_team_default_thread_title_model,
     get_team_fable_enabled,
+    get_team_model_routing_enabled,
 )
 from agent.dashboard.user_mappings import email_for_login
 from agent.desktop import create_desktop_backend, desktop_artifact_routes, is_desktop_run
@@ -546,6 +548,14 @@ async def _cached_fable_enabled() -> bool:
     )
 
 
+async def _cached_team_model_routing_enabled() -> bool | None:
+    return await ttl_cache.cached(
+        "team:model-routing-enabled",
+        60,
+        get_team_model_routing_enabled,
+    )
+
+
 async def _cached_profile(profile_login: str | None):
     if not profile_login:
         return None
@@ -858,6 +868,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         use_gateway = gateway_env_default()
         profile = None
         fable_enabled = False
+        team_routing_default: bool | None = None
     else:
         async with aphase(thread_id, "factory.settings_defaults"):
             (
@@ -867,6 +878,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                 use_gateway,
                 profile,
                 fable_enabled,
+                team_routing_default,
             ) = await asyncio.gather(
                 _cached_team_default_model_pair("agent"),
                 _cached_agent_routing_models(),
@@ -874,6 +886,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                 _cached_gateway_enabled(),
                 _cached_profile(None if thread_settings.get("model_id") else profile_login),
                 _cached_fable_enabled(),
+                _cached_team_model_routing_enabled(),
             )
 
     linear_issue = as_json_object(cfg.linear_issue.model_dump() if cfg.linear_issue else None)
@@ -910,14 +923,24 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             subagent_model_id = overridden_subagent_model
             subagent_effort = overridden_subagent_effort
 
-    adaptive_model_routing = profile_model_routing_enabled(profile)
+    # Org-wide Slack default first, then the user's explicit override; non-Slack
+    # runs keep the user-level toggle alone.
+    if cfg.source == "slack":
+        adaptive_model_routing = team_routing_default is True
+        user_override = profile_model_routing_override(profile)
+        if user_override is not None:
+            adaptive_model_routing = user_override
+    else:
+        adaptive_model_routing = profile_model_routing_enabled(profile)
     stored_model = thread_settings.get("model_id")
     if isinstance(stored_model, str):
         model_id = stored_model
         profile_effort = thread_settings.get("effort")
         subagent_model_id = thread_settings.get("subagent_model_id") or stored_model
         subagent_effort = thread_settings.get("subagent_effort")
-        adaptive_model_routing = thread_settings.get("model_routing_enabled", False)
+        adaptive_model_routing = thread_settings.get(
+            "model_routing_enabled", adaptive_model_routing
+        )
         logger.info("Using stored thread settings: model=%s effort=%s", model_id, profile_effort)
 
     # An explicit per-run model choice is the one thing allowed to move a thread

--- a/swagger.json
+++ b/swagger.json
@@ -222,6 +222,17 @@
       },
       "Environment": {
         "properties": {
+          "base_snapshot_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Snapshot Id"
+          },
           "create_params": {
             "additionalProperties": {
               "$ref": "#/components/schemas/JsonValue"
@@ -282,12 +293,127 @@
             "title": "Prompt",
             "type": "string"
           },
+          "refresh_cron_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Refresh Cron Id"
+          },
+          "refresh_error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Refresh Error"
+          },
+          "refresh_finished_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Refresh Finished At"
+          },
+          "refresh_kind": {
+            "anyOf": [
+              {
+                "enum": [
+                  "full",
+                  "update"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Refresh Kind"
+          },
+          "refresh_log": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Refresh Log"
+          },
+          "refresh_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Refresh Run Id"
+          },
+          "refresh_sandbox_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Refresh Sandbox Id"
+          },
+          "refresh_started_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Refresh Started At"
+          },
+          "refresh_status": {
+            "default": "never",
+            "enum": [
+              "never",
+              "refreshing",
+              "success",
+              "failed"
+            ],
+            "title": "Refresh Status",
+            "type": "string"
+          },
+          "refresh_steps": {
+            "items": {
+              "$ref": "#/components/schemas/RefreshStep"
+            },
+            "title": "Refresh Steps",
+            "type": "array"
+          },
           "repos": {
             "items": {
               "type": "string"
             },
             "title": "Repos",
             "type": "array"
+          },
+          "setup_script": {
+            "default": "",
+            "title": "Setup Script",
+            "type": "string"
           },
           "slug": {
             "title": "Slug",
@@ -326,6 +452,17 @@
             "title": "Snapshot Status",
             "type": "string"
           },
+          "snapshot_tag": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Snapshot Tag"
+          },
           "source_sandbox_id": {
             "anyOf": [
               {
@@ -347,6 +484,11 @@
               }
             ],
             "title": "Status Message"
+          },
+          "update_script": {
+            "default": "",
+            "title": "Update Script",
+            "type": "string"
           },
           "updated_at": {
             "default": "",
@@ -373,6 +515,17 @@
       },
       "EnvironmentCreate": {
         "properties": {
+          "base_snapshot_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Snapshot Id"
+          },
           "create_params": {
             "additionalProperties": {
               "$ref": "#/components/schemas/JsonValue"
@@ -420,6 +573,27 @@
             "title": "Repos",
             "type": "array"
           },
+          "setup_script": {
+            "default": "",
+            "title": "Setup Script",
+            "type": "string"
+          },
+          "snapshot_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Snapshot Name"
+          },
+          "update_script": {
+            "default": "",
+            "title": "Update Script",
+            "type": "string"
+          },
           "vcpus": {
             "anyOf": [
               {
@@ -442,6 +616,17 @@
       "EnvironmentUpdate": {
         "description": "Partial update: only the fields present are written.",
         "properties": {
+          "base_snapshot_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Snapshot Id"
+          },
           "create_params": {
             "anyOf": [
               {
@@ -515,6 +700,39 @@
               }
             ],
             "title": "Repos"
+          },
+          "setup_script": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Setup Script"
+          },
+          "snapshot_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Snapshot Name"
+          },
+          "update_script": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Update Script"
           },
           "vcpus": {
             "anyOf": [
@@ -862,6 +1080,17 @@
             ],
             "title": "Model Routing Enabled"
           },
+          "model_routing_override": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Routing Override"
+          },
           "reasoning_effort": {
             "title": "Reasoning Effort",
             "type": "string"
@@ -966,6 +1195,68 @@
           "state"
         ],
         "title": "PullRequestState",
+        "type": "object"
+      },
+      "RefreshStep": {
+        "description": "One stage of a refresh \u2014 booting the builder, a script, the capture.\n\nRecorded as it happens so a poll mid-rebuild can say how far it got. A\nrebuild is minutes to an hour, and a single terminal status at the end is\nnot enough to tell slow from wedged.",
+        "properties": {
+          "exit_code": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Exit Code"
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Finished At"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "log_path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Log Path"
+          },
+          "started_at": {
+            "default": "",
+            "title": "Started At",
+            "type": "string"
+          },
+          "status": {
+            "default": "running",
+            "enum": [
+              "running",
+              "success",
+              "failed"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "label"
+        ],
+        "title": "RefreshStep",
         "type": "object"
       },
       "ReviewCommentCreate": {
@@ -1751,6 +2042,17 @@
               }
             ],
             "title": "Gateway Enabled"
+          },
+          "model_routing_enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Routing Enabled"
           },
           "org_guidelines": {
             "anyOf": [
@@ -2912,7 +3214,7 @@
     },
     "/dashboard/api/environments/options": {
       "get": {
-        "description": "Pickable environments for any signed-in user: names only, no prompts.",
+        "description": "Pickable environments for any signed-in user; refresh logs only for admins.",
         "operationId": "api_environment_options_dashboard_api_environments_options_get",
         "responses": {
           "200": {
@@ -3079,6 +3381,56 @@
           }
         ],
         "summary": "Api Update Environment",
+        "tags": [
+          "dashboard"
+        ]
+      }
+    },
+    "/dashboard/api/environments/{slug}/refresh": {
+      "post": {
+        "description": "Start a snapshot rebuild from the environment's scripts.\n\nStarted in the background rather than awaited: a rebuild takes minutes, and\nthe outcome lands on the record for the dashboard to poll.",
+        "operationId": "api_refresh_environment_dashboard_api_environments__slug__refresh_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "slug",
+            "required": true,
+            "schema": {
+              "title": "Slug",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Api Refresh Environment Dashboard Api Environments  Slug  Refresh Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "DashboardSession": []
+          }
+        ],
+        "summary": "Api Refresh Environment",
         "tags": [
           "dashboard"
         ]

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -138,6 +138,8 @@ export interface Profile {
   branch_prefix?: string | null
   auto_fix_ci?: boolean
   model_routing_enabled?: boolean
+  /** Tri-state user override of the org-wide routing default; null = team default. */
+  model_routing_override?: boolean | null
   draft_prs?: boolean
   review_draft_prs?: boolean | null
   updated_at?: string
@@ -153,6 +155,7 @@ export interface ProfileUpdate {
   branch_prefix?: string | null
   auto_fix_ci?: boolean
   model_routing_enabled?: boolean
+  model_routing_override?: boolean | null
   draft_prs?: boolean
   review_draft_prs?: boolean | null
 }
@@ -187,6 +190,8 @@ export interface TeamSettings {
   default_chat_reasoning_effort?: string | null
   default_thread_title_model?: string | null
   default_thread_title_reasoning_effort?: string | null
+  /** Org-wide adaptive model routing default for Slack-triggered runs; null = off. */
+  model_routing_enabled?: boolean | null
   updated_at?: string | null
 }
 

--- a/ui/src/lib/profile.ts
+++ b/ui/src/lib/profile.ts
@@ -122,6 +122,7 @@ export function buildProfileUpdate(
     branch_prefix: current?.branch_prefix ?? null,
     auto_fix_ci: current?.auto_fix_ci ?? true,
     model_routing_enabled: current?.model_routing_enabled ?? false,
+    model_routing_override: current?.model_routing_override ?? null,
     draft_prs: current?.draft_prs ?? true,
     review_draft_prs: current?.review_draft_prs ?? null,
     ...patch,

--- a/ui/src/routes/admin.tsx
+++ b/ui/src/routes/admin.tsx
@@ -715,6 +715,23 @@ function GlobalDefaultsSection({ models }: { models: Array<ModelOption> }) {
           }
           disabled={!settings.data || save.isPending}
         />
+        <SettingsRow
+          label="Adaptive model routing (Slack default)"
+          description="Turns on adaptive model routing by default for Slack-triggered runs across the workspace. Users can still override it on their own Open SWE Agent settings."
+          control={
+            <Switch
+              checked={settings.data?.model_routing_enabled === true}
+              onCheckedChange={(next) =>
+                settings.data &&
+                save.mutate({
+                  ...settings.data,
+                  model_routing_enabled: next,
+                })
+              }
+              disabled={!settings.data || save.isPending}
+            />
+          }
+        />
         <RolePicker
           label="Agent routing: fast"
           description="Model used for straightforward agent turns."

--- a/ui/src/routes/cloud-agents.tsx
+++ b/ui/src/routes/cloud-agents.tsx
@@ -153,11 +153,31 @@ function CloudAgentsPage() {
             label="Adaptive model routing"
             description="Automatically choose a model for each turn; turn this off to always use your default model"
             control={
-              <Switch
-                checked={profile.data?.model_routing_enabled ?? false}
-                onCheckedChange={(v) => persist({ model_routing_enabled: v })}
+              <Select
+                value={
+                  profile.data?.model_routing_override === true
+                    ? "on"
+                    : profile.data?.model_routing_override === false
+                      ? "off"
+                      : "team-default"
+                }
+                onValueChange={(v) =>
+                  persist({
+                    model_routing_override:
+                      v === "team-default" ? null : v === "on",
+                  })
+                }
                 disabled={profile.isLoading || save.isPending}
-              />
+              >
+                <SelectTrigger className="w-44">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="team-default">Team default</SelectItem>
+                  <SelectItem value="on">On</SelectItem>
+                  <SelectItem value="off">Off</SelectItem>
+                </SelectContent>
+              </Select>
             }
           />
           <SettingsRow


### PR DESCRIPTION
Org-level routing default for Slack-triggered runs, with user override:

- **Team settings** (`PUT /team-settings`, admin-only): new tri-state `model_routing_enabled` toggle. On = adaptive model routing is the default for every Slack-triggered run.
- **User profile** (`PUT /profile`): new `model_routing_override` (`true` / `false` / `null`). `null` (the default) means "team-default"; explicit on/off wins over the org default. The existing `model_routing_enabled` field is unchanged and still governs non-Slack runs.
- **Resolution** in `get_agent`: Slack runs use `org default → user override`; other sources keep the user toggle alone. Stored thread settings still win once a thread has been snapshotted, and per-run model overrides behave as before.
- **UI**: admin Global Defaults gets the org toggle; the Open SWE Agent page's routing switch becomes a Team default / On / Off select.
- `swagger.json` regenerated via `make swagger`.

Made by [Open SWE](https://openswe.vercel.app/agents/01a08ca2-8472-7579-8422-484c10eb5450) · fireworks:accounts/fireworks/models/glm-5p3-flash (max)