### PR TITLE
fix: link Slack failure replies to LangSmith instead of Open SWE Web

### DIFF
--- a/agent/completion.py
+++ b/agent/completion.py
@@ -31,8 +31,8 @@ from agent.slack.client import post_slack_thread_reply
 from agent.slack.code_channels import is_code_channel_session, set_session_status
 from agent.source_context import SourceContext
 from agent.thread_feedback import schedule_answer_feedback
-from agent.utils.dashboard_links import dashboard_thread_url
 from agent.utils.errors import LAST_MODEL_ERROR_KEY, code_for_error_type
+from agent.utils.langsmith import get_langsmith_trace_url
 from agent.utils.thread_ops import langgraph_client
 from agent.utils.user_messages import warning
 
@@ -94,9 +94,7 @@ _REASON_FOLLOW_UP = {
 }
 
 
-def _failure_text(
-    status: str, dashboard_url: str | None = None, reason_code: str | None = None
-) -> str:
+def _failure_text(status: str, trace_url: str | None = None, reason_code: str | None = None) -> str:
     reason = _REASON_TEXT.get(reason_code or "")
     if reason is None:
         if status == "timeout":
@@ -107,8 +105,8 @@ def _failure_text(
             reason = "the run hit an unexpected error"
     follow_up = _REASON_FOLLOW_UP.get(reason_code or "", _DEFAULT_FOLLOW_UP)
     text = warning(f"Open SWE wasn't able to finish that — {reason}. {follow_up}")
-    if dashboard_url:
-        text += f" You can view the error in <{dashboard_url}|Open SWE Web>."
+    if trace_url:
+        text += f" View the error in <{trace_url}|LangSmith>."
     return text
 
 
@@ -185,24 +183,25 @@ async def _post_failure_reply(
     """Post a failure reply to the run's originating channel. Best-effort."""
     source = metadata.get("source")
     ctx = SourceContext.from_metadata(metadata)
-    text = _failure_text(status, reason_code=reason_code)
 
     if source == "slack" or ctx.slack_thread is not None:
         location = ctx.slack_location
         if location is not None:
-            slack_text = _failure_text(status, dashboard_thread_url(thread_id), reason_code)
+            trace_url = await get_langsmith_trace_url(thread_id)
+            slack_text = _failure_text(status, trace_url, reason_code)
             return await post_slack_thread_reply(
                 location[0],
                 location[1],
                 slack_text,
                 agent_thread_id=thread_id,
-                include_trace_link=True,
             )
         return False
 
     if source == "linear":
         if ctx.linear_issue and ctx.linear_issue.id:
-            return await comment_on_linear_issue(ctx.linear_issue.id, text)
+            return await comment_on_linear_issue(
+                ctx.linear_issue.id, _failure_text(status, reason_code=reason_code)
+            )
         return False
 
     if source in ("github", "github_issue"):
@@ -213,7 +212,12 @@ async def _post_failure_reply(
         if isinstance(repo_config, dict) and isinstance(number, int):
             token = await get_github_app_installation_token()
             if token:
-                return await post_github_comment(repo_config, number, text, token=token)
+                return await post_github_comment(
+                    repo_config,
+                    number,
+                    _failure_text(status, reason_code=reason_code),
+                    token=token,
+                )
         return False
 
     logger.info("No failure-reply channel for thread %s (source=%s)", thread_id, source)

--- a/agent/slack/client.py
+++ b/agent/slack/client.py
@@ -547,17 +547,11 @@ def with_slack_session_cost(
 def format_slack_web_link_footer(
     dashboard_url: str | None,
     usage: RunUsageSummary | None = None,
-    *,
-    trace_url: str | None = None,
 ) -> str:
     """Format the compact Slack footer links."""
-    if not dashboard_url and not trace_url:
+    if not dashboard_url:
         return ""
-    links = []
-    if dashboard_url:
-        links.append(f"<{dashboard_url}|{SLACK_WEB_LINK_FOOTER_LABEL}>")
-    if trace_url:
-        links.append(f"<{trace_url}|View trace>")
+    links = [f"<{dashboard_url}|{SLACK_WEB_LINK_FOOTER_LABEL}>"]
     usage_text = format_slack_run_usage(usage)
     if usage_text:
         links.append(usage_text)
@@ -568,11 +562,9 @@ def append_slack_web_link_footer(
     text: str,
     dashboard_url: str | None,
     usage: RunUsageSummary | None = None,
-    *,
-    trace_url: str | None = None,
 ) -> str:
     """Append the compact Slack footer links to fallback text."""
-    footer = format_slack_web_link_footer(dashboard_url, usage, trace_url=trace_url)
+    footer = format_slack_web_link_footer(dashboard_url, usage)
     if not footer or footer in text:
         return text
     stripped = text.rstrip()
@@ -584,10 +576,8 @@ def append_slack_web_link_footer(
 def _slack_web_link_context_block(
     dashboard_url: str | None,
     usage: RunUsageSummary | None = None,
-    *,
-    trace_url: str | None = None,
 ) -> dict[str, Any] | None:
-    footer = format_slack_web_link_footer(dashboard_url, usage, trace_url=trace_url)
+    footer = format_slack_web_link_footer(dashboard_url, usage)
     if not footer:
         return None
     return {"type": "context", "elements": [{"type": "mrkdwn", "text": footer}]}
@@ -610,10 +600,8 @@ def _with_slack_web_link_context_block(
     blocks: list[dict[str, Any]] | None,
     dashboard_url: str | None,
     usage: RunUsageSummary | None = None,
-    *,
-    trace_url: str | None = None,
 ) -> list[dict[str, Any]] | None:
-    context_block = _slack_web_link_context_block(dashboard_url, usage, trace_url=trace_url)
+    context_block = _slack_web_link_context_block(dashboard_url, usage)
     if context_block is None:
         return blocks
     if not blocks:
@@ -647,7 +635,6 @@ async def post_slack_thread_reply_with_ts(
     blocks: list[dict[str, Any]] | None = None,
     usage: RunUsageSummary | None = None,
     agent_thread_id: str | None = None,
-    include_trace_link: bool = False,
 ) -> tuple[str | None, str | None]:
     """Post a reply in a Slack thread and return its Slack timestamp and error."""
     from agent.slack.code_channels import is_code_channel_session
@@ -655,15 +642,8 @@ async def post_slack_thread_reply_with_ts(
     if is_code_channel_session(thread_ts):
         agent_thread_id = None
     dashboard_url = _slack_thread_dashboard_url(channel_id, thread_ts, agent_thread_id)
-    trace_url = (
-        await get_langsmith_trace_url(agent_thread_id)
-        if include_trace_link and agent_thread_id
-        else None
-    )
-    blocks = _with_slack_web_link_context_block(
-        text, blocks, dashboard_url, usage, trace_url=trace_url
-    )
-    text = append_slack_web_link_footer(text, dashboard_url, usage, trace_url=trace_url)
+    blocks = _with_slack_web_link_context_block(text, blocks, dashboard_url, usage)
+    text = append_slack_web_link_footer(text, dashboard_url, usage)
     return await _post_slack_message_with_ts(
         channel_id,
         text,
@@ -944,12 +924,9 @@ async def post_slack_thread_reply(
     *,
     blocks: list[dict[str, Any]] | None = None,
     agent_thread_id: str | None = None,
-    include_trace_link: bool = False,
 ) -> bool:
     """Post a reply in a Slack thread."""
     kwargs: dict[str, Any] = {"blocks": blocks}
-    if include_trace_link:
-        kwargs["include_trace_link"] = True
     if agent_thread_id is not None:
         kwargs["agent_thread_id"] = agent_thread_id
     message_ts, _ = await post_slack_thread_reply_with_ts(channel_id, thread_ts, text, **kwargs)

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -491,31 +491,6 @@ def test_post_slack_thread_reply_adds_web_context_block(monkeypatch: pytest.Monk
         {"type": "context", "elements": [{"type": "mrkdwn", "text": expected_footer}]},
     ]
 
-    async def trace_url(thread_id: str) -> str:
-        assert thread_id == "mapped-thread"
-        return "https://smith.example/trace"
-
-    monkeypatch.setattr(slack_utils, "get_langsmith_trace_url", trace_url)
-    captured.clear()
-    asyncio.run(
-        slack_utils.post_slack_thread_reply_with_ts(
-            "C123",
-            "1.0",
-            "Failed",
-            agent_thread_id="mapped-thread",
-            include_trace_link=True,
-        )
-    )
-    expected_error_footer = f"{expected_footer} • <https://smith.example/trace|View trace>"
-    assert captured["text"] == f"Failed {expected_error_footer}"
-    assert captured["blocks"] == [
-        {"type": "section", "text": {"type": "mrkdwn", "text": "Failed"}},
-        {
-            "type": "context",
-            "elements": [{"type": "mrkdwn", "text": expected_error_footer}],
-        },
-    ]
-
     captured.clear()
     asyncio.run(
         slack_utils.post_slack_thread_reply_with_ts(

--- a/tests/webhooks/test_completion_webhook.py
+++ b/tests/webhooks/test_completion_webhook.py
@@ -76,7 +76,9 @@ async def test_error_status_posts_slack_failure_reply(monkeypatch: pytest.Monkey
     reply = AsyncMock(return_value=True)
     monkeypatch.setattr(completion, "post_slack_thread_reply", reply)
     monkeypatch.setattr(
-        completion, "dashboard_thread_url", lambda thread_id: f"https://ui/{thread_id}"
+        completion,
+        "get_langsmith_trace_url",
+        AsyncMock(return_value="https://smith.example/t1"),
     )
 
     result = await completion.handle_run_completion(
@@ -90,8 +92,8 @@ async def test_error_status_posts_slack_failure_reply(monkeypatch: pytest.Monkey
     args = await_args.args
     assert args[0] == "C1"
     assert args[1] == "123.45"
-    assert "<https://ui/t1|Open SWE Web>" in args[2]
-    assert await_args.kwargs == {"agent_thread_id": "t1", "include_trace_link": True}
+    assert "View the error in <https://smith.example/t1|LangSmith>" in args[2]
+    assert await_args.kwargs == {"agent_thread_id": "t1"}
     assert client.threads.updates == [
         {"failure_reply_posted_run_id": "run-1", "failure_reply_posted_run_ids": ["run-1"]}
     ]


### PR DESCRIPTION
The Slack failure reply told users to "view the error in Open SWE Web," but the dashboard doesn't render run errors. This points the failure reply at the LangSmith trace instead, and drops the now-redundant "View trace" link from the Slack footer (the error path is the only place it carried real information).

### Changes
- `agent/completion.py` — `_failure_text` now takes the LangSmith trace URL and appends "View the error in LangSmith" linking to the trace; the Slack failure reply resolves the trace URL itself instead of the dashboard URL, and no longer passes `include_trace_link`.
- `agent/slack/client.py` — removed the `trace_url` parameter from `format_slack_web_link_footer`, `append_slack_web_link_footer`, `_slack_web_link_context_block`, and `_with_slack_web_link_context_block`, and removed `include_trace_link` from `post_slack_thread_reply`/`post_slack_thread_reply_with_ts`. The trace-reply message (`View trace • Open in Web`) is unchanged.

Failure replies on other surfaces (Linear, GitHub) keep the plain text without a link since there's no inline way to link the trace there today.

Made by [Open SWE](https://openswe.vercel.app/agents/eb0a4273-f5e7-53ce-a59c-2af462d2f1f7) · openai:gpt-5.6-sol (high)