### PR TITLE
fix: validate image bytes before encoding multimodal payloads

### DIFF
--- a/agent/utils/multimodal.py
+++ b/agent/utils/multimodal.py
@@ -2,7 +2,6 @@
 
 import base64
 import logging
-import mimetypes
 import re
 from urllib.parse import urlparse
 
@@ -20,6 +19,25 @@ from agent.utils.url_safety import request_with_safe_redirects
 logger = logging.getLogger(__name__)
 
 _MAX_IMAGE_BYTES = 10 * 1024 * 1024
+
+# Sniffed from actual bytes; a response can lie about its Content-Type (e.g. a
+# JSON error body labeled image/png), and providers reject impostor payloads.
+_IMAGE_MAGIC: tuple[tuple[bytes, str], ...] = (
+    (b"\x89PNG\r\n\x1a\n", "image/png"),
+    (b"\xff\xd8\xff", "image/jpeg"),
+    (b"GIF87a", "image/gif"),
+    (b"GIF89a", "image/gif"),
+)
+
+
+def _sniff_image_type(data: bytes) -> str | None:
+    for magic, mime in _IMAGE_MAGIC:
+        if data.startswith(magic):
+            return mime
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
 
 IMAGE_MARKDOWN_RE = re.compile(r"!\[[^\]]*\]\((https?://[^\s)]+)\)")
 IMAGE_URL_RE = re.compile(
@@ -105,22 +123,19 @@ async def fetch_image_block(
         if response is None:
             return None
         response.raise_for_status()
-        content_type = response.headers.get("Content-Type", "").split(";")[0].strip()
-        if not content_type:
-            guessed, _ = mimetypes.guess_type(image_url)
-            if not guessed:
-                logger.warning(
-                    "Could not determine content type for %s; skipping image",
-                    image_url,
-                )
-                return None
-            content_type = guessed
+        sniffed = _sniff_image_type(response.content)
+        if sniffed is None:
+            logger.warning(
+                "Response for %s is not a decodable image; skipping",
+                image_url,
+            )
+            return None
 
         supported_types = {"image/jpeg", "image/png", "image/gif", "image/webp"}
-        if content_type not in supported_types:
+        if sniffed not in supported_types:
             logger.warning(
                 "Unsupported content type '%s' for %s; skipping image",
-                content_type,
+                sniffed,
                 image_url,
             )
             return None
@@ -138,10 +153,10 @@ async def fetch_image_block(
         logger.info(
             "Fetched image %s (%s, %d bytes)",
             image_url,
-            content_type,
+            sniffed,
             len(response.content),
         )
-        return create_image_block(base64=encoded, mime_type=content_type)
+        return create_image_block(base64=encoded, mime_type=sniffed)
     except Exception:
         logger.exception("Failed to fetch image from %s", image_url)
         return None

--- a/tests/agent/test_multimodal.py
+++ b/tests/agent/test_multimodal.py
@@ -217,7 +217,7 @@ async def test_fetch_image_block_tries_each_validated_address(monkeypatch: Any) 
             status_code=200,
             url=url,
             headers={"Content-Type": "image/png"},
-            content=b"png",
+            content=b"\x89PNG\r\n\x1a\npng",
         )
 
     client = FakeImageClient(responder)
@@ -226,7 +226,7 @@ async def test_fetch_image_block_tries_each_validated_address(monkeypatch: Any) 
         "https://example.com/image.png", cast(httpx2.AsyncClient, client)
     )
 
-    assert result == {"base64": "cG5n", "mime_type": "image/png"}
+    assert result == {"base64": "iVBORw0KGgpwbmc=", "mime_type": "image/png"}
     assert [urlparse(call["url"]).hostname for call in client.calls] == [
         "93.184.216.34",
         "93.184.216.35",
@@ -235,7 +235,7 @@ async def test_fetch_image_block_tries_each_validated_address(monkeypatch: Any) 
 
 async def test_fetch_image_block_accepts_image_at_size_limit(monkeypatch: Any) -> None:
     _patch_image_dns(monkeypatch)
-    monkeypatch.setattr(multimodal, "_MAX_IMAGE_BYTES", 3)
+    monkeypatch.setattr(multimodal, "_MAX_IMAGE_BYTES", 12)
     monkeypatch.setattr(multimodal, "create_image_block", lambda **kwargs: kwargs)
 
     def responder(method: str, url: str, **kwargs: Any) -> FakeImageResponse:
@@ -243,14 +243,14 @@ async def test_fetch_image_block_accepts_image_at_size_limit(monkeypatch: Any) -
             status_code=200,
             url=url,
             headers={"Content-Type": "image/png"},
-            content=b"png",
+            content=b"\x89PNG\r\n\x1a\npng",
         )
 
     result = await fetch_image_block(
         "https://example.com/image.png", cast(httpx2.AsyncClient, FakeImageClient(responder))
     )
 
-    assert result == {"base64": "cG5n", "mime_type": "image/png"}
+    assert result == {"base64": "iVBORw0KGgpwbmc=", "mime_type": "image/png"}
 
 
 async def test_fetch_image_block_warns_about_image_above_size_limit(monkeypatch: Any) -> None:
@@ -263,7 +263,7 @@ async def test_fetch_image_block_warns_about_image_above_size_limit(monkeypatch:
             status_code=200,
             url=url,
             headers={"Content-Type": "image/png"},
-            content=b"large",
+            content=b"\x89PNG\r\n\x1a\nlarge",
         )
 
     result = await fetch_image_block(
@@ -275,6 +275,24 @@ async def test_fetch_image_block_warns_about_image_above_size_limit(monkeypatch:
     assert result["text"] == (
         "An attached image was skipped because it exceeded the 10 MiB size limit."
     )
+
+
+async def test_fetch_image_block_skips_json_body_labeled_as_image(monkeypatch: Any) -> None:
+    _patch_image_dns(monkeypatch)
+
+    def responder(method: str, url: str, **kwargs: Any) -> FakeImageResponse:
+        return FakeImageResponse(
+            status_code=200,
+            url=url,
+            headers={"Content-Type": "image/png"},
+            content=b'{"detail": "Not Found"}',
+        )
+
+    result = await fetch_image_block(
+        "https://example.com/image.png", cast(httpx2.AsyncClient, FakeImageClient(responder))
+    )
+
+    assert result is None
 
 
 async def test_fetch_image_block_does_not_forward_slack_auth_to_redirect_host(
@@ -296,7 +314,7 @@ async def test_fetch_image_block_does_not_forward_slack_auth_to_redirect_host(
             status_code=200,
             url=url,
             headers={"Content-Type": "image/png"},
-            content=b"png",
+            content=b"\x89PNG\r\n\x1a\npng",
         )
 
     client = FakeImageClient(responder)
@@ -305,7 +323,7 @@ async def test_fetch_image_block_does_not_forward_slack_auth_to_redirect_host(
         "https://files.slack.com/image.png", cast(httpx2.AsyncClient, client)
     )
 
-    assert result == {"base64": "cG5n", "mime_type": "image/png"}
+    assert result == {"base64": "iVBORw0KGgpwbmc=", "mime_type": "image/png"}
     assert len(client.calls) == 2
     assert client.calls[0]["headers"]["Authorization"] == "Bearer test-slack-token"
     assert "Authorization" not in client.calls[1]["headers"]
@@ -330,7 +348,7 @@ async def test_fetch_image_block_does_not_add_slack_auth_after_untrusted_redirec
             status_code=200,
             url=url,
             headers={"Content-Type": "image/png"},
-            content=b"png",
+            content=b"\x89PNG\r\n\x1a\npng",
         )
 
     client = FakeImageClient(responder)
@@ -339,7 +357,7 @@ async def test_fetch_image_block_does_not_add_slack_auth_after_untrusted_redirec
         "https://example.com/start.png", cast(httpx2.AsyncClient, client)
     )
 
-    assert result == {"base64": "cG5n", "mime_type": "image/png"}
+    assert result == {"base64": "iVBORw0KGgpwbmc=", "mime_type": "image/png"}
     assert len(client.calls) == 2
     assert all("Authorization" not in call["headers"] for call in client.calls)
 
@@ -360,7 +378,7 @@ async def test_fetch_image_block_keeps_auth_within_slack_host_family(monkeypatch
             status_code=200,
             url=url,
             headers={"Content-Type": "image/png"},
-            content=b"png",
+            content=b"\x89PNG\r\n\x1a\npng",
         )
 
     client = FakeImageClient(responder)
@@ -369,7 +387,7 @@ async def test_fetch_image_block_keeps_auth_within_slack_host_family(monkeypatch
         "https://files.slack.com/image.png", cast(httpx2.AsyncClient, client)
     )
 
-    assert result == {"base64": "cG5n", "mime_type": "image/png"}
+    assert result == {"base64": "iVBORw0KGgpwbmc=", "mime_type": "image/png"}
     assert len(client.calls) == 2
     assert all(
         call["headers"]["Authorization"] == "Bearer test-slack-token" for call in client.calls


### PR DESCRIPTION
## Description
Remote image fetches (Slack/Linear attachments, markdown image links) were base64-encoded and sent to the model based on the response's declared `Content-Type` alone. When a URL returned a non-image body — e.g. a JSON error document behind a 200 with `Content-Type: image/png` — the garbage payload was stamped as `data:image/png;base64,...` and the provider rejected it:

```
Failed to decode image 'data:image/png;base64,eyJkZXRh...': cannot identify image file
```

The failing blob decodes to `{"deta...` — JSON text, not image bytes. The model was fine; the payload was not.

`fetch_image_block` now sniffs the response's magic bytes and skips anything that is not a decodable png/jpeg/gif/webp, using the sniffed type as the mime type. One regression test covers the JSON-body case.

Fixes the model-input side of the GLM 5.3 Flash image failures (unrelated to langchain-ai/deepagents#5544, which is about runtime model-switch filtering).

Made by [Open SWE](https://openswe.vercel.app/agents/2e02a623-e554-568a-8208-22eed897a555) · openai:gpt-5.6-sol (high)