### PR TITLE
feat: org-wide adaptive model routing toggle

### DIFF
--- a/agent/dashboard/agent_overrides.py
+++ b/agent/dashboard/agent_overrides.py
@@ -92,10 +92,10 @@ def profile_draft_prs(profile: dict[str, Any] | None) -> bool:
     return value if isinstance(value, bool) else True
 
 
-def profile_model_routing_enabled(profile: dict[str, Any] | None) -> bool:
-    """Return whether adaptive model routing is enabled. Defaults to False."""
+def profile_model_routing_enabled(profile: dict[str, Any] | None) -> bool | None:
+    """The user's adaptive model routing preference, or ``None`` to inherit the org default."""
     value = profile.get("model_routing_enabled") if isinstance(profile, dict) else None
-    return value if isinstance(value, bool) else False
+    return value if isinstance(value, bool) else None
 
 
 def _normalize_profile_model_pair(

--- a/agent/dashboard/profiles.py
+++ b/agent/dashboard/profiles.py
@@ -153,8 +153,8 @@ async def upsert_profile(login: str, email: str, update: ProfileUpdate) -> dict[
         "auto_fix_ci": update.auto_fix_ci,
         "model_routing_enabled": (
             update.model_routing_enabled
-            if update.model_routing_enabled is not None
-            else existing.get("model_routing_enabled", False)
+            if "model_routing_enabled" in update.model_fields_set
+            else existing.get("model_routing_enabled")
         ),
         "draft_prs": (
             update.draft_prs if update.draft_prs is not None else existing.get("draft_prs", True)

--- a/agent/dashboard/team_settings.py
+++ b/agent/dashboard/team_settings.py
@@ -61,6 +61,9 @@ class TeamSettingsUpdate(TranscriptionSettingsUpdate):
     review_trace_links: bool = True
     # Tri-state LLM Gateway toggle: True/False is authoritative, None inherits the
     # LANGSMITH_GATEWAY_ENABLED deployment default.
+    # Tri-state adaptive model routing toggle: True/False is authoritative,
+    # None is off (routing is opt-in until an admin enables it org-wide).
+    model_routing_enabled: bool | None = None
     gateway_enabled: bool | None = None
     transcription_model: str = DEFAULT_TRANSCRIPTION_MODEL
     fable_enabled: bool = False
@@ -304,6 +307,7 @@ def _default_settings() -> dict[str, Any]:
         "review_draft_prs": False,
         "pr_summaries": True,
         "review_trace_links": True,
+        "model_routing_enabled": None,
         "gateway_enabled": None,
         "transcription_model": DEFAULT_TRANSCRIPTION_MODEL,
         "fable_enabled": False,
@@ -372,6 +376,7 @@ async def upsert_team_settings(update: TeamSettingsUpdate) -> dict[str, Any]:
         "review_draft_prs": update.review_draft_prs,
         "pr_summaries": update.pr_summaries,
         "review_trace_links": update.review_trace_links,
+        "model_routing_enabled": update.model_routing_enabled,
         "gateway_enabled": update.gateway_enabled,
         "transcription_model": update.transcription_model,
         "fable_enabled": update.fable_enabled,
@@ -571,6 +576,13 @@ async def update_team_transcription_model(model: str) -> dict[str, Any]:
     ).transcription_model
     settings.pop("updated_at", None)
     return await upsert_team_settings(TeamSettingsUpdate.model_validate(settings))
+
+
+async def get_team_model_routing_enabled() -> bool:
+    """Return whether adaptive model routing is enabled org-wide."""
+    settings = await get_team_settings()
+    value = settings.get("model_routing_enabled")
+    return value if isinstance(value, bool) else False
 
 
 async def get_team_gateway_enabled() -> bool | None:

--- a/agent/server.py
+++ b/agent/server.py
@@ -72,6 +72,7 @@ from agent.dashboard.team_settings import (
     get_team_default_repo,
     get_team_default_thread_title_model,
     get_team_fable_enabled,
+    get_team_model_routing_enabled,
 )
 from agent.dashboard.user_mappings import email_for_login
 from agent.desktop import create_desktop_backend, desktop_artifact_routes, is_desktop_run
@@ -546,6 +547,14 @@ async def _cached_fable_enabled() -> bool:
     )
 
 
+async def _cached_team_model_routing_enabled() -> bool:
+    return await ttl_cache.cached(
+        "team:model-routing-enabled",
+        60,
+        get_team_model_routing_enabled,
+    )
+
+
 async def _cached_profile(profile_login: str | None):
     if not profile_login:
         return None
@@ -910,7 +919,10 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             subagent_model_id = overridden_subagent_model
             subagent_effort = overridden_subagent_effort
 
+    # User preference overrides the org-wide toggle; None inherits it.
     adaptive_model_routing = profile_model_routing_enabled(profile)
+    if adaptive_model_routing is None:
+        adaptive_model_routing = False if local_run else await _cached_team_model_routing_enabled()
     stored_model = thread_settings.get("model_id")
     if isinstance(stored_model, str):
         model_id = stored_model

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -152,7 +152,7 @@ export interface ProfileUpdate {
   base_branch?: string | null
   branch_prefix?: string | null
   auto_fix_ci?: boolean
-  model_routing_enabled?: boolean
+  model_routing_enabled?: boolean | null
   draft_prs?: boolean
   review_draft_prs?: boolean | null
 }
@@ -161,6 +161,8 @@ export interface TeamSettings {
   review_draft_prs: boolean
   pr_summaries: boolean
   review_trace_links: boolean
+  /** Tri-state adaptive model routing toggle; user preference overrides this org default. */
+  model_routing_enabled?: boolean | null
   /** Tri-state LLM Gateway toggle; null inherits the LANGSMITH_GATEWAY_ENABLED default. */
   gateway_enabled?: boolean | null
   transcription_model?: string

--- a/ui/src/lib/profile.ts
+++ b/ui/src/lib/profile.ts
@@ -121,7 +121,7 @@ export function buildProfileUpdate(
     base_branch: current?.base_branch ?? null,
     branch_prefix: current?.branch_prefix ?? null,
     auto_fix_ci: current?.auto_fix_ci ?? true,
-    model_routing_enabled: current?.model_routing_enabled ?? false,
+    model_routing_enabled: current?.model_routing_enabled ?? null,
     draft_prs: current?.draft_prs ?? true,
     review_draft_prs: current?.review_draft_prs ?? null,
     ...patch,

--- a/ui/src/routes/admin.tsx
+++ b/ui/src/routes/admin.tsx
@@ -681,6 +681,20 @@ function GlobalDefaultsSection({ models }: { models: Array<ModelOption> }) {
       description="Workspace-wide model defaults. Per-user Cloud Agent selections override the agent defaults."
     >
       <div className="divide-y divide-border">
+        <SettingsRow
+          label="Adaptive model routing"
+          description="Automatically choose a model for each turn, org-wide. Users can still override this in their personal settings."
+          control={
+            <Switch
+              checked={settings.data?.model_routing_enabled ?? false}
+              onCheckedChange={(next) =>
+                settings.data &&
+                save.mutate({ ...settings.data, model_routing_enabled: next })
+              }
+              disabled={!settings.data || save.isPending}
+            />
+          }
+        />
         <RolePicker
           label="Open SWE Agent"
           description="Model used for code-writing runs triggered from Slack, Linear, GitHub, and the Open SWE Agent."

--- a/ui/src/routes/cloud-agents.tsx
+++ b/ui/src/routes/cloud-agents.tsx
@@ -151,13 +151,33 @@ function CloudAgentsPage() {
         <div className="divide-y divide-border">
           <SettingsRow
             label="Adaptive model routing"
-            description="Automatically choose a model for each turn; turn this off to always use your default model"
+            description="Automatically choose a model for each turn. Inherit uses the org-wide default; Enabled or Disabled overrides it."
             control={
-              <Switch
-                checked={profile.data?.model_routing_enabled ?? false}
-                onCheckedChange={(v) => persist({ model_routing_enabled: v })}
+              <Select
+                value={
+                  profile.data?.model_routing_enabled === true
+                    ? "enabled"
+                    : profile.data?.model_routing_enabled === false
+                      ? "disabled"
+                      : "inherit"
+                }
+                onValueChange={(v) =>
+                  persist({
+                    model_routing_enabled:
+                      v === "enabled" ? true : v === "disabled" ? false : null,
+                  })
+                }
                 disabled={profile.isLoading || save.isPending}
-              />
+              >
+                <SelectTrigger className="w-40">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="inherit">Inherit org default</SelectItem>
+                  <SelectItem value="enabled">Enabled</SelectItem>
+                  <SelectItem value="disabled">Disabled</SelectItem>
+                </SelectContent>
+              </Select>
             }
           />
           <SettingsRow


### PR DESCRIPTION
Adds an org-wide adaptive model routing toggle so routing can be enabled for everyone, not just per-user.

- **Team settings**: new tri-state `model_routing_enabled` on `TeamSettingsUpdate` (admin PUT `/team-settings`), defaulting to off.
- **Profile inheritance**: the per-user `model_routing_enabled` preference becomes tri-state — explicit on/off overrides the org default; unset/omitted inherits the org setting (existing profiles keep their explicit value).
- **Agent resolution**: `get_agent` resolves routing as user preference → org default → off (local runs stay off).
- **UI**: org toggle in the admin "Global defaults" section; the per-user Cloud Agents setting becomes a select (Inherit org default / Enabled / Disabled). No slider.

Made by [Open SWE](https://openswe.vercel.app/agents/70e685f5-00eb-52c6-8519-bd58615b1694) · openai:gpt-5.6-sol (high)