### PR TITLE
feat: scope thread credentials and preserve initiator PR ownership

### DIFF
--- a/agent/credential_scope.py
+++ b/agent/credential_scope.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import langgraph_sdk
 
+from agent.dashboard.profiles import resolve_oauth_login
 from agent.run_config import RunConfig
 from agent.utils.json_types import thread_metadata
 
@@ -62,10 +63,7 @@ async def pr_author_login() -> str | None:
         owner = owner.strip()
         if metadata.get("owner_type") == "user":
             return owner
-        login = (cfg.github_login or "").strip()
-        # Older owner metadata was lowercased; keep the OAuth storage key when
-        # the initiator themselves resumes that thread.
-        return login if login.lower() == owner.lower() else owner
+        return await resolve_oauth_login(owner) or owner
     if metadata.get("owner_type") == "user":
         raise RuntimeError("User-owned thread has no GitHub owner for PR creation")
     return None

--- a/agent/credential_scope.py
+++ b/agent/credential_scope.py
@@ -1,4 +1,4 @@
-"""Personal credentials are available only to a private thread's owner."""
+"""Resolve personal integration access and PR authorship from saved thread ownership."""
 
 from collections.abc import Mapping
 from typing import Any
@@ -9,10 +9,9 @@ from agent.run_config import RunConfig
 from agent.utils.json_types import thread_metadata
 
 
-async def private_credential_login(
+async def _thread_scope(
     config: Mapping[str, Any] | None = None, *, thread_id: str | None = None
-) -> str | None:
-    """Verify saved visibility and ownership; never trust caller-supplied visibility."""
+) -> tuple[RunConfig, dict[str, Any]]:
     cfg = RunConfig.from_config(config) if config is not None else RunConfig.from_runtime()
     thread_id = thread_id or cfg.thread_id
     if not thread_id:
@@ -20,10 +19,17 @@ async def private_credential_login(
     thread = await langgraph_sdk.get_client().threads.get(thread_id)
     metadata = thread_metadata(thread)
     visibility = metadata.get("visibility", "public")
-    if visibility == "public":
-        return None
-    if visibility != "private":
+    if visibility not in ("public", "private"):
         raise RuntimeError("Cannot resolve credentials for an unknown thread visibility")
+    owner_type = metadata.get("owner_type")
+    if owner_type not in (None, "user", "system"):
+        raise RuntimeError("Cannot resolve credentials for an unknown thread owner type")
+    if owner_type == "system" and visibility != "public":
+        raise RuntimeError("System threads cannot use private credentials")
+    return cfg, metadata
+
+
+def _private_owner_login(cfg: RunConfig, metadata: Mapping[str, Any]) -> str:
     owner = metadata.get("owner_login")
     if not isinstance(owner, str) or not owner.strip():
         raise RuntimeError("Private thread has no credential owner")
@@ -32,3 +38,34 @@ async def private_credential_login(
     if owner != login.lower():
         raise RuntimeError("Personal credentials require the private thread owner to start the run")
     return login
+
+
+async def private_credential_login(
+    config: Mapping[str, Any] | None = None, *, thread_id: str | None = None
+) -> str | None:
+    """Personal integrations require the saved private owner to start the run."""
+    cfg, metadata = await _thread_scope(config, thread_id=thread_id)
+    if metadata.get("visibility", "public") == "public":
+        return None
+    return _private_owner_login(cfg, metadata)
+
+
+async def pr_author_login() -> str | None:
+    """User-owned PRs belong to the initiator, including in public conversations."""
+    cfg, metadata = await _thread_scope()
+    if metadata.get("visibility", "public") == "private":
+        return _private_owner_login(cfg, metadata)
+    if metadata.get("owner_type") == "system":
+        return None
+    owner = metadata.get("owner_login")
+    if isinstance(owner, str) and owner.strip():
+        owner = owner.strip()
+        if metadata.get("owner_type") == "user":
+            return owner
+        login = (cfg.github_login or "").strip()
+        # Older owner metadata was lowercased; keep the OAuth storage key when
+        # the initiator themselves resumes that thread.
+        return login if login.lower() == owner.lower() else owner
+    if metadata.get("owner_type") == "user":
+        raise RuntimeError("User-owned thread has no GitHub owner for PR creation")
+    return None

--- a/agent/credential_scope.py
+++ b/agent/credential_scope.py
@@ -1,0 +1,34 @@
+"""Personal credentials are available only to a private thread's owner."""
+
+from collections.abc import Mapping
+from typing import Any
+
+import langgraph_sdk
+
+from agent.run_config import RunConfig
+from agent.utils.json_types import thread_metadata
+
+
+async def private_credential_login(
+    config: Mapping[str, Any] | None = None, *, thread_id: str | None = None
+) -> str | None:
+    """Verify saved visibility and ownership; never trust caller-supplied visibility."""
+    cfg = RunConfig.from_config(config) if config is not None else RunConfig.from_runtime()
+    thread_id = thread_id or cfg.thread_id
+    if not thread_id:
+        raise RuntimeError("Cannot resolve credential scope without a thread_id")
+    thread = await langgraph_sdk.get_client().threads.get(thread_id)
+    metadata = thread_metadata(thread)
+    visibility = metadata.get("visibility", "public")
+    if visibility == "public":
+        return None
+    if visibility != "private":
+        raise RuntimeError("Cannot resolve credentials for an unknown thread visibility")
+    owner = metadata.get("owner_login")
+    if not isinstance(owner, str) or not owner.strip():
+        raise RuntimeError("Private thread has no credential owner")
+    owner = owner.strip().lower()
+    login = (cfg.github_login or "").strip()
+    if owner != login.lower():
+        raise RuntimeError("Personal credentials require the private thread owner to start the run")
+    return login

--- a/agent/dashboard/profiles.py
+++ b/agent/dashboard/profiles.py
@@ -30,7 +30,14 @@ from agent.dashboard.options import (
     provider_fallback_pair,
 )
 from agent.encryption import decrypt_token, encrypt_token
-from agent.store import delete_value, get_value, now_iso, put_value, search_values
+from agent.store import (
+    delete_value,
+    get_value,
+    now_iso,
+    put_value,
+    search_all_values,
+    search_values,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -129,6 +136,18 @@ async def get_profile(login: str) -> dict[str, Any] | None:
 async def get_oauth_token_record(login: str) -> dict[str, Any] | None:
     """The raw encrypted-token record, for callers that need its expiry metadata."""
     return await get_value(OAUTH_TOKENS_NAMESPACE, login)
+
+
+async def resolve_oauth_login(login: str) -> str | None:
+    """Recover the stored OAuth key when older thread metadata lost its casing."""
+    if await get_oauth_token_record(login):
+        return login
+    matches = {
+        candidate
+        for record in await search_all_values(OAUTH_TOKENS_NAMESPACE)
+        if isinstance(candidate := record.get("login"), str) and candidate.lower() == login.lower()
+    }
+    return next(iter(matches)) if len(matches) == 1 else None
 
 
 async def upsert_profile(login: str, email: str, update: ProfileUpdate) -> dict[str, Any]:

--- a/agent/dashboard/profiles.py
+++ b/agent/dashboard/profiles.py
@@ -307,7 +307,7 @@ async def _refresh_stored_token(login: str, record: dict[str, Any]) -> tuple[str
     try:
         data = await refresh_user_access_token(refresh_token)
     except Exception as exc:  # noqa: BLE001
-        logger.warning("GitHub token refresh failed for %s", login, exc_info=True)
+        logger.warning("GitHub token refresh failed")
         return None, is_unrecoverable_refresh_error(exc)
     email_value = record.get("email")
     email = email_value if isinstance(email_value, str) else ""
@@ -356,7 +356,7 @@ async def get_valid_access_token(login: str, *, force_refresh: bool = False) -> 
                 "encrypted_gh_refresh_token"
             ):
                 return _decrypt_access_token(latest)
-            logger.info("Dropping dead GitHub authorization for %s; re-login required", login)
+            logger.info("Dropping dead GitHub authorization; re-login required")
             await delete_access_token(login)
             return None
         return access_token

--- a/agent/dashboard/repo_access.py
+++ b/agent/dashboard/repo_access.py
@@ -4,6 +4,7 @@ import httpx2
 from fastapi import HTTPException
 
 from agent.dashboard.profiles import get_valid_access_token
+from agent.github.app import get_github_app_installation_token
 from agent.review.styles import normalize_repo_full_name
 from agent.utils.http import DEFAULT_HTTP_TIMEOUT
 
@@ -49,6 +50,23 @@ async def require_repo_access_for_user(login: str, full_name: str) -> str:
         if not token:
             raise HTTPException(401, "github token expired, re-login required") from exc
         await assert_repo_access(full_name, token)
+    return token
+
+
+async def require_repo_access_for_workspace(full_name: str) -> str:
+    token = await get_github_app_installation_token()
+    if not token:
+        raise HTTPException(503, "workspace GitHub App token unavailable")
+    try:
+        await assert_repo_access(full_name, token)
+    except HTTPException as exc:
+        if exc.status_code == 401:
+            raise HTTPException(502, "workspace GitHub App token rejected") from exc
+        if exc.status_code in (403, 404):
+            raise HTTPException(
+                exc.status_code, "repository unavailable to the workspace GitHub App"
+            ) from exc
+        raise
     return token
 
 

--- a/agent/dashboard/repo_access.py
+++ b/agent/dashboard/repo_access.py
@@ -80,3 +80,15 @@ async def repo_config_for_user(login: str, full_name: str | None) -> dict[str, s
     await require_repo_access_for_user(login, normalized)
     owner, name = normalized.split("/", 1)
     return {"owner": owner, "name": name}
+
+
+async def repo_config_for_workspace(full_name: str | None) -> dict[str, str] | None:
+    if not isinstance(full_name, str) or not full_name.strip():
+        return None
+    try:
+        normalized = normalize_repo_full_name(full_name)
+    except ValueError as exc:
+        raise HTTPException(422, str(exc)) from exc
+    await require_repo_access_for_workspace(normalized)
+    owner, name = normalized.split("/", 1)
+    return {"owner": owner, "name": name}

--- a/agent/dashboard/schedules.py
+++ b/agent/dashboard/schedules.py
@@ -12,10 +12,9 @@ from pydantic import BaseModel, Field, field_validator
 from agent.dashboard.admin import is_admin
 from agent.dashboard.options import gate_fable_model, normalize_model_choice
 from agent.dashboard.profiles import get_profile, get_valid_access_token
-from agent.dashboard.repo_access import repo_config_for_user, require_repo_access_for_user
+from agent.dashboard.repo_access import repo_config_for_user, require_repo_access_for_workspace
 from agent.dashboard.team_settings import get_team_fable_enabled
 from agent.dashboard.threads.access import agent_version_metadata, resolve_run_email
-from agent.dashboard.user_mappings import slack_id_for_login
 from agent.dispatch import create_durable_run
 from agent.input_messages import InputMessageContext, build_run_input
 from agent.invocation import new_invocation_id, with_invocation_id
@@ -28,7 +27,6 @@ from agent.slack.client import (
 from agent.source_context import SourceContext
 from agent.store import delete_value, get_value, now_iso, now_ms, put_value, search_all_values
 from agent.utils.thread_ops import langgraph_client
-from agent.utils.thread_participants import PARTICIPANT_LOGINS_KEY, merge_participants
 
 logger = logging.getLogger(__name__)
 
@@ -277,7 +275,9 @@ async def _create_cron(record: dict[str, Any]) -> str:
         metadata={
             "kind": "agent_schedule",
             "schedule_id": record["id"],
-            "github_login": record.get("created_by"),
+            "created_by": record.get("created_by"),
+            "owner_type": "system",
+            "visibility": "public",
             **agent_version_metadata(),
         },
     )
@@ -473,11 +473,11 @@ def _agent_run_metadata(
         "trigger_kind": "schedule_test" if test_run else "schedule",
         "schedule_id": record["id"],
         "automation_scope": "workspace",
+        "owner_type": "system",
+        "visibility": "public",
         "schedule_name": record.get("name"),
         "schedule_test": test_run,
-        "github_login": record.get("created_by"),
-        PARTICIPANT_LOGINS_KEY: merge_participants(None, record.get("created_by")),
-        "triggering_user_email": record.get("user_email"),
+        "created_by": record.get("created_by"),
         "title": f"{title_prefix}: {record.get('name') or 'Agent'}",
         "base_branch": record.get("base_branch") or "main",
         "branch_prefix": record.get("branch_prefix"),
@@ -508,8 +508,6 @@ async def _agent_run_config(
         {
             "thread_id": thread_id,
             "source": "schedule",
-            "github_login": record.get("created_by"),
-            "user_email": record.get("user_email"),
             "schedule_id": record["id"],
             "schedule_test": test_run,
         },
@@ -553,23 +551,9 @@ async def _launch_agent_schedule_record(
 
     repo = record.get("repo") if isinstance(record.get("repo"), dict) else None
     full_name = _repo_full_name(repo)
-    login = record.get("created_by")
     if full_name:
-        if not (isinstance(login, str) and login):
-            await _put_run_state(
-                record,
-                {
-                    "last_error": "schedule owner unavailable",
-                    "last_error_at": now_iso(),
-                },
-            )
-            return {
-                "status": "unauthorized",
-                "schedule_id": schedule_id,
-                "error": "schedule owner unavailable",
-            }
         try:
-            await require_repo_access_for_user(login, full_name)
+            await require_repo_access_for_workspace(full_name)
         except HTTPException as exc:
             await _put_run_state(
                 record,
@@ -611,11 +595,6 @@ async def _launch_agent_schedule_record(
             "channel_id": slack_channel_id,
             "thread_ts": message_ts,
             "triggering_event_ts": message_ts,
-            "triggering_user_id": await slack_id_for_login(
-                record.get("created_by") if isinstance(record.get("created_by"), str) else None
-            )
-            or "",
-            "triggering_user_email": record.get("user_email") or "",
         }
         await bind_slack_thread_id(client, slack_channel_id, message_ts, thread_id)
 

--- a/agent/dashboard/schedules.py
+++ b/agent/dashboard/schedules.py
@@ -12,13 +12,18 @@ from pydantic import BaseModel, Field, field_validator
 from agent.dashboard.admin import is_admin
 from agent.dashboard.options import gate_fable_model, normalize_model_choice
 from agent.dashboard.profiles import get_profile, get_valid_access_token
-from agent.dashboard.repo_access import repo_config_for_user, require_repo_access_for_workspace
+from agent.dashboard.repo_access import (
+    repo_config_for_user,
+    repo_config_for_workspace,
+    require_repo_access_for_workspace,
+)
 from agent.dashboard.team_settings import get_team_fable_enabled
 from agent.dashboard.threads.access import agent_version_metadata, resolve_run_email
 from agent.dispatch import create_durable_run
 from agent.input_messages import InputMessageContext, build_run_input
 from agent.invocation import new_invocation_id, with_invocation_id
 from agent.prompts import render_prompt
+from agent.run_config import RunConfig
 from agent.slack.client import (
     bind_slack_thread_id,
     post_slack_top_level_message_with_ts,
@@ -26,6 +31,7 @@ from agent.slack.client import (
 )
 from agent.source_context import SourceContext
 from agent.store import delete_value, get_value, now_iso, now_ms, put_value, search_all_values
+from agent.utils.json_types import thread_metadata
 from agent.utils.thread_ops import langgraph_client
 
 logger = logging.getLogger(__name__)
@@ -302,13 +308,20 @@ async def create_agent_schedule(
     *,
     email: str | None = None,
     allow_admin_thread: bool = False,
+    use_workspace_credentials: bool = False,
 ) -> dict[str, Any]:
     if body.admin_thread and not allow_admin_thread:
         raise HTTPException(403, "admin only")
-    await _ensure_dashboard_github_token(login)
-    profile = await get_profile(login) or {}
+    if use_workspace_credentials:
+        profile: dict[str, Any] = {}
+        repo = await repo_config_for_workspace(body.repo)
+        run_email = email
+    else:
+        await _ensure_dashboard_github_token(login)
+        profile = await get_profile(login) or {}
+        repo = await repo_config_for_user(login, body.repo)
+        run_email = await resolve_run_email(login, profile) or email
     chosen_model, chosen_effort = normalize_model_choice(body.model_id, body.effort)
-    repo = await repo_config_for_user(login, body.repo)
     schedule_id = str(uuid.uuid4())
     now = now_iso()
     record: dict[str, Any] = {
@@ -334,7 +347,7 @@ async def create_agent_schedule(
         "scope": "workspace",
         "created_by": login,
         "updated_by": login,
-        "user_email": (await resolve_run_email(login, profile) or email or "").strip().lower(),
+        "user_email": (run_email or "").strip().lower(),
         "created_at": now,
         "updated_at": now,
     }
@@ -356,6 +369,7 @@ async def update_agent_schedule(
     *,
     email: str | None = None,
     allow_admin_thread: bool = False,
+    use_workspace_credentials: bool = False,
 ) -> dict[str, Any]:
     existing = await get_agent_schedule(schedule_id)
     _assert_schedule_exists(existing)
@@ -375,7 +389,11 @@ async def update_agent_schedule(
     if body.name is not None:
         patch["name"] = body.name.strip() or _derive_name(patch.get("prompt", existing["prompt"]))
     if body.repo is not None:
-        patch["repo"] = await repo_config_for_user(existing["created_by"], body.repo)
+        patch["repo"] = (
+            await repo_config_for_workspace(body.repo)
+            if use_workspace_credentials
+            else await repo_config_for_user(existing["created_by"], body.repo)
+        )
     if body.model_id is not None or body.effort is not None:
         model, effort = normalize_model_choice(body.model_id, body.effort)
         if model and effort:
@@ -453,6 +471,33 @@ def _admin_thread_enabled(record: dict[str, Any]) -> bool:
         email if isinstance(email, str) else None,
         login=login if isinstance(login, str) else None,
     )
+
+
+async def authorized_admin_schedule(cfg: RunConfig) -> dict[str, Any] | None:
+    """Verify a system admin grant against its saved invocation and current schedule."""
+    if (
+        cfg.source != "schedule"
+        or cfg.admin_thread is not True
+        or not cfg.thread_id
+        or not cfg.invocation_id
+        or cfg.github_login
+        or cfg.user_email
+    ):
+        return None
+    metadata = thread_metadata(await langgraph_client().threads.get(cfg.thread_id))
+    if metadata.get("owner_type") != "system" or metadata.get("visibility") != "public":
+        return None
+    grant = metadata.get("system_authorization")
+    if (
+        not isinstance(grant, dict)
+        or grant.get("invocation_id") != cfg.invocation_id
+        or not isinstance(schedule_id := grant.get("schedule_id"), str)
+        or not schedule_id
+        or schedule_id != cfg.schedule_id
+    ):
+        return None
+    record = await get_agent_schedule(schedule_id)
+    return record if record and _admin_thread_enabled(record) else None
 
 
 def _agent_run_metadata(
@@ -599,6 +644,9 @@ async def _launch_agent_schedule_record(
         await bind_slack_thread_id(client, slack_channel_id, message_ts, thread_id)
 
     admin_thread = _admin_thread_enabled(record)
+    run_config = await _agent_run_config(
+        record, thread_id, slack_thread, test_run=test_run, admin_thread=admin_thread
+    )
     metadata = _agent_run_metadata(
         record,
         thread_id,
@@ -606,6 +654,11 @@ async def _launch_agent_schedule_record(
         test_run=test_run,
         admin_thread=admin_thread,
     )
+    if admin_thread:
+        metadata["system_authorization"] = {
+            "schedule_id": schedule_id,
+            "invocation_id": run_config["configurable"]["invocation_id"],
+        }
     await client.threads.create(thread_id=thread_id, metadata=metadata, if_exists="do_nothing")
     await client.threads.update(thread_id=thread_id, metadata=metadata)
     input_context: InputMessageContext = {
@@ -635,13 +688,7 @@ async def _launch_agent_schedule_record(
             ),
         ),
         source="schedule",
-        config=await _agent_run_config(
-            record,
-            thread_id,
-            slack_thread,
-            test_run=test_run,
-            admin_thread=admin_thread,
-        ),
+        config=run_config,
         client=client,
         stream_resumable=True,
     )

--- a/agent/dashboard/threads/api.py
+++ b/agent/dashboard/threads/api.py
@@ -493,7 +493,8 @@ async def continue_thread_privately(
         {
             "source": _DASHBOARD_SOURCE,
             "origin": _DASHBOARD_SOURCE,
-            "owner_login": login.strip().lower(),
+            "owner_type": "user",
+            "owner_login": login.strip(),
             "visibility": "private",
             "continued_from_thread_id": thread_id,
             "thread_category": "interactive",

--- a/agent/dashboard/threads/runs.py
+++ b/agent/dashboard/threads/runs.py
@@ -640,7 +640,7 @@ async def _enrich_run_start_command(
             **{
                 key: value
                 for key, value in run_metadata.items()
-                if key not in {"visibility", "owner_type", "owner_login"}
+                if key not in {"visibility", "owner_type", "owner_login", "system_authorization"}
             },
             **agent_version_metadata(),
         },

--- a/agent/dashboard/threads/runs.py
+++ b/agent/dashboard/threads/runs.py
@@ -242,7 +242,8 @@ async def _create_dashboard_thread_record(
     metadata: dict[str, Any] = {
         "source": _DASHBOARD_SOURCE,
         "origin": _DASHBOARD_SOURCE,
-        "owner_login": login.strip().lower(),
+        "owner_type": "user",
+        "owner_login": login.strip(),
         "visibility": visibility,
         "thread_category": "interactive",
         "trigger_kind": "user",
@@ -639,7 +640,7 @@ async def _enrich_run_start_command(
             **{
                 key: value
                 for key, value in run_metadata.items()
-                if key not in {"visibility", "owner_login"}
+                if key not in {"visibility", "owner_type", "owner_login"}
             },
             **agent_version_metadata(),
         },

--- a/agent/github/token.py
+++ b/agent/github/token.py
@@ -12,11 +12,12 @@ from langgraph.graph.state import RunnableConfig
 from langgraph_sdk import get_client
 
 from agent.config import ENV
+from agent.credential_scope import private_credential_login
 from agent.github.app import get_github_app_installation_token_with_expiry
 from agent.github.thread_token import (
     cache_github_token_for_thread,
-    get_github_token_from_thread,
     github_token_principal,
+    invalidate_cached_github_token,
 )
 from agent.linear.client import comment_on_linear_issue
 from agent.run_config import RunConfig
@@ -457,13 +458,10 @@ async def _resolve_bot_installation_token(thread_id: str) -> tuple[str, str | No
     bot_token, expires_at = await get_github_app_installation_token_with_expiry()
     if not bot_token:
         raise RuntimeError(
-            "Bot-token-only mode is active (LANGSMITH_API_KEY set without "
-            "X_SERVICE_AUTH_JWT_SECRET) but the GitHub App is not configured. "
+            "The GitHub App is not configured for workspace authentication. "
             "Set GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY, and GITHUB_APP_INSTALLATION_ID."
         )
-    logger.info(
-        "Using GitHub App installation token for thread %s (bot-token-only mode)", thread_id
-    )
+    logger.info("Using GitHub App installation token", extra={"thread_id": thread_id})
     return _cache_resolved_github_token(
         thread_id, bot_token, expires_at=expires_at, is_bot_token=True
     )
@@ -472,66 +470,13 @@ async def _resolve_bot_installation_token(thread_id: str) -> tuple[str, str | No
 async def resolve_github_token(
     config: Mapping[str, Any] | RunnableConfig, thread_id: str
 ) -> tuple[str, str | None]:
-    """Resolve a GitHub token from the run config based on the source.
-
-    Routes to the correct auth method depending on the source. Sources that
-    carry a mapped GitHub login (Slack, Linear, dashboard, schedule) resolve a
-    per-user OAuth token from the dashboard store; GitHub runs are login-based;
-    otherwise resolution falls back to email-based auth.
-
-    In bot-token-only mode (LANGSMITH_API_KEY set without
-    X_SERVICE_AUTH_JWT_SECRET), the GitHub App installation token is used
-    for all operations instead of per-user OAuth tokens.
-
-    Raises:
-        RuntimeError: If source is missing or token resolution fails.
-    """
+    """Use workspace bot auth publicly and the verified owner's OAuth privately."""
     cfg = RunConfig.from_config(config)
-    source = cfg.source
-    if not source:
-        logger.error("Missing source for thread %s; cannot route auth failure responses", thread_id)
-        raise RuntimeError(f"GitHub auth failed for thread {thread_id}: missing source")
-
-    github_login = cfg.github_login
-
-    # Per-user OAuth from the dashboard store wins even in bot-token-only mode,
-    # for sources that carry a mapped GitHub login (Slack, Linear, dashboard).
-    # This is what lets the agent open PRs as the triggering user.
-    if (
-        source in ("slack", "linear", "dashboard", "schedule")
-        and github_login
-        and github_login.strip()
-    ):
-        try:
-            user_token = await _resolve_dashboard_user_token(thread_id, github_login)
-        except ValueError as exc:
-            logger.error("GitHub auth failed for thread %s: %s", thread_id, str(exc))
-            raise RuntimeError(str(exc)) from exc
-        if user_token is not None:
-            return user_token
-        # No valid user token. In bot-token-only mode fall back to the bot so the
-        # deployment stays functional; otherwise block and require auth.
-        if is_bot_token_only_mode():
-            return await _resolve_bot_installation_token(thread_id)
-        raise GitHubUserAuthRequired(source, github_login)
-
-    if is_bot_token_only_mode():
+    login = await private_credential_login(config, thread_id=thread_id)
+    await invalidate_cached_github_token(thread_id)
+    if login is None:
         return await _resolve_bot_installation_token(thread_id)
-
-    try:
-        if source == "github":
-            cached_token, cached_expires_at = await get_github_token_from_thread(
-                thread_id, principal=github_token_principal(login=github_login)
-            )
-            if cached_token:
-                return cached_token, cached_expires_at
-            from agent.dashboard.user_mappings import email_for_login
-
-            email = await email_for_login(github_login)
-            if not email:
-                raise ValueError(f"No email mapping found for GitHub user '{github_login}'")
-            return await resolve_token_from_email(email, source)
-        return await resolve_token_from_email(cfg.user_email, source)
-    except ValueError as exc:
-        logger.error("GitHub auth failed for thread %s: %s", thread_id, str(exc))
-        raise RuntimeError(str(exc)) from exc
+    user_token = await _resolve_dashboard_user_token(thread_id, login)
+    if user_token is None:
+        raise GitHubUserAuthRequired(cfg.source or "private", login)
+    return user_token

--- a/agent/middleware/__init__.py
+++ b/agent/middleware/__init__.py
@@ -31,6 +31,7 @@ _MIDDLEWARE_MODULES = {
     "TimeoutWrapupMiddleware": ".timeout_wrapup",
     "ToolErrorMiddleware": ".tool_error_handler",
     "WorkflowPushGuardMiddleware": ".workflow_push_guard",
+    "WorkspaceSkillsMiddleware": ".workspace_skills",
 }
 
 __all__ = [
@@ -55,6 +56,7 @@ __all__ = [
     "ToolErrorMiddleware",
     "TimeoutWrapupMiddleware",
     "WorkflowPushGuardMiddleware",
+    "WorkspaceSkillsMiddleware",
     "check_message_queue_before_model",
     "notify_step_limit_reached",
     "record_run_usage",
@@ -90,6 +92,7 @@ if TYPE_CHECKING:
     from agent.middleware.timeout_wrapup import TimeoutWrapupMiddleware
     from agent.middleware.tool_error_handler import ToolErrorMiddleware
     from agent.middleware.workflow_push_guard import WorkflowPushGuardMiddleware
+    from agent.middleware.workspace_skills import WorkspaceSkillsMiddleware
 
 
 def _load_export(name: str) -> Any:

--- a/agent/middleware/workspace_skills.py
+++ b/agent/middleware/workspace_skills.py
@@ -1,0 +1,45 @@
+"""Exclude personal skill context retained by legacy public checkpoints."""
+
+from collections.abc import Awaitable, Callable
+from typing import Any, cast
+
+from deepagents.middleware.skills import SkillsMiddleware, SkillsState, SkillsStateUpdate
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
+from langchain_core.runnables import RunnableConfig
+from langgraph.runtime import Runtime
+
+
+class WorkspaceSkillsMiddleware(SkillsMiddleware):
+    @property
+    def name(self) -> str:
+        # Replace the built-in middleware in its existing stack position.
+        return "SkillsMiddleware"
+
+    def _scoped_state(self, state: dict[str, Any]) -> SkillsState:
+        scoped = dict(state)
+        if "skills_metadata" in scoped:
+            scoped["skills_metadata"] = [
+                skill
+                for skill in scoped["skills_metadata"]
+                if isinstance(skill, dict)
+                and isinstance(skill.get("path"), str)
+                and skill["path"].startswith(tuple(self.sources))
+            ]
+        scoped["skills_load_errors"] = []
+        return cast(SkillsState, scoped)
+
+    async def abefore_agent(
+        self, state: SkillsState, runtime: Runtime, config: RunnableConfig
+    ) -> SkillsStateUpdate | None:
+        scoped = self._scoped_state(cast(dict[str, Any], state))
+        loaded = await super().abefore_agent(scoped, runtime, config)
+        return loaded or {
+            "skills_metadata": scoped.get("skills_metadata", []),
+            "skills_load_errors": [],
+        }
+
+    async def awrap_model_call(
+        self, request: ModelRequest, handler: Callable[[ModelRequest], Awaitable[ModelResponse]]
+    ) -> ModelResponse:
+        request = request.override(state=self._scoped_state(cast(dict[str, Any], request.state)))
+        return await super().awrap_model_call(request, handler)

--- a/agent/middleware/workspace_skills.py
+++ b/agent/middleware/workspace_skills.py
@@ -1,4 +1,4 @@
-"""Exclude personal skill context retained by legacy public checkpoints."""
+"""Exclude personal skill context retained by public thread checkpoints."""
 
 from collections.abc import Awaitable, Callable
 from typing import Any, cast

--- a/agent/server.py
+++ b/agent/server.py
@@ -65,6 +65,7 @@ from agent.dashboard.options import (
     gate_fable_model,
     model_supports_effort,
 )
+from agent.dashboard.schedules import authorized_admin_schedule
 from agent.dashboard.skills import ORGANIZATION_SKILLS_NAMESPACE, SKILLS_NAMESPACE
 from agent.dashboard.team_settings import (
     get_effective_gateway_enabled,
@@ -471,6 +472,8 @@ def environment_slug(cfg: RunConfig) -> str | None:
 
 async def _workspace_admin(config: RunnableConfig, profile_login: str | None) -> bool:
     cfg = RunConfig.from_config(config)
+    if cfg.source == "schedule":
+        return await authorized_admin_schedule(cfg) is not None
     login = profile_login or cfg.github_login
     if is_admin(cfg.user_email, login=login):
         return True
@@ -482,7 +485,8 @@ async def _admin_thread(config: RunnableConfig, profile_login: str | None) -> bo
 
     The dashboard only stamps ``admin_thread`` for an admin session, but the flag
     is re-checked here against ``CONFIGURED_ADMINS`` so a thread cannot carry the
-    capability to a non-admin who later messages it.
+    capability to a non-admin who later messages it. Scheduled runs instead verify
+    the saved authorization for their specific invocation.
     """
     return RunConfig.from_config(config).admin_thread is True and await _workspace_admin(
         config, profile_login

--- a/agent/server.py
+++ b/agent/server.py
@@ -45,6 +45,7 @@ from langchain.agents.middleware.types import AgentMiddleware
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage
 
+from agent.credential_scope import private_credential_login
 from agent.dashboard.admin import is_admin
 from agent.dashboard.agent_overrides import (
     load_profile,
@@ -105,6 +106,7 @@ from agent.middleware import (
     TimeoutWrapupMiddleware,
     ToolErrorMiddleware,
     WorkflowPushGuardMiddleware,
+    WorkspaceSkillsMiddleware,
     check_message_queue_before_model,
     notify_step_limit_reached,
     record_run_usage,
@@ -408,6 +410,7 @@ def _general_purpose_subagent(
     *,
     sandbox_file_downloads: bool = False,
     offloading: ConversationOffloadingMiddleware | None = None,
+    workspace_skills: WorkspaceSkillsMiddleware | None = None,
 ) -> SubAgent:
     subagent: SubAgent = {
         "name": GENERAL_PURPOSE_SUBAGENT["name"],
@@ -423,10 +426,14 @@ def _general_purpose_subagent(
         + GENERAL_PURPOSE_SUBAGENT["system_prompt"],
         "model": model,
         "tools": [tool for tool in tools if not _is_subagent_excluded_tool(tool)],
-        "middleware": [
-            *_subagent_middleware(dynamic_tools),
-            *([offloading] if offloading else []),
-        ],
+        "middleware": cast(
+            list[AgentMiddleware[Any, Any, Any]],
+            [
+                *([workspace_skills] if workspace_skills else []),
+                *_subagent_middleware(dynamic_tools),
+                *([offloading] if offloading else []),
+            ],
+        ),
     }
     if skills:
         subagent["skills"] = skills
@@ -606,10 +613,12 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
         draft_prs: bool,
         plan_mode: bool,
         admin_environments: bool,
+        credential_login: str | None = None,
     ) -> None:
         self._thread_id = thread_id
         self._config = config
         self._profile_login = profile_login
+        self._credential_login = credential_login
         self._repo_instructions = repo_instructions
         self._model_id = model_id
         self._effort = effort
@@ -625,6 +634,7 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
     def _prepare_config_fingerprint(self) -> Any:
         cfg = RunConfig.from_config(self._config)
         return {
+            "credential_login": self._credential_login,
             "invocation_id": cfg.invocation_id,
             "thread_id": self._thread_id,
             "source": self._source,
@@ -741,7 +751,7 @@ class PrepareAgentRunMiddleware(BasePrepareRunMiddleware):
             environment = await resolve_environment(environment_slug(cfg))
         async with aphase(self._thread_id, "prepare.sender_context"):
             sender_instructions, participant_identities = await asyncio.gather(
-                _resolve_user_custom_instructions(self._profile_login),
+                _resolve_user_custom_instructions(self._credential_login),
                 _thread_participant_identities(self._thread_id),
             )
             sender_context = construct_sender_context(
@@ -825,6 +835,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         ).with_config(bindable_config(config))
 
     profile_login = resolve_github_login(as_json_object(config))
+    credential_login = None if is_desktop_run(cfg) else await private_credential_login(config)
 
     async def reconnect_backend(
         _thread_id: str = thread_id,
@@ -841,7 +852,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
     backend.start()
 
     # `profile_login` is whoever sent the message that started this run; it drives
-    # authorization and credentialed integrations, which stay personal to them.
+    # authorization. Personal integrations require verified private ownership.
     # Everything else comes from the thread's own settings, seeded from the first
     # sender's profile and frozen there afterwards.
     local_run = is_desktop_run(cfg)
@@ -1052,7 +1063,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             _phase_result(
                 thread_id,
                 "factory.notion_tools",
-                lambda: _notion_tools_for(profile_login),
+                lambda: _notion_tools_for(credential_login),
             ),
         )
 
@@ -1104,6 +1115,14 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         slack_thread_reply,
         *(ADMIN_TOOLS if admin_thread else ()),
     ]
+    if credential_login is None:
+        personal_tools = (
+            save_user_instructions,
+            save_user_skill,
+            delete_user_skill,
+            read_user_settings,
+        )
+        static_tools = [tool for tool in static_tools if tool not in personal_tools]
     if not _slack_tools_enabled(cfg):
         static_tools = [tool for tool in static_tools if tool not in slack_tools]
     static_tools = apply_tool_descriptions(static_tools)
@@ -1147,10 +1166,10 @@ async def get_agent(config: RunnableConfig) -> Pregel:
             StoreBackend(namespace=lambda _runtime: (ORGANIZATION_SKILLS_NAMESPACE,))
         )
         skill_sources = [ORGANIZATION_SKILLS_ROUTE, BUNDLED_SKILLS_ROUTE]
-        if profile_login:
+        if credential_login:
             skill_routes[USER_SKILLS_ROUTE] = ReadOnlyBackend(
                 StoreBackend(
-                    namespace=lambda _runtime, login=profile_login: (SKILLS_NAMESPACE, login)
+                    namespace=lambda _runtime, login=credential_login: (SKILLS_NAMESPACE, login)
                 )
             )
             skill_sources.insert(0, USER_SKILLS_ROUTE)
@@ -1192,6 +1211,11 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         use_gateway=use_gateway,
         **title_model_kwargs,
     )
+    workspace_skills = (
+        WorkspaceSkillsMiddleware(backend=agent_backend, sources=skill_sources)
+        if credential_login is None and not local_run
+        else None
+    )
     return create_deep_agent(
         model=main_model,
         system_prompt="",
@@ -1201,6 +1225,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                 subagent_model,
                 tools=subagent_tools,
                 skills=skill_sources,
+                workspace_skills=workspace_skills,
                 dynamic_tools=dynamic_tool_middleware,
                 sandbox_file_downloads=sandbox_file_downloads,
                 offloading=ConversationOffloadingMiddleware(subagent_model, agent_backend),
@@ -1216,6 +1241,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                     main_model, agent_backend, manual=cfg.offload_conversation is True
                 ),
                 PrepareAgentRunMiddleware(
+                    credential_login=credential_login,
                     thread_id=thread_id,
                     config=config,
                     profile_login=profile_login,
@@ -1231,6 +1257,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                     plan_mode=plan_mode,
                     admin_environments=admin_thread,
                 ),
+                *([workspace_skills] if workspace_skills else []),
                 *([dynamic_tool_middleware] if dynamic_tool_middleware else []),
                 SanitizeToolInputsMiddleware(),
                 ModelCallLimitMiddleware(run_limit=MODEL_CALL_RECURSION_LIMIT, exit_behavior="end"),

--- a/agent/tool_loaders/notion_mcp.py
+++ b/agent/tool_loaders/notion_mcp.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 
 from langchain_core.tools import BaseTool
 
+from agent.credential_scope import private_credential_login
 from agent.dashboard.notion_oauth import NOTION_MCP_URL
 from agent.dashboard.user_credentials import get_notion_access_token
 from agent.utils.thread_participants import resolve_participant
@@ -34,7 +35,10 @@ async def _build_mcp_tools(access_token: str) -> list[BaseTool]:
 
 
 async def _fresh_mcp_tool(login: str, tool_name: str) -> BaseTool:
-    access_token = await get_notion_access_token(login)
+    owner = await private_credential_login()
+    if owner is None or owner.lower() != login.strip().lower():
+        raise RuntimeError("Personal Notion MCP tools require the private thread owner")
+    access_token = await get_notion_access_token(owner)
     if not access_token:
         raise RuntimeError(
             "Notion MCP authorization unavailable; reconnect Notion in Profile Settings"
@@ -107,14 +111,11 @@ def _refreshing_tool(tool: BaseTool) -> BaseTool:
 
 
 async def load_notion_tools(login: str) -> list[BaseTool]:
-    """Return Notion MCP tool definitions, keyed to no particular user.
-
-    ``login`` only supplies a token to read the hosted server's tool list; the
-    resulting definitions are identical for every user, so the agent's tool
-    schema does not change when a different person replies in a thread. Each
-    call names the participant to act for and resolves that person's token then.
-    """
-    access_token = await get_notion_access_token(login)
+    """Load the private owner's personal Notion tools."""
+    owner = await private_credential_login()
+    if owner is None or owner.lower() != login.strip().lower():
+        return []
+    access_token = await get_notion_access_token(owner)
     if not access_token:
         return []
     try:

--- a/agent/tools/admin_gate.py
+++ b/agent/tools/admin_gate.py
@@ -1,10 +1,10 @@
 """Admin gate for tools wired only into admin threads.
 
-Tools re-check the triggering user against ``CONFIGURED_ADMINS`` so a thread whose
-metadata says "admin" cannot act on behalf of someone who is not one.
+Tools recheck user admin membership or a system invocation's saved authorization.
 """
 
 from agent.dashboard.admin import is_admin
+from agent.dashboard.schedules import authorized_admin_schedule
 from agent.run_config import RunConfig
 
 
@@ -15,9 +15,14 @@ def configurable() -> RunConfig:
         return RunConfig()
 
 
-def require_admin(action: str) -> str | None:
-    """Return an error message when the triggering user is not an admin."""
+async def require_admin(action: str) -> str | None:
+    """Recheck either the triggering admin or the saved system authorization."""
     cfg = configurable()
-    if is_admin(cfg.user_email, login=cfg.github_login):
+    allowed = (
+        await authorized_admin_schedule(cfg) is not None
+        if cfg.source == "schedule"
+        else is_admin(cfg.user_email, login=cfg.github_login)
+    )
+    if allowed:
         return None
     return f"Only workspace admins can {action}."

--- a/agent/tools/automations.py
+++ b/agent/tools/automations.py
@@ -11,8 +11,14 @@ from agent.tools.admin_gate import configurable, require_admin
 logger = logging.getLogger(__name__)
 
 
-def _identity() -> tuple[str, str | None] | None:
+async def _identity() -> tuple[str, str | None] | None:
     cfg = configurable()
+    if cfg.source == "schedule":
+        record = await schedules.authorized_admin_schedule(cfg)
+        if not record:
+            return None
+        login = record.get("created_by") or f"system:schedule:{record['id']}"
+        return login, record.get("user_email") or None
     if not cfg.github_login:
         return None
     return cfg.github_login, cfg.user_email or None
@@ -27,7 +33,7 @@ def _error(exc: Exception) -> dict[str, Any]:
 
 async def list_automations() -> dict[str, Any]:
     """Implement the `list_automations` tool."""
-    if error := require_admin("manage workspace automations"):
+    if error := await require_admin("manage workspace automations"):
         return {"ok": False, "error": error}
     return {"ok": True, "automations": await schedules.list_agent_schedules()}
 
@@ -44,9 +50,9 @@ async def create_automation(
     admin_thread: bool = False,
 ) -> dict[str, Any]:
     """Implement the `create_automation` tool."""
-    if error := require_admin("manage workspace automations"):
+    if error := await require_admin("manage workspace automations"):
         return {"ok": False, "error": error}
-    identity = _identity()
+    identity = await _identity()
     if identity is None:
         return {"ok": False, "error": "No GitHub identity is available for this admin thread."}
     login, email = identity
@@ -66,6 +72,7 @@ async def create_automation(
             ),
             email=email,
             allow_admin_thread=True,
+            use_workspace_credentials=configurable().source == "schedule",
         )
     except Exception as exc:
         return _error(exc)
@@ -88,9 +95,9 @@ async def update_automation(
     admin_thread: bool | None = None,
 ) -> dict[str, Any]:
     """Implement the `update_automation` tool."""
-    if error := require_admin("manage workspace automations"):
+    if error := await require_admin("manage workspace automations"):
         return {"ok": False, "error": error}
-    identity = _identity()
+    identity = await _identity()
     if identity is None:
         return {"ok": False, "error": "No GitHub identity is available for this admin thread."}
     if clear_repo and repo is not None:
@@ -122,6 +129,7 @@ async def update_automation(
             schedules.ScheduleUpdateBody(**values),
             email=identity[1],
             allow_admin_thread=True,
+            use_workspace_credentials=configurable().source == "schedule",
         )
     except Exception as exc:
         return _error(exc)
@@ -130,7 +138,7 @@ async def update_automation(
 
 async def trigger_automation(automation_id: str) -> dict[str, Any]:
     """Implement the `trigger_automation` tool."""
-    if error := require_admin("manage workspace automations"):
+    if error := await require_admin("manage workspace automations"):
         return {"ok": False, "error": error}
     try:
         result = await schedules.trigger_agent_schedule(automation_id)
@@ -141,7 +149,7 @@ async def trigger_automation(automation_id: str) -> dict[str, Any]:
 
 async def delete_automation(automation_id: str) -> dict[str, Any]:
     """Implement the `delete_automation` tool."""
-    if error := require_admin("manage workspace automations"):
+    if error := await require_admin("manage workspace automations"):
         return {"ok": False, "error": error}
     try:
         await schedules.delete_agent_schedule(automation_id)

--- a/agent/tools/background_task.py
+++ b/agent/tools/background_task.py
@@ -72,7 +72,7 @@ async def background_task(
             return {"success": True, "tasks": await _list_all()}
         assert task_id is not None
         provider = next(p for p in _providers() if p.owns(task_id))
-        if provider.admin_only and (denied := require_admin(f"read {provider.name} tasks")):
+        if provider.admin_only and (denied := await require_admin(f"read {provider.name} tasks")):
             return {"success": False, "error": denied}
         result = await (provider.status if action == "status" else provider.stop)(task_id)
         return {"success": True, **result}
@@ -89,7 +89,7 @@ async def _list_all() -> list[dict[str, Any]]:
     """
     tasks: list[dict[str, Any]] = []
     for provider in _providers():
-        if provider.admin_only and require_admin(f"list {provider.name} tasks"):
+        if provider.admin_only and await require_admin(f"list {provider.name} tasks"):
             continue
         try:
             tasks.extend(await provider.list_all())

--- a/agent/tools/environments.py
+++ b/agent/tools/environments.py
@@ -1,8 +1,6 @@
 """Admin-thread tools for managing environments.
 
-Wired into the agent only for admin threads (see ``agent/server.py``). Every tool
-re-checks the triggering user against ``CONFIGURED_ADMINS`` so a thread whose
-metadata says "admin" cannot act on behalf of someone who is not one.
+Wired into admin threads; each tool rechecks user or system authorization.
 """
 
 import logging
@@ -16,8 +14,8 @@ from agent.tools.admin_gate import require_admin
 logger = logging.getLogger(__name__)
 
 
-def _require_admin() -> str | None:
-    return require_admin("manage environments")
+async def _require_admin() -> str | None:
+    return await require_admin("manage environments")
 
 
 # Deliberately narrower than the record: the agent has no use for authorship
@@ -85,7 +83,7 @@ async def list_environments() -> dict[str, Any]:
     Returns:
         ``{"ok": True, "environments": [...]}``.
     """
-    if error := _require_admin():
+    if error := await _require_admin():
         return {"ok": False, "error": error}
     records = await store.ENVIRONMENTS.list_all()
     return {
@@ -114,7 +112,7 @@ async def publish_environment(
     clear_create_params: bool = False,
 ) -> dict[str, Any]:
     """Implement the `publish_environment` tool."""
-    if error := _require_admin():
+    if error := await _require_admin():
         return {"ok": False, "error": error}
     sizing = {
         "mem_bytes": mem_bytes,
@@ -224,7 +222,7 @@ async def publish_environment(
 
 async def refresh_environment_start(name: str) -> dict[str, Any]:
     """Implement the `refresh_environment_start` tool."""
-    if error := _require_admin():
+    if error := await _require_admin():
         return {"status": "error", "error": error}
     try:
         slug = store.slugify(name)
@@ -235,7 +233,7 @@ async def refresh_environment_start(name: str) -> dict[str, Any]:
 
 async def delete_environment(name: str) -> dict[str, Any]:
     """Implement the `delete_environment` tool."""
-    if error := _require_admin():
+    if error := await _require_admin():
         return {"ok": False, "error": error}
     try:
         slug = store.slugify(name)

--- a/agent/tools/open_pull_request.py
+++ b/agent/tools/open_pull_request.py
@@ -1,4 +1,4 @@
-"""Open a GitHub pull request attributed to the triggering user."""
+"""Open a GitHub pull request using the thread's credential scope."""
 
 import logging
 from typing import Any
@@ -8,10 +8,12 @@ import httpx2
 from langgraph.config import get_config
 from langgraph_sdk import get_client
 
+from agent.credential_scope import private_credential_login
 from agent.dashboard.agent_usage import record_agent_pr_usage
 from agent.dashboard.plan_store import get_plan_content
 from agent.github.app import get_github_app_installation_token
 from agent.github.comments import derive_pr_state
+from agent.github.token import GitHubUserAuthRequired
 from agent.run_config import RunConfig
 from agent.slack.client import (
     get_active_slack_thread,
@@ -30,7 +32,6 @@ from agent.utils.dashboard_links import dashboard_plan_url, dashboard_thread_url
 logger = logging.getLogger(__name__)
 
 GITHUB_API = "https://api.github.com"
-_USER_TOKEN_SOURCES = ("slack", "linear", "dashboard")
 _REFERENCES_HEADING = "## References"
 _ACCESS_FAILURE_CODE = "github_app_access_missing_or_repo_not_found"
 _BRANCH_FAILURE_CODE = "github_pr_branch_not_visible"
@@ -50,31 +51,16 @@ _REPORTED_RESPONSE_HEADERS = (
 
 
 async def _resolve_pr_author_token() -> tuple[str | None, str]:
-    """Return ``(token, kind)`` for opening the PR.
+    """Return the workspace bot token or the verified private owner's token."""
+    login = await private_credential_login()
+    if login is None:
+        return await get_github_app_installation_token(), "bot"
+    from agent.dashboard.profiles import get_valid_access_token
 
-    Prefers the triggering user's OAuth token (so the PR is created *as them*)
-    for Slack/Linear/dashboard runs with a mapped GitHub login, resolving it by
-    login from the dashboard OAuth store. Falls back to the GitHub App
-    installation token (creator = open-swe[bot]) for GitHub-triggered runs,
-    unmapped users, or bot-token-only deployments — preserving today's behavior.
-
-    The token is resolved by login rather than read from the shared thread
-    metadata: Slack thread ids are shared across a conversation, so a cached
-    token could belong to a prior triggering user.
-    """
-    cfg = RunConfig.from_runtime()
-    source = cfg.source
-    github_login = cfg.github_login
-
-    if source in _USER_TOKEN_SOURCES and github_login and github_login.strip():
-        from agent.dashboard.profiles import get_valid_access_token
-
-        user_token = await get_valid_access_token(github_login.strip())
-        if user_token:
-            return user_token, "user"
-        logger.info("No valid user token for %s; opening PR as open-swe[bot]", github_login.strip())
-
-    return await get_github_app_installation_token(), "bot"
+    token = await get_valid_access_token(login)
+    if not token:
+        raise GitHubUserAuthRequired(RunConfig.from_runtime().source or "private", login)
+    return token, "user"
 
 
 def _auth_headers(token: str) -> dict[str, str]:

--- a/agent/tools/open_pull_request.py
+++ b/agent/tools/open_pull_request.py
@@ -8,7 +8,7 @@ import httpx2
 from langgraph.config import get_config
 from langgraph_sdk import get_client
 
-from agent.credential_scope import private_credential_login
+from agent.credential_scope import pr_author_login
 from agent.dashboard.agent_usage import record_agent_pr_usage
 from agent.dashboard.plan_store import get_plan_content
 from agent.github.app import get_github_app_installation_token
@@ -51,8 +51,8 @@ _REPORTED_RESPONSE_HEADERS = (
 
 
 async def _resolve_pr_author_token() -> tuple[str | None, str]:
-    """Return the workspace bot token or the verified private owner's token."""
-    login = await private_credential_login()
+    """Use the initiator's OAuth for user-owned threads and the bot for system threads."""
+    login = await pr_author_login()
     if login is None:
         return await get_github_app_installation_token(), "bot"
     from agent.dashboard.profiles import get_valid_access_token

--- a/agent/tools/open_pull_request.py
+++ b/agent/tools/open_pull_request.py
@@ -8,7 +8,7 @@ import httpx2
 from langgraph.config import get_config
 from langgraph_sdk import get_client
 
-from agent.credential_scope import pr_author_login
+from agent.credential_scope import pr_author_login, private_credential_login
 from agent.dashboard.agent_usage import record_agent_pr_usage
 from agent.dashboard.plan_store import get_plan_content
 from agent.github.app import get_github_app_installation_token
@@ -61,6 +61,29 @@ async def _resolve_pr_author_token() -> tuple[str | None, str]:
     if not token:
         raise GitHubUserAuthRequired(RunConfig.from_runtime().source or "private", login)
     return token, "user"
+
+
+async def _workspace_has_repository(client: httpx2.AsyncClient, owner: str, repo: str) -> bool:
+    token = await get_github_app_installation_token()
+    if not token:
+        return False
+    page = 1
+    while True:
+        response = await client.get(
+            f"{GITHUB_API}/installation/repositories",
+            headers=_auth_headers(token),
+            params={"per_page": "100", "page": str(page)},
+        )
+        if response.status_code != 200:
+            return False
+        repositories = response.json().get("repositories", [])
+        if any(
+            item.get("full_name", "").lower() == f"{owner}/{repo}".lower() for item in repositories
+        ):
+            return True
+        if len(repositories) < 100:
+            return False
+        page += 1
 
 
 def _auth_headers(token: str) -> dict[str, str]:
@@ -806,6 +829,22 @@ async def _open_pull_request(
         )
 
     async with httpx2.AsyncClient(timeout=30.0) as client:
+        if (
+            kind == "user"
+            and await private_credential_login() is None
+            and not await _workspace_has_repository(client, owner, repo)
+        ):
+            return _access_failure_payload(
+                owner=owner,
+                repo=repo,
+                head=head,
+                base=base,
+                token_kind=kind,
+                http_status=None,
+                reason="Could not verify the target repository belongs to the workspace GitHub App installation",
+                branch_pushed=None,
+                failed_step="workspace_repo",
+            )
         preflight_failure = await _preflight_pr_access(
             client=client,
             token=token,

--- a/agent/tools/organization_skills.py
+++ b/agent/tools/organization_skills.py
@@ -14,7 +14,7 @@ async def save_organization_skill(
     name: str, description: str, instructions: str = ""
 ) -> dict[str, Any]:
     """Implement the `save_organization_skill` tool."""
-    if error := require_admin(_ACTION):
+    if error := await require_admin(_ACTION):
         return {"ok": False, "error": error}
     try:
         body = store.SkillCreate(name=name, description=description, instructions=instructions)
@@ -36,7 +36,7 @@ async def save_organization_skill(
 
 async def delete_organization_skill(name: str) -> dict[str, Any]:
     """Implement the `delete_organization_skill` tool."""
-    if error := require_admin(_ACTION):
+    if error := await require_admin(_ACTION):
         return {"ok": False, "error": error}
     try:
         await store.delete_organization_skill(name)

--- a/agent/tools/sandbox_reset.py
+++ b/agent/tools/sandbox_reset.py
@@ -46,7 +46,7 @@ class SandboxResetParams(BaseModel):
 )
 async def sandbox_reset(**create_options: Any) -> dict[str, Any]:
     """Implement the `sandbox_reset` tool."""
-    if error := require_admin("reset sandboxes"):
+    if error := await require_admin("reset sandboxes"):
         return {"success": False, "error": error}
 
     cfg = configurable()

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -69,13 +69,10 @@ from agent.github.comments import (
 from agent.github.org_membership import INTERNAL_BOT_LOGINS, is_user_active_org_member
 from agent.github.thread_token import (
     cache_github_token_for_thread,
-    get_github_token_from_thread,
-    github_token_principal,
     invalidate_cached_github_token,
 )
 from agent.github.token import (
     is_bot_token_only_mode,
-    resolve_github_token_from_email,
 )
 from agent.linear.client import post_linear_trace_comment  # noqa: F401
 from agent.linear.comments import get_recent_comments  # noqa: F401
@@ -1498,39 +1495,17 @@ async def refresh_thread_github_token_after_401(thread_id: str, email: str) -> s
 
 
 async def get_or_resolve_thread_github_token(thread_id: str, email: str) -> str | None:
-    """Resolve and cache a GitHub token for a thread when available.
-
-    In bot-token-only mode, returns a fresh GitHub App installation token
-    instead of resolving per-user OAuth tokens.
-    """
-    if is_bot_token_only_mode():
-        bot_token, expires_at = await get_github_app_installation_token_with_expiry()
-        if bot_token:
-            cache_github_token_for_thread(
-                thread_id, bot_token, expires_at=expires_at, is_bot_token=True
-            )
-            return bot_token
-        logger.warning("Bot-token-only mode but GitHub App token unavailable")
-        return None
-
-    principal = github_token_principal(email=email)
-    github_token, _expires_at = await get_github_token_from_thread(thread_id, principal=principal)
-    if github_token:
-        return github_token
-
-    auth_result = await resolve_github_token_from_email(email)
-    github_token = auth_result.get("token")
-    if not github_token:
-        return None
-
-    expires_at = auth_result.get("expires_at")
-    cache_github_token_for_thread(
-        thread_id,
-        github_token,
-        expires_at=expires_at if isinstance(expires_at, str) else None,
-        principal=principal,
-    )
-    return github_token
+    """GitHub webhook conversations always use the workspace bot identity."""
+    del email
+    await invalidate_cached_github_token(thread_id)
+    bot_token, expires_at = await get_github_app_installation_token_with_expiry()
+    if bot_token:
+        cache_github_token_for_thread(
+            thread_id, bot_token, expires_at=expires_at, is_bot_token=True
+        )
+        return bot_token
+    logger.warning("Workspace GitHub App token unavailable", extra={"thread_id": thread_id})
+    return None
 
 
 def finding_comment_ids(finding: Finding) -> set[int]:

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -748,8 +748,10 @@ async def upsert_agent_thread_metadata(
         "visibility" not in existing_meta and existing_meta.get("created_at_ms") is None
     ):
         metadata["visibility"] = visibility
-        if owner_login.strip():
-            metadata["owner_login"] = owner_login.strip().lower()
+        metadata["owner_type"] = "user"
+        initiating_login = owner_login.strip() or sender_login.strip()
+        if initiating_login:
+            metadata["owner_login"] = initiating_login
 
     try:
         if existing is None:

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -354,11 +354,16 @@ Public threads use the GitHub App installation identity for agent GitHub
 operations. PRs from user-owned threads are opened with the original initiator's
 stored GitHub OAuth token, even when another participant starts the run. If that
 token is unavailable, the initiator must sign in again; PR creation does not fall
-back to the bot. System-owned threads, including scheduled automations, open PRs
+back to the bot. Public PR creation first verifies that the target repository is
+accessible through the configured workspace installation. System-owned threads, including scheduled automations, open PRs
 as the GitHub App. Existing threads without recorded ownership retain bot PR
 authorship. Scheduled runs check repository access with the workspace GitHub App.
 They record the automation creator for auditing but do not require that person's
 OAuth token or inject their GitHub login or email as the agent's execution identity.
+Admin schedules retain their management tools through authorization tied to the
+scheduled invocation. The graph and tools recheck the creator's current admin
+status; later participants do not inherit that authorization. Automation management
+from these system runs also uses workspace credentials.
 
 Public threads load workspace MCP connections and organization skills. Personal
 Notion connections, user skills, and user custom instructions are available only in a private thread

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -227,9 +227,9 @@ On LangGraph Platform, set them under the deployment's environment variables; sa
 
 **Dashboard.** Open `<URL>`, click **Sign in with GitHub**, and you should land logged in. With your login in `CONFIGURED_ADMINS`, the **Admin** pages (Team settings, User mappings, Sandbox, Environments, …) appear. Set **Admin → Team settings → Default repository** so runs that name no repository have somewhere to go. Start a task from the composer. Every run gets a sandbox booted from LangSmith's root snapshot; when your repositories need extra toolchains preinstalled, an admin can start an **admin thread** (the Admin toggle in the composer), have the agent set the sandbox up, and capture it under **Admin → Environments** as the environment named `default`, which later runs boot from.
 
-**Slack.** Invite the bot to a channel and mention it: `@Open SWE what's in the repo?`. It replies in a thread. Runs it starts act as the GitHub App until the Slack user is linked to a GitHub login, either by signing in to the dashboard once or through [Sign in with Slack](#slack-sign-in-and-code-channels).
+**Slack.** Invite the bot to a channel and mention it: `@Open SWE what's in the repo?`. It replies in a thread. Public runs use the workspace GitHub App for agent operations, and user-owned PRs are opened as the thread's initiating GitHub user. Link the Slack user to a GitHub login before starting the thread, either by signing in to the dashboard once or through [Sign in with Slack](#slack-sign-in-and-code-channels).
 
-**GitHub.** GitHub-triggered conversations are public and use the GitHub App installation identity; the commenter must still have a linked account, and an unmapped commenter is skipped with a warning in the server log. Comment `@openswe what files are in this repo?` on an issue in a repository where the App is installed. Within a few seconds you should see a 👀 reaction, a run in your LangSmith project, and a reply comment. GitHub lists every delivery and its response under the App's **Advanced** tab.
+**GitHub.** GitHub-triggered conversations are public. Agent GitHub operations use the App installation identity, while PRs use the initiating commenter's OAuth. The commenter must have a linked account; an unmapped commenter is skipped with a warning in the server log. Comment `@openswe what files are in this repo?` on an issue in a repository where the App is installed. Within a few seconds you should see a 👀 reaction, a run in your LangSmith project, and a reply comment. GitHub lists every delivery and its response under the App's **Advanced** tab.
 
 ---
 
@@ -350,10 +350,18 @@ Shared backend startup requires at least one entry in `ALLOWED_GITHUB_ORGS` or `
 
 ### Thread credential scope
 
-Public threads, including threads without visibility metadata, use the
-GitHub App installation identity for GitHub operations and PR creation. They load
-workspace MCP connections and organization skills. Personal Notion connections,
-user skills, and user custom instructions are available only in a private thread
+Public threads use the GitHub App installation identity for agent GitHub
+operations. PRs from user-owned threads are opened with the original initiator's
+stored GitHub OAuth token, even when another participant starts the run. If that
+token is unavailable, the initiator must sign in again; PR creation does not fall
+back to the bot. System-owned threads, including scheduled automations, open PRs
+as the GitHub App. Existing threads without recorded ownership retain bot PR
+authorship. Scheduled runs check repository access with the workspace GitHub App.
+They record the automation creator for auditing but do not require that person's
+OAuth token or inject their GitHub login or email as the agent's execution identity.
+
+Public threads load workspace MCP connections and organization skills. Personal
+Notion connections, user skills, and user custom instructions are available only in a private thread
 started by its immutable owner. The same ownership check applies when a personal
 MCP tool refreshes its credentials at execution time.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -350,7 +350,7 @@ Shared backend startup requires at least one entry in `ALLOWED_GITHUB_ORGS` or `
 
 ### Thread credential scope
 
-Public threads, including legacy threads without visibility metadata, use the
+Public threads, including threads without visibility metadata, use the
 GitHub App installation identity for GitHub operations and PR creation. They load
 workspace MCP connections and organization skills. Personal Notion connections,
 user skills, and user custom instructions are available only in a private thread

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -229,7 +229,7 @@ On LangGraph Platform, set them under the deployment's environment variables; sa
 
 **Slack.** Invite the bot to a channel and mention it: `@Open SWE what's in the repo?`. It replies in a thread. Runs it starts act as the GitHub App until the Slack user is linked to a GitHub login, either by signing in to the dashboard once or through [Sign in with Slack](#slack-sign-in-and-code-channels).
 
-**GitHub.** Signing in once is also what lets GitHub-triggered runs act as you: they run as the commenting user and need the token the sign-in stored; an unmapped commenter is skipped with a warning in the server log. Comment `@openswe what files are in this repo?` on an issue in a repository where the App is installed. Within a few seconds you should see a 👀 reaction, a run in your LangSmith project, and a reply comment. GitHub lists every delivery and its response under the App's **Advanced** tab.
+**GitHub.** GitHub-triggered conversations are public and use the GitHub App installation identity; the commenter must still have a linked account, and an unmapped commenter is skipped with a warning in the server log. Comment `@openswe what files are in this repo?` on an issue in a repository where the App is installed. Within a few seconds you should see a 👀 reaction, a run in your LangSmith project, and a reply comment. GitHub lists every delivery and its response under the App's **Advanced** tab.
 
 ---
 
@@ -347,6 +347,21 @@ Shared backend startup requires at least one entry in `ALLOWED_GITHUB_ORGS` or `
 - The URL configured in GitHub, Slack, or Linear must be the deployment's URL; GitHub shows each delivery and its response under the App's **Advanced** tab. A new webhook or signing secret takes effect only after the deployment restarts with it; deliveries in between are rejected as `Invalid signature`, and Slack then needs **Retry** on its Request URL under **Event Subscriptions**.
 - Enable the right events: Issue comment and the pull request review events for GitHub, `app_mention` for Slack, Comments → Create for Linear.
 - Webhook secrets are required: without `GITHUB_WEBHOOK_SECRET`, `SLACK_SIGNING_SECRET`, or `LINEAR_WEBHOOK_SECRET`, every request to that endpoint is rejected with 401.
+
+### Thread credential scope
+
+Public threads, including legacy threads without visibility metadata, use the
+GitHub App installation identity for GitHub operations and PR creation. They load
+workspace MCP connections and organization skills. Personal Notion connections,
+user skills, and user custom instructions are available only in a private thread
+started by its immutable owner. The same ownership check applies when a personal
+MCP tool refreshes its credentials at execution time.
+
+Private threads use their owner's stored GitHub OAuth token for server-side
+GitHub operations and PR creation. If that token is unavailable, the owner must
+sign in again; the run does not fall back to the bot. Sandbox GitHub proxy access
+continues to use the GitHub App installation token in both kinds of thread.
+User identity and membership checks still apply to public runs.
 
 ### GitHub authentication errors
 

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -8,9 +8,11 @@ is what makes deepagents auto-wire `FilesystemMiddleware` tool-result eviction a
 """
 
 import asyncio
+from types import SimpleNamespace
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import langgraph_sdk
 import pytest
 from deepagents.backends.composite import CompositeBackend
 from deepagents.backends.state import StateBackend
@@ -19,6 +21,41 @@ from langgraph.graph.state import RunnableConfig
 from agent.sandboxes.read_only_backend import ReadOnlyBackend
 from agent.sandboxes.state import SANDBOX_BACKENDS, SandboxBackendProxy
 from agent.server import DesktopAgentState, _registered_tool_name, get_agent
+
+
+@pytest.fixture(autouse=True)
+def saved_thread_scope(monkeypatch):
+    metadata = {"visibility": "private", "owner_login": "octocat"}
+    monkeypatch.setattr(
+        langgraph_sdk,
+        "get_client",
+        lambda: SimpleNamespace(
+            threads=SimpleNamespace(get=AsyncMock(side_effect=lambda _id: {"metadata": metadata}))
+        ),
+    )
+    return metadata
+
+
+@pytest.mark.asyncio
+async def test_public_agent_excludes_personal_skills_and_tools(saved_thread_scope):
+    saved_thread_scope["visibility"] = "public"
+    with patch("agent.server._notion_tools_for", new_callable=AsyncMock, return_value=[]) as notion:
+        captured = await _capture_create_deep_agent_kwargs()
+    assert captured["skills"] == ["/organization-skills/", "/bundled-skills/"]
+    assert "/skills/" not in captured["backend"].routes
+    tools = captured["tools"]
+    assert isinstance(tools, list)
+    tool_names = {_registered_tool_name(tool) for tool in tools}
+    assert not tool_names.intersection(
+        {"save_user_instructions", "save_user_skill", "delete_user_skill", "read_user_settings"}
+    )
+    notion.assert_awaited_once_with(None)
+    from agent.middleware import WorkspaceSkillsMiddleware
+
+    middleware = cast(list[object], captured["middleware"])
+    assert any(isinstance(item, WorkspaceSkillsMiddleware) for item in middleware)
+    subagents = cast(list[dict], captured["subagents"])
+    assert any(isinstance(item, WorkspaceSkillsMiddleware) for item in subagents[0]["middleware"])
 
 
 class _DummyAgent:
@@ -108,7 +145,10 @@ async def _capture_create_deep_agent_kwargs(
 
 
 @pytest.mark.asyncio
-async def test_existing_thread_reloads_sender_draft_preference_into_run_config() -> None:
+async def test_existing_thread_reloads_sender_draft_preference_into_run_config(
+    saved_thread_scope,
+) -> None:
+    saved_thread_scope["owner_login"] = "draft-preference-owner"
     config = _base_config()
     configurable = config.get("configurable")
     assert isinstance(configurable, dict)

--- a/tests/agent/test_agent_schedules.py
+++ b/tests/agent/test_agent_schedules.py
@@ -1,5 +1,6 @@
 import uuid
 from typing import Any
+from unittest.mock import AsyncMock
 from xml.etree import ElementTree
 
 import httpx2
@@ -73,6 +74,10 @@ class _FakeThreads:
     async def update(self, **kwargs: Any) -> None:
         self.updated.append(kwargs)
 
+    async def get(self, thread_id: str) -> dict[str, Any]:
+        thread = next(item for item in self.created if item["thread_id"] == thread_id)
+        return {"metadata": thread["metadata"]}
+
 
 class _FakeRuns:
     def __init__(self) -> None:
@@ -125,6 +130,9 @@ def auth(monkeypatch) -> None:  # noqa: ANN001
     monkeypatch.setattr(schedules, "repo_config_for_user", fake_repo_config_for_user)
     monkeypatch.setattr(
         schedules, "require_repo_access_for_workspace", fake_require_repo_access_for_workspace
+    )
+    monkeypatch.setattr(
+        repo_access, "require_repo_access_for_workspace", fake_require_repo_access_for_workspace
     )
 
 
@@ -764,6 +772,78 @@ async def test_system_schedule_can_run_without_user_credentials(
     configurable = fake_client.runs.created[0]["config"]["configurable"]
     assert "github_login" not in configurable
     assert "user_email" not in configurable
+
+
+async def test_admin_schedule_keeps_tools_without_personal_execution_identity(
+    fake_client, auth, monkeypatch
+) -> None:  # noqa: ANN001, ARG001
+    from agent import server
+    from agent.run_config import RunConfig
+    from agent.tools import automations, environments, organization_skills
+
+    monkeypatch.setenv("CONFIGURED_ADMINS", "alice")
+    monkeypatch.setattr(server, "email_for_login", AsyncMock(return_value=None))
+    record = {
+        "id": "admin-schedule",
+        "prompt": "Manage workspace environments",
+        "enabled": True,
+        "admin_thread": True,
+        "created_by": "alice",
+    }
+    await fake_client.store.put_item(schedules.SCHEDULES_NAMESPACE, record["id"], record)
+    await schedules.launch_scheduled_agent_run(record["id"])
+    run_config = fake_client.runs.created[0]["config"]
+    monkeypatch.setattr("agent.run_config.get_config", lambda: run_config)
+
+    assert await server._admin_thread(run_config, None) is True
+    assert RunConfig.from_config(run_config).github_login is None
+    assert RunConfig.from_config(run_config).user_email is None
+    monkeypatch.setattr(environments.store.ENVIRONMENTS, "list_all", AsyncMock(return_value=[]))
+    assert (await environments.list_environments())["ok"] is True
+    assert (await automations.list_automations())["ok"] is True
+    await organization_skills.save_organization_skill("system-check", "Check", "instructions")
+    assert (await organization_skills.delete_organization_skill("system-check"))["ok"] is True
+
+    async def no_personal_access(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("A system admin must use workspace credentials and defaults")
+
+    for name in (
+        "get_valid_access_token",
+        "get_profile",
+        "repo_config_for_user",
+        "resolve_run_email",
+    ):
+        monkeypatch.setattr(schedules, name, no_personal_access)
+    child = await automations.create_automation(
+        "Check workspace repos", "0 9 * * *", repo="langchain-ai/open-swe", admin_thread=True
+    )
+    assert child["ok"] is True
+    child_id = child["automation"]["id"]
+    changed = await automations.update_automation(child_id, repo="langchain-ai/another-repo")
+    assert changed["ok"] is True
+    assert changed["automation"]["repo"] == "langchain-ai/another-repo"
+
+    # A later invocation or human reply cannot inherit the scheduled grant.
+    original = dict(run_config["configurable"])
+    for patch in (
+        {"invocation_id": "new-run", "prepare_run_id": "new-run"},
+        {"source": "dashboard", "github_login": "bob"},
+        {"github_login": "bob"},
+        {"schedule_id": "another-schedule"},
+    ):
+        run_config["configurable"] = {**original, **patch}
+        assert await server._admin_thread(run_config, None) is False
+        assert (await environments.list_environments())["ok"] is False
+
+    run_config["configurable"] = original
+    metadata = fake_client.threads.created[0]["metadata"]
+    metadata["owner_type"] = "user"
+    assert await server._admin_thread(run_config, None) is False
+    assert (await environments.list_environments())["ok"] is False
+    metadata["owner_type"] = "system"
+    monkeypatch.setenv("CONFIGURED_ADMINS", "bob")
+    assert await server._admin_thread(run_config, None) is False
+    assert (await environments.list_environments())["ok"] is False
 
 
 async def test_launch_admin_schedule_without_current_admin_access_is_ordinary_thread(

--- a/tests/agent/test_agent_schedules.py
+++ b/tests/agent/test_agent_schedules.py
@@ -2,12 +2,13 @@ import uuid
 from typing import Any
 from xml.etree import ElementTree
 
+import httpx2
 import pytest
 from fastapi import HTTPException
 from pydantic import ValidationError
 
 from agent import store as agent_store
-from agent.dashboard import schedules
+from agent.dashboard import repo_access, schedules
 from agent.dashboard.schedules import ScheduleCreateBody, ScheduleUpdateBody
 
 
@@ -115,20 +116,16 @@ def auth(monkeypatch) -> None:  # noqa: ANN001
         owner, name = full_name.split("/", 1)
         return {"owner": owner, "name": name}
 
-    async def fake_require_repo_access_for_user(login: str, full_name: str) -> str:
-        return "gho_token"
-
-    async def fake_slack_id_for_login(login: str | None) -> str | None:
-        return "UALICE" if login == "alice" else None
+    async def fake_require_repo_access_for_workspace(full_name: str) -> str:
+        return "workspace-app-token"
 
     monkeypatch.setattr(schedules, "get_valid_access_token", fake_get_valid_access_token)
     monkeypatch.setattr(schedules, "get_profile", fake_get_profile)
     monkeypatch.setattr(schedules, "resolve_run_email", fake_resolve_run_email)
     monkeypatch.setattr(schedules, "repo_config_for_user", fake_repo_config_for_user)
     monkeypatch.setattr(
-        schedules, "require_repo_access_for_user", fake_require_repo_access_for_user
+        schedules, "require_repo_access_for_workspace", fake_require_repo_access_for_workspace
     )
-    monkeypatch.setattr(schedules, "slack_id_for_login", fake_slack_id_for_login)
 
 
 def test_cron_validation_rejects_non_five_field_expression() -> None:
@@ -597,16 +594,16 @@ async def test_trigger_agent_schedule_preserves_repo_auth_error(fake_client, mon
     }
     await fake_client.store.put_item(schedules.SCHEDULES_NAMESPACE, "sched_1", record)
 
-    async def expired_token(login: str, full_name: str) -> str:
-        raise HTTPException(401, "github token unavailable, re-login required")
+    async def unavailable_token(full_name: str) -> str:
+        raise HTTPException(503, "workspace GitHub App token unavailable")
 
-    monkeypatch.setattr(schedules, "require_repo_access_for_user", expired_token)
+    monkeypatch.setattr(schedules, "require_repo_access_for_workspace", unavailable_token)
 
     with pytest.raises(HTTPException) as exc:
         await schedules.trigger_agent_schedule("sched_1")
 
-    assert exc.value.status_code == 401
-    assert exc.value.detail == "github token unavailable, re-login required"
+    assert exc.value.status_code == 503
+    assert exc.value.detail == "workspace GitHub App token unavailable"
     assert fake_client.runs.created == []
 
 
@@ -632,22 +629,22 @@ async def test_launch_scheduled_agent_run_skips_when_repo_access_revoked(
     }
     await fake_client.store.put_item(schedules.SCHEDULES_NAMESPACE, "sched_1", record)
 
-    async def deny_access(login: str, full_name: str) -> str:
-        raise HTTPException(403, "no access to this private repository")
+    async def deny_access(full_name: str) -> str:
+        raise HTTPException(403, "repository unavailable to the workspace GitHub App")
 
-    monkeypatch.setattr(schedules, "require_repo_access_for_user", deny_access)
+    monkeypatch.setattr(schedules, "require_repo_access_for_workspace", deny_access)
 
     result = await schedules.launch_scheduled_agent_run("sched_1")
 
     assert result == {
         "status": "unauthorized",
         "schedule_id": "sched_1",
-        "error": "no access to this private repository",
+        "error": "repository unavailable to the workspace GitHub App",
         "status_code": 403,
     }
     assert fake_client.runs.created == []
     stored = fake_client.store.items[(tuple(schedules.SCHEDULE_RUN_STATE_NAMESPACE), "sched_1")]
-    assert stored["last_error"] == "no access to this private repository"
+    assert stored["last_error"] == "repository unavailable to the workspace GitHub App"
 
 
 async def test_launch_scheduled_agent_run_starts_fresh_agent_thread(
@@ -684,6 +681,13 @@ async def test_launch_scheduled_agent_run_starts_fresh_agent_thread(
     assert metadata["origin"] == "schedule"
     assert metadata["thread_category"] == "automation"
     assert metadata["trigger_kind"] == "schedule"
+    assert metadata["owner_type"] == "system"
+    assert metadata["visibility"] == "public"
+    assert "owner_login" not in metadata
+    assert metadata["created_by"] == "alice"
+    assert "github_login" not in metadata
+    assert "participant_logins" not in metadata
+    assert "triggering_user_email" not in metadata
     assert metadata["admin_thread"] is True
     assert metadata["repo_owner"] == "langchain-ai"
     assert metadata["repo_name"] == "open-swe"
@@ -698,6 +702,8 @@ async def test_launch_scheduled_agent_run_starts_fresh_agent_thread(
     assert run["multitask_strategy"] == "interrupt"
     assert run["if_not_exists"] == "create"
     assert run["config"]["configurable"]["source"] == "schedule"
+    assert "github_login" not in run["config"]["configurable"]
+    assert "user_email" not in run["config"]["configurable"]
     assert run["config"]["configurable"]["admin_thread"] is True
     assert run["config"]["configurable"]["repo"] == record["repo"]
 
@@ -705,6 +711,59 @@ async def test_launch_scheduled_agent_run_starts_fresh_agent_thread(
     assert stored["last_thread_id"] == thread_id
     assert stored["last_run_id"] == "run_123"
     assert stored["scope"] == "workspace"
+
+
+@pytest.mark.parametrize("creator", [None, "alice"])
+@pytest.mark.parametrize("github_status", [None, 200, 401, 403, 404])
+async def test_system_schedule_can_run_without_user_credentials(
+    fake_client, monkeypatch, creator, github_status
+) -> None:  # noqa: ANN001
+    async def no_user_token(*args: Any, **kwargs: Any) -> str:
+        raise AssertionError("System execution must not use a user's credentials")
+
+    monkeypatch.setattr(schedules, "get_valid_access_token", no_user_token)
+    monkeypatch.setattr(repo_access, "get_valid_access_token", no_user_token)
+
+    async def app_token() -> str | None:
+        return "workspace-app-token" if github_status is not None else None
+
+    monkeypatch.setattr(repo_access, "get_github_app_installation_token", app_token)
+
+    async def github(request: httpx2.Request) -> httpx2.Response:
+        assert request.headers["Authorization"] == "Bearer workspace-app-token"
+        assert str(request.url) == "https://api.github.com/repos/langchain-ai/open-swe"
+        assert github_status is not None
+        return httpx2.Response(github_status, json={})
+
+    http_client = httpx2.AsyncClient(transport=httpx2.MockTransport(github))
+    monkeypatch.setattr(repo_access.httpx2, "AsyncClient", lambda **kwargs: http_client)
+    record = {
+        "id": "sched_system",
+        "prompt": "Check dependencies",
+        "repo": {"owner": "langchain-ai", "name": "open-swe"},
+        "enabled": True,
+    }
+    if creator:
+        record["created_by"] = creator
+    await fake_client.store.put_item(schedules.SCHEDULES_NAMESPACE, "sched_system", record)
+
+    result = await schedules.launch_scheduled_agent_run("sched_system")
+
+    if github_status != 200:
+        assert result["status"] == "unauthorized"
+        assert result["status_code"] == {None: 503, 401: 502, 403: 403, 404: 404}[github_status]
+        assert "workspace GitHub App" in result["error"]
+        assert not fake_client.threads.created
+        assert not fake_client.runs.created
+        return
+
+    assert result["status"] == "started"
+    metadata = fake_client.threads.created[0]["metadata"]
+    assert metadata["owner_type"] == "system"
+    assert "owner_login" not in metadata
+    configurable = fake_client.runs.created[0]["config"]["configurable"]
+    assert "github_login" not in configurable
+    assert "user_email" not in configurable
 
 
 async def test_launch_admin_schedule_without_current_admin_access_is_ordinary_thread(
@@ -778,7 +837,8 @@ async def test_launch_scheduled_agent_run_connects_slack_thread(
     slack_thread = metadata["source_context"]["slack_thread"]
     assert slack_thread["channel_id"] == "C0123456789"
     assert slack_thread["thread_ts"] == "1784302353.900029"
-    assert slack_thread["triggering_user_id"] == "UALICE"
+    assert not slack_thread.get("triggering_user_id")
+    assert not slack_thread.get("triggering_user_email")
     run = fake_client.runs.created[0]
     assert run["config"]["configurable"]["slack_thread"] == slack_thread
     prompt = ElementTree.fromstring(run["input"]["messages"][-1]["content"])

--- a/tests/agent/test_factory_tool_loading.py
+++ b/tests/agent/test_factory_tool_loading.py
@@ -1,9 +1,11 @@
 """The graph factory tool loaders must overlap, not run back-to-back."""
 
 import asyncio
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import langgraph_sdk
 import pytest
 from langchain.agents.middleware.types import ModelRequest
 from langchain_core.tools import StructuredTool
@@ -44,6 +46,15 @@ async def test_workspace_mcps_load_for_non_admins_and_respect_plan_mode(
 ) -> None:
     monkeypatch.setenv("CONFIGURED_ADMINS", "workspace-admin")
     monkeypatch.setenv("OBSERVABILITY_AUTHORIZED_EMAILS", "other@example.com")
+    monkeypatch.setattr(
+        langgraph_sdk,
+        "get_client",
+        lambda: SimpleNamespace(
+            threads=SimpleNamespace(
+                get=AsyncMock(return_value={"metadata": {"visibility": "public"}})
+            )
+        ),
+    )
     barrier = asyncio.Barrier(2)
 
     async def delete_incident() -> str:

--- a/tests/auth/test_auth_sources.py
+++ b/tests/auth/test_auth_sources.py
@@ -1,7 +1,10 @@
 import asyncio
 import logging
+from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock
 
+import langgraph_sdk
 import pytest
 
 from agent.github import token as auth
@@ -116,9 +119,10 @@ def _stub_dashboard_store(
     cached: tuple[str | None, str | None] = (None, None),
 ) -> None:
     from agent.dashboard import profiles
+    from agent.github.thread_token import cache_github_token_for_thread
 
-    async def fake_get_from_thread(thread_id: str):
-        return cached
+    if cached[0]:
+        cache_github_token_for_thread("t1", cached[0], cached[1], principal="login:mason-gh")
 
     async def fake_get_valid(login: str):
         return token
@@ -126,7 +130,17 @@ def _stub_dashboard_store(
     async def fake_get_record(login: str):
         return {"token_expires_at": expires_at}
 
-    monkeypatch.setattr(auth, "get_github_token_from_thread", fake_get_from_thread)
+    monkeypatch.setattr(
+        langgraph_sdk,
+        "get_client",
+        lambda: SimpleNamespace(
+            threads=SimpleNamespace(
+                get=AsyncMock(
+                    return_value={"metadata": {"visibility": "private", "owner_login": "mason-gh"}}
+                )
+            )
+        ),
+    )
     monkeypatch.setattr(profiles, "get_valid_access_token", fake_get_valid)
     monkeypatch.setattr(profiles, "get_oauth_token_record", fake_get_record)
 
@@ -146,8 +160,7 @@ def test_resolve_github_token_slack_uses_dashboard_store(
 def test_resolve_github_token_slack_ignores_stale_thread_cache(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # Slack thread ids are shared, so a prior user's cached token must NOT be
-    # returned. Resolution always goes by github_login via the dashboard store.
+    # A private run must refresh its owner token instead of trusting an older cache entry.
     _stub_dashboard_store(
         monkeypatch,
         token="bob-token",
@@ -185,7 +198,7 @@ def test_resolve_github_token_per_user_wins_over_bot_only_mode(
     assert token == "user-tok"
 
 
-def test_resolve_github_token_slack_no_token_falls_back_to_bot_in_bot_only_mode(
+def test_private_slack_no_token_requires_auth_in_bot_only_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _stub_dashboard_store(monkeypatch, token=None)
@@ -196,8 +209,8 @@ def test_resolve_github_token_slack_no_token_falls_back_to_bot_in_bot_only_mode(
 
     monkeypatch.setattr(auth, "_resolve_bot_installation_token", fake_bot)
 
-    token, expires_at = asyncio.run(auth.resolve_github_token(_slack_config(), "t1"))
-    assert (token, expires_at) == ("bot-tok", None)
+    with pytest.raises(auth.GitHubUserAuthRequired):
+        asyncio.run(auth.resolve_github_token(_slack_config(), "t1"))
 
 
 def _linear_config(github_login: str | None = "mason-gh") -> dict:
@@ -233,7 +246,7 @@ def test_resolve_github_token_linear_no_token_raises(
         asyncio.run(auth.resolve_github_token(_linear_config(), "t1"))
 
 
-def test_resolve_github_token_linear_no_token_falls_back_to_bot_in_bot_only_mode(
+def test_private_linear_no_token_requires_auth_in_bot_only_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _stub_dashboard_store(monkeypatch, token=None)
@@ -244,8 +257,8 @@ def test_resolve_github_token_linear_no_token_falls_back_to_bot_in_bot_only_mode
 
     monkeypatch.setattr(auth, "_resolve_bot_installation_token", fake_bot)
 
-    token, expires_at = asyncio.run(auth.resolve_github_token(_linear_config(), "t1"))
-    assert (token, expires_at) == ("bot-tok", None)
+    with pytest.raises(auth.GitHubUserAuthRequired):
+        asyncio.run(auth.resolve_github_token(_linear_config(), "t1"))
 
 
 @pytest.mark.parametrize("source", ["github"])
@@ -259,6 +272,13 @@ def test_resolve_github_token_bot_only_mode_non_slack_uses_bot(
 
     monkeypatch.setattr(auth, "_resolve_bot_installation_token", fake_bot)
 
+    monkeypatch.setattr(
+        langgraph_sdk,
+        "get_client",
+        lambda: SimpleNamespace(
+            threads=SimpleNamespace(get=AsyncMock(return_value={"metadata": {}}))
+        ),
+    )
     config = {"configurable": {"source": source, "github_login": "octo", "thread_id": "t1"}}
     token, _ = asyncio.run(auth.resolve_github_token(config, "t1"))
     assert token == "bot-tok"

--- a/tests/auth/test_thread_credential_scope.py
+++ b/tests/auth/test_thread_credential_scope.py
@@ -53,7 +53,7 @@ def config(source="dashboard", login="alice"):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("source", ["dashboard", "slack", "linear", "github", "schedule"])
 @pytest.mark.parametrize("visibility", ["public", None])
-async def test_public_and_legacy_threads_never_resolve_personal_github_auth(
+async def test_public_threads_never_resolve_personal_github_auth(
     source,
     visibility,
     thread_metadata,

--- a/tests/auth/test_thread_credential_scope.py
+++ b/tests/auth/test_thread_credential_scope.py
@@ -13,7 +13,7 @@ from agent.tool_loaders import notion_mcp
 
 @pytest.fixture
 def thread_metadata(monkeypatch):
-    metadata = {"visibility": "public", "owner_login": "alice"}
+    metadata = {"visibility": "public", "owner_type": "user", "owner_login": "alice"}
     get_thread = AsyncMock(side_effect=lambda _id: {"metadata": metadata})
     monkeypatch.setattr(
         langgraph_sdk,
@@ -93,6 +93,26 @@ async def test_public_pr_preserves_initiator_login_case(
     thread_metadata.update(owner_type="user", owner_login="Alice")
     credentials.side_effect = lambda login: "personal-token" if login == "Alice" else None
     monkeypatch.setattr("agent.run_config.get_config", lambda: config(login=actor))
+    assert await opr._resolve_pr_author_token() == ("personal-token", "user")
+    credentials.assert_awaited_once_with("Alice")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("actor", ["Alice", "bob"])
+async def test_older_public_owner_resolves_oauth_key_independently_of_participant(
+    monkeypatch, thread_metadata, credentials, actor
+):
+    opr = importlib.import_module("agent.tools.open_pull_request")
+    thread_metadata.pop("owner_type")
+    credentials.side_effect = lambda login: "personal-token" if login == "Alice" else None
+    monkeypatch.setattr("agent.run_config.get_config", lambda: config(login=actor))
+    monkeypatch.setattr(
+        profiles,
+        "search_all_values",
+        AsyncMock(return_value=[{"login": "Bob"}, {"login": "Alice"}]),
+        raising=False,
+    )
+
     assert await opr._resolve_pr_author_token() == ("personal-token", "user")
     credentials.assert_awaited_once_with("Alice")
 

--- a/tests/auth/test_thread_credential_scope.py
+++ b/tests/auth/test_thread_credential_scope.py
@@ -1,0 +1,210 @@
+import importlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import langgraph_sdk
+import pytest
+
+from agent.dashboard import profiles
+from agent.github import thread_token
+from agent.github import token as auth
+from agent.tool_loaders import notion_mcp
+
+
+@pytest.fixture
+def thread_metadata(monkeypatch):
+    metadata = {"visibility": "public", "owner_login": "alice"}
+    get_thread = AsyncMock(side_effect=lambda _id: {"metadata": metadata})
+    monkeypatch.setattr(
+        langgraph_sdk,
+        "get_client",
+        lambda: SimpleNamespace(threads=SimpleNamespace(get=get_thread)),
+    )
+    return metadata
+
+
+@pytest.fixture
+def credentials(monkeypatch):
+    thread_token._GITHUB_TOKEN_CACHE.clear()
+    user = AsyncMock(return_value="personal-token")
+    monkeypatch.setattr(profiles, "get_valid_access_token", user)
+    monkeypatch.setattr(profiles, "get_oauth_token_record", AsyncMock(return_value={}))
+    monkeypatch.setattr(
+        auth,
+        "get_github_app_installation_token_with_expiry",
+        AsyncMock(return_value=("bot-token", None)),
+    )
+    monkeypatch.setattr(auth, "is_bot_token_only_mode", lambda: False)
+    return user
+
+
+def config(source="dashboard", login="alice"):
+    return {
+        "configurable": {
+            "thread_id": "thread-1",
+            "source": source,
+            "github_login": login,
+            "visibility": "private",
+            "owner_login": login,
+        }
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("source", ["dashboard", "slack", "linear", "github", "schedule"])
+@pytest.mark.parametrize("visibility", ["public", None])
+async def test_public_and_legacy_threads_never_resolve_personal_github_auth(
+    source,
+    visibility,
+    thread_metadata,
+    credentials,
+):
+    if visibility is None:
+        thread_metadata.pop("visibility")
+    else:
+        thread_metadata["visibility"] = visibility
+    thread_token.cache_github_token_for_thread(
+        "thread-1", "old-personal-token", principal="login:alice"
+    )
+    assert await auth.resolve_github_token(config(source), "thread-1") == ("bot-token", None)
+    assert thread_token.get_github_token(config(source)) == "bot-token"
+    credentials.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_public_pr_is_opened_as_bot(monkeypatch, thread_metadata, credentials):
+    opr = importlib.import_module("agent.tools.open_pull_request")
+    monkeypatch.setattr("agent.run_config.get_config", config)
+    monkeypatch.setattr(
+        opr, "get_github_app_installation_token", AsyncMock(return_value="bot-token")
+    )
+    assert await opr._resolve_pr_author_token() == ("bot-token", "bot")
+    credentials.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_public_notion_tools_do_not_load_personal_credentials(monkeypatch, thread_metadata):
+    monkeypatch.setattr("agent.run_config.get_config", config)
+    get_token = AsyncMock(return_value="notion-token")
+    monkeypatch.setattr(notion_mcp, "get_notion_access_token", get_token)
+    monkeypatch.setattr(notion_mcp, "_build_mcp_tools", AsyncMock(return_value=[]))
+    assert await notion_mcp.load_notion_tools("alice") == []
+    get_token.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cached_notion_tool_cannot_run_in_public_thread(monkeypatch, thread_metadata):
+    from langchain_core.tools import StructuredTool
+
+    async def search(query: str) -> str:
+        return query
+
+    tool = notion_mcp._refreshing_tool(
+        StructuredTool.from_function(
+            coroutine=search, name="notion_search", description="Search Notion"
+        )
+    )
+    monkeypatch.setattr("agent.run_config.get_config", config)
+    monkeypatch.setattr(notion_mcp, "resolve_participant", AsyncMock(return_value="alice"))
+    get_token = AsyncMock(return_value="notion-token")
+    monkeypatch.setattr(notion_mcp, "get_notion_access_token", get_token)
+    monkeypatch.setattr(notion_mcp, "_build_mcp_tools", AsyncMock(return_value=[]))
+    with pytest.raises(RuntimeError, match="private"):
+        await tool.ainvoke({"on_behalf_of": "alice", "query": "roadmap"})
+    get_token.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_private_thread_uses_its_owners_auth(thread_metadata, credentials):
+    thread_metadata["visibility"] = "private"
+    credentials.side_effect = lambda login: "personal-token" if login == "Alice" else None
+    assert await auth.resolve_github_token(config(login="Alice"), "thread-1") == (
+        "personal-token",
+        None,
+    )
+    credentials.assert_awaited_once_with("Alice")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("visibility", [None, "unknown", True])
+async def test_invalid_visibility_does_not_enable_personal_credentials(
+    visibility, thread_metadata, credentials
+):
+    thread_metadata["visibility"] = visibility
+    with pytest.raises(RuntimeError, match="visibility"):
+        await auth.resolve_github_token(config(), "thread-1")
+    credentials.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_public_thread_requires_app_auth_even_when_user_token_exists(
+    monkeypatch, thread_metadata, credentials
+):
+    monkeypatch.setattr(
+        auth, "get_github_app_installation_token_with_expiry", AsyncMock(return_value=(None, None))
+    )
+    with pytest.raises(RuntimeError, match="GitHub App"):
+        await auth.resolve_github_token(config(), "thread-1")
+    credentials.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("owner", [None, "", "bob"])
+async def test_private_thread_rejects_missing_or_different_owner(
+    owner,
+    thread_metadata,
+    credentials,
+):
+    thread_metadata.update(visibility="private", owner_login=owner)
+    with pytest.raises(RuntimeError, match="owner"):
+        await auth.resolve_github_token(config(), "thread-1")
+    credentials.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_private_thread_does_not_fall_back_to_bot(
+    monkeypatch,
+    thread_metadata,
+    credentials,
+):
+    thread_metadata["visibility"] = "private"
+    credentials.return_value = None
+    monkeypatch.setattr(auth, "is_bot_token_only_mode", lambda: True)
+    with pytest.raises(auth.GitHubUserAuthRequired):
+        await auth.resolve_github_token(config(), "thread-1")
+
+
+@pytest.mark.asyncio
+async def test_metadata_lookup_failure_cannot_use_personal_credentials(
+    monkeypatch,
+    credentials,
+):
+    monkeypatch.setattr(
+        langgraph_sdk,
+        "get_client",
+        lambda: SimpleNamespace(
+            threads=SimpleNamespace(get=AsyncMock(side_effect=RuntimeError("store unavailable")))
+        ),
+    )
+    with pytest.raises(RuntimeError, match="store unavailable"):
+        await auth.resolve_github_token(config(), "thread-1")
+    credentials.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_github_webhook_context_always_uses_workspace_bot(monkeypatch, credentials):
+    from agent.webhooks import common
+
+    monkeypatch.setattr(common, "is_bot_token_only_mode", lambda: False)
+    monkeypatch.setattr(
+        common,
+        "get_github_app_installation_token_with_expiry",
+        AsyncMock(return_value=("bot-token", None)),
+    )
+    personal = AsyncMock(return_value={"token": "personal-token"})
+    monkeypatch.setattr(auth, "resolve_github_token_from_email", personal)
+    assert (
+        await common.get_or_resolve_thread_github_token("thread-1", "alice@example.com")
+        == "bot-token"
+    )
+    personal.assert_not_awaited()

--- a/tests/auth/test_thread_credential_scope.py
+++ b/tests/auth/test_thread_credential_scope.py
@@ -45,6 +45,7 @@ def config(source="dashboard", login="alice"):
             "source": source,
             "github_login": login,
             "visibility": "private",
+            "owner_type": "system",
             "owner_login": login,
         }
     }
@@ -72,13 +73,84 @@ async def test_public_threads_never_resolve_personal_github_auth(
 
 
 @pytest.mark.asyncio
-async def test_public_pr_is_opened_as_bot(monkeypatch, thread_metadata, credentials):
+@pytest.mark.parametrize("actor", ["alice", "bob"])
+async def test_public_pr_is_opened_as_initiator(monkeypatch, thread_metadata, credentials, actor):
     opr = importlib.import_module("agent.tools.open_pull_request")
+    monkeypatch.setattr("agent.run_config.get_config", lambda: config(login=actor))
+    bot = AsyncMock(return_value="bot-token")
+    monkeypatch.setattr(opr, "get_github_app_installation_token", bot)
+    assert await opr._resolve_pr_author_token() == ("personal-token", "user")
+    credentials.assert_awaited_once_with("alice")
+    bot.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("actor", ["bob", "alice"])
+async def test_public_pr_preserves_initiator_login_case(
+    monkeypatch, thread_metadata, credentials, actor
+):
+    opr = importlib.import_module("agent.tools.open_pull_request")
+    thread_metadata.update(owner_type="user", owner_login="Alice")
+    credentials.side_effect = lambda login: "personal-token" if login == "Alice" else None
+    monkeypatch.setattr("agent.run_config.get_config", lambda: config(login=actor))
+    assert await opr._resolve_pr_author_token() == ("personal-token", "user")
+    credentials.assert_awaited_once_with("Alice")
+
+
+@pytest.mark.asyncio
+async def test_public_pr_does_not_fall_back_to_bot(monkeypatch, thread_metadata, credentials):
+    opr = importlib.import_module("agent.tools.open_pull_request")
+    monkeypatch.setattr("agent.run_config.get_config", lambda: config(login="bob"))
+    credentials.return_value = None
+    bot = AsyncMock(return_value="bot-token")
+    monkeypatch.setattr(opr, "get_github_app_installation_token", bot)
+    with pytest.raises(auth.GitHubUserAuthRequired):
+        await opr._resolve_pr_author_token()
+    bot.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_system_pr_uses_bot_even_with_a_triggering_user(
+    monkeypatch, thread_metadata, credentials
+):
+    opr = importlib.import_module("agent.tools.open_pull_request")
+    thread_metadata.update(owner_type="system")
+    thread_metadata.pop("owner_login")
     monkeypatch.setattr("agent.run_config.get_config", config)
     monkeypatch.setattr(
         opr, "get_github_app_installation_token", AsyncMock(return_value="bot-token")
     )
     assert await opr._resolve_pr_author_token() == ("bot-token", "bot")
+    credentials.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_user_owned_pr_requires_saved_initiator(monkeypatch, thread_metadata, credentials):
+    opr = importlib.import_module("agent.tools.open_pull_request")
+    thread_metadata.update(owner_type="user")
+    thread_metadata.pop("owner_login")
+    monkeypatch.setattr("agent.run_config.get_config", config)
+    with pytest.raises(RuntimeError, match="owner"):
+        await opr._resolve_pr_author_token()
+    credentials.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("owner_type", [True, "unknown"])
+async def test_invalid_owner_type_cannot_resolve_credentials(
+    owner_type, thread_metadata, credentials
+):
+    thread_metadata["owner_type"] = owner_type
+    with pytest.raises(RuntimeError, match="owner type"):
+        await auth.resolve_github_token(config(), "thread-1")
+    credentials.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_system_thread_cannot_use_private_credentials(thread_metadata, credentials):
+    thread_metadata.update(owner_type="system", visibility="private")
+    with pytest.raises(RuntimeError, match="System threads"):
+        await auth.resolve_github_token(config(), "thread-1")
     credentials.assert_not_awaited()
 
 

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -989,16 +989,27 @@ async def test_enrich_run_start_command_allowlists_client_configurable(monkeypat
     command = {
         "method": "run.start",
         "params": {
+            "metadata": {
+                "owner_login": "attacker",
+                "owner_type": "system",
+                "visibility": "private",
+                "system_authorization": {
+                    "schedule_id": "admin-schedule",
+                    "invocation_id": "stolen",
+                },
+            },
             "config": {
                 "configurable": {
                     "github_login": "attacker",
                     "user_email": "attacker@example.com",
                     "source": "github",
+                    "invocation_id": "stolen",
+                    "prepare_run_id": "stolen",
                     "repo": {"owner": "evil", "name": "repo"},
                     "agent_model_id": _VISION_MODEL,
                     "agent_effort": "medium",
                 }
-            }
+            },
         },
     }
 
@@ -1018,6 +1029,11 @@ async def test_enrich_run_start_command_allowlists_client_configurable(monkeypat
     assert configurable["github_login"] == "octocat"
     assert configurable["user_email"] == "octocat@example.com"
     assert configurable["source"] == "dashboard"
+    assert configurable["invocation_id"] != "stolen"
+    assert not (
+        {"owner_login", "owner_type", "visibility", "system_authorization"}
+        & enriched["params"]["metadata"].keys()
+    )
     assert configurable["repo"] == {"owner": "octo", "name": "repo"}
     assert configurable["agent_model_id"] == _VISION_MODEL
     assert configurable["agent_effort"] == "medium"

--- a/tests/dashboard/test_thread_visibility.py
+++ b/tests/dashboard/test_thread_visibility.py
@@ -155,7 +155,8 @@ async def test_continue_privately_copies_transcript_and_drops_linkage(private_th
 
     metadata = client.threads.create.call_args.kwargs["metadata"]
     assert metadata["visibility"] == "private"
-    assert metadata["owner_login"] == "bob"
+    assert metadata["owner_type"] == "user"
+    assert metadata["owner_login"] == "Bob"
     assert metadata["source"] == metadata["origin"] == "dashboard"
     assert metadata["continued_from_thread_id"] == "private-thread"
     assert metadata["title"] == "Fix the flaky build"

--- a/tests/github/test_open_pull_request.py
+++ b/tests/github/test_open_pull_request.py
@@ -1,8 +1,10 @@
 import asyncio
 import sys
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import langgraph_sdk
 import pytest
 
 import agent.tools.open_pull_request  # noqa: F401
@@ -99,6 +101,19 @@ def _install_client(monkeypatch: pytest.MonkeyPatch, client: _FakeClient | _Rout
 
 
 def _set_config(monkeypatch: pytest.MonkeyPatch, configurable: dict[str, Any]) -> None:
+    configurable.setdefault("thread_id", "pr-thread")
+    metadata = (
+        {"visibility": "public"}
+        if configurable.get("source") == "github"
+        else {"visibility": "private", "owner_login": configurable.get("github_login")}
+    )
+    monkeypatch.setattr(
+        langgraph_sdk,
+        "get_client",
+        lambda: SimpleNamespace(
+            threads=SimpleNamespace(get=AsyncMock(return_value={"metadata": metadata}))
+        ),
+    )
     monkeypatch.setattr("agent.run_config.get_config", lambda: {"configurable": configurable})
     monkeypatch.setattr(opr, "get_config", lambda: {"configurable": configurable}, raising=False)
 
@@ -237,7 +252,7 @@ def test_falls_back_to_bot_for_github_source(monkeypatch: pytest.MonkeyPatch) ->
     assert client.post_calls[0]["headers"]["Authorization"] == "Bearer bot-tok"
 
 
-def test_falls_back_to_bot_when_user_token_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_private_pr_requires_user_token(monkeypatch: pytest.MonkeyPatch) -> None:
     _set_config(monkeypatch, {"source": "slack", "github_login": "johannes117"})
 
     from agent.dashboard import profiles
@@ -255,7 +270,8 @@ def test_falls_back_to_bot_when_user_token_missing(monkeypatch: pytest.MonkeyPat
     client = _FakeClient(post=_FakeResponse(201, {"html_url": "u", "number": 3, "user": {}}))
     _install_client(monkeypatch, client)
 
-    assert _open()["token_kind"] == "bot"
+    with pytest.raises(opr.GitHubUserAuthRequired):
+        _open()
 
 
 def test_returns_existing_pr_on_422(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/github/test_open_pull_request.py
+++ b/tests/github/test_open_pull_request.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx2
 import langgraph_sdk
 import pytest
 
@@ -60,6 +61,8 @@ class _FakeClient:
         self, url: str, *, headers: dict[str, str], params: dict[str, str] | None = None
     ) -> _FakeResponse:
         self.get_calls.append({"url": url, "headers": headers, "params": params})
+        if url.endswith("/installation/repositories"):
+            return _FakeResponse(200, {"repositories": [{"full_name": "langchain-ai/open-swe"}]})
         if self._get is not None:
             return self._get
         return _FakeResponse(200, {"name": "ok"})
@@ -141,6 +144,67 @@ def _open(base: str = "main") -> dict[str, Any]:
     )
 
 
+@pytest.mark.parametrize(
+    "workspace_access", ["allowed", "other_account", "unavailable", "no_token"]
+)
+def test_public_pr_cannot_use_initiator_authority_outside_workspace(
+    monkeypatch: pytest.MonkeyPatch, workspace_access: str
+) -> None:
+    _set_config(
+        monkeypatch,
+        {"source": "slack", "github_login": "bob"},
+        metadata={"visibility": "public", "owner_type": "user", "owner_login": "Alice"},
+    )
+    monkeypatch.setattr(
+        "agent.dashboard.profiles.get_valid_access_token", AsyncMock(return_value="alice-token")
+    )
+    monkeypatch.setattr(
+        opr,
+        "get_github_app_installation_token",
+        AsyncMock(return_value=None if workspace_access == "no_token" else "workspace-token"),
+    )
+    monkeypatch.setattr(opr, "_record_pr_telemetry", AsyncMock())
+    monkeypatch.setattr(opr, "get_plan_content", AsyncMock(return_value=None))
+    requests: list[httpx2.Request] = []
+
+    async def github(request: httpx2.Request) -> httpx2.Response:
+        requests.append(request)
+        if request.url.path == "/installation/repositories":
+            assert request.headers["Authorization"] == "Bearer workspace-token"
+            if workspace_access == "unavailable":
+                return httpx2.Response(503)
+            if request.url.params["page"] == "1":
+                return httpx2.Response(
+                    200,
+                    json={
+                        "repositories": [{"full_name": f"workspace/repo-{i}"} for i in range(100)]
+                    },
+                )
+            full_name = (
+                "langchain-ai/open-swe" if workspace_access == "allowed" else "other/open-swe"
+            )
+            return httpx2.Response(200, json={"repositories": [{"full_name": full_name}]})
+        # OAuth has broader access, including branches already pushed by someone else.
+        assert request.headers["Authorization"] == "Bearer alice-token"
+        if request.method == "POST":
+            return httpx2.Response(201, json={"number": 1, "user": {"login": "Alice"}})
+        return httpx2.Response(200, json={"name": "existing-branch", "private": False})
+
+    client = httpx2.AsyncClient(transport=httpx2.MockTransport(github))
+    monkeypatch.setattr(opr.httpx2, "AsyncClient", lambda **kwargs: client)
+    result = _open()
+
+    if workspace_access == "allowed":
+        assert result["success"] is True
+        assert result["author"] == "Alice"
+        assert result["token_kind"] == "user"
+        assert any(request.method == "POST" for request in requests)
+    else:
+        assert result["success"] is False
+        assert "workspace" in result["error"]
+        assert all(request.headers["Authorization"] != "Bearer alice-token" for request in requests)
+
+
 @pytest.mark.parametrize("visibility", ["public", "private"])
 def test_uses_user_token_for_slack_with_login(
     monkeypatch: pytest.MonkeyPatch, visibility: str
@@ -160,7 +224,8 @@ def test_uses_user_token_for_slack_with_login(
     monkeypatch.setattr(profiles, "get_valid_access_token", fake_user_token)
 
     async def fail_bot() -> str | None:
-        raise AssertionError("bot token should not be used when a user token exists")
+        assert visibility == "public", "private PRs should not need workspace credentials"
+        return "workspace-token"
 
     monkeypatch.setattr(opr, "get_github_app_installation_token", fail_bot)
 
@@ -440,6 +505,7 @@ def _open_with_body(body: str) -> dict[str, Any]:
 
 
 def _stub_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(opr, "private_credential_login", AsyncMock(return_value="test-owner"))
     monkeypatch.setattr(opr, "_resolve_pr_author_token", lambda: _coro(("tok", "user")))
 
 

--- a/tests/github/test_open_pull_request.py
+++ b/tests/github/test_open_pull_request.py
@@ -100,12 +100,21 @@ def _install_client(monkeypatch: pytest.MonkeyPatch, client: _FakeClient | _Rout
     monkeypatch.setattr(opr.httpx2, "AsyncClient", lambda **_kwargs: client)
 
 
-def _set_config(monkeypatch: pytest.MonkeyPatch, configurable: dict[str, Any]) -> None:
+def _set_config(
+    monkeypatch: pytest.MonkeyPatch,
+    configurable: dict[str, Any],
+    *,
+    metadata: dict[str, Any] | None = None,
+) -> None:
     configurable.setdefault("thread_id", "pr-thread")
     metadata = (
-        {"visibility": "public"}
-        if configurable.get("source") == "github"
-        else {"visibility": "private", "owner_login": configurable.get("github_login")}
+        metadata
+        if metadata is not None
+        else (
+            {"visibility": "public"}
+            if configurable.get("source") == "github"
+            else {"visibility": "private", "owner_login": configurable.get("github_login")}
+        )
     )
     monkeypatch.setattr(
         langgraph_sdk,
@@ -132,8 +141,15 @@ def _open(base: str = "main") -> dict[str, Any]:
     )
 
 
-def test_uses_user_token_for_slack_with_login(monkeypatch: pytest.MonkeyPatch) -> None:
-    _set_config(monkeypatch, {"source": "slack", "github_login": "johannes117"})
+@pytest.mark.parametrize("visibility", ["public", "private"])
+def test_uses_user_token_for_slack_with_login(
+    monkeypatch: pytest.MonkeyPatch, visibility: str
+) -> None:
+    _set_config(
+        monkeypatch,
+        {"source": "slack", "github_login": "johannes117"},
+        metadata={"visibility": visibility, "owner_type": "user", "owner_login": "johannes117"},
+    )
 
     from agent.dashboard import profiles
 
@@ -224,8 +240,12 @@ def test_uses_user_token_for_linear_with_login(monkeypatch: pytest.MonkeyPatch) 
     assert client.post_calls[0]["headers"]["Authorization"] == "Bearer user-tok"
 
 
-def test_falls_back_to_bot_for_github_source(monkeypatch: pytest.MonkeyPatch) -> None:
-    _set_config(monkeypatch, {"source": "github", "github_login": "johannes117"})
+def test_system_thread_uses_bot_for_github_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_config(
+        monkeypatch,
+        {"source": "github", "github_login": "johannes117"},
+        metadata={"visibility": "public", "owner_type": "system"},
+    )
 
     from agent.dashboard import profiles
 

--- a/tests/middleware/test_workspace_skills.py
+++ b/tests/middleware/test_workspace_skills.py
@@ -1,0 +1,52 @@
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+from deepagents.backends.state import StateBackend
+from deepagents.middleware.skills import SkillsMiddleware
+from langchain.agents.middleware.types import ModelRequest
+
+
+@pytest.mark.asyncio
+async def test_resumed_public_skill_prompt_excludes_cached_personal_context():
+    from agent.middleware.workspace_skills import WorkspaceSkillsMiddleware
+
+    middleware = WorkspaceSkillsMiddleware(
+        backend=StateBackend(), sources=["/organization-skills/", "/bundled-skills/"]
+    )
+    state = {
+        "messages": [],
+        "skills_metadata": [
+            {
+                "name": "personal",
+                "description": "private detail",
+                "path": "/skills/personal/SKILL.md",
+                "allowed_tools": [],
+            },
+            {
+                "name": "workspace",
+                "description": "team detail",
+                "path": "/organization-skills/workspace/SKILL.md",
+                "allowed_tools": [],
+            },
+        ],
+        "skills_load_errors": ["private diagnostic"],
+    }
+    request = ModelRequest(
+        model=MagicMock(), messages=[], tools=[], runtime=MagicMock(), state=state
+    )
+    seen = []
+
+    async def capture(request):
+        seen.append(request.system_message.text)
+        return MagicMock()
+
+    await middleware.awrap_model_call(request, capture)
+    assert "team detail" in seen[0]
+    assert "private detail" not in seen[0]
+    assert "private diagnostic" not in seen[0]
+    assert len(state["skills_metadata"]) == 2
+    update = await middleware.abefore_agent(cast(Any, state), MagicMock(), {})
+    assert [skill["name"] for skill in update["skills_metadata"]] == ["workspace"]
+    assert update["skills_load_errors"] == []
+    assert middleware.name == SkillsMiddleware(backend=StateBackend(), sources=[]).name

--- a/tests/models/test_agent_subagent_models.py
+++ b/tests/models/test_agent_subagent_models.py
@@ -1,9 +1,23 @@
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import langgraph_sdk
 import pytest
 from langgraph.graph.state import RunnableConfig
 
 from agent.server import get_agent
+
+
+@pytest.fixture(autouse=True, params=["public", "private"])
+def saved_thread_scope(monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest) -> None:
+    client = SimpleNamespace(
+        threads=SimpleNamespace(
+            get=AsyncMock(
+                return_value={"metadata": {"visibility": request.param, "owner_login": "octocat"}}
+            )
+        )
+    )
+    monkeypatch.setattr(langgraph_sdk, "get_client", lambda: client)
 
 
 class _DummyAgent:

--- a/tests/sandbox/test_proxy_auth.py
+++ b/tests/sandbox/test_proxy_auth.py
@@ -1,10 +1,12 @@
 """Tests for GitHub proxy auth configuration."""
 
 import base64
+from types import SimpleNamespace
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx2
+import langgraph_sdk
 import pytest
 from langchain.agents.middleware import AgentMiddleware, AgentState
 from langchain_core.runnables import RunnableConfig
@@ -600,8 +602,17 @@ class TestRefreshProxyOnSandboxReuse:
         )
 
     @pytest.mark.asyncio
-    async def test_refreshes_proxy_for_cached_langsmith_sandbox(self) -> None:
+    async def test_refreshes_proxy_for_cached_langsmith_sandbox(self, monkeypatch) -> None:
         """Cached sandboxes should get a fresh proxy token before git operations."""
+        monkeypatch.setattr(
+            langgraph_sdk,
+            "get_client",
+            lambda: SimpleNamespace(
+                threads=SimpleNamespace(
+                    get=AsyncMock(return_value={"metadata": {"visibility": "public"}})
+                )
+            ),
+        )
         config = self._execution_config()
         mock_sandbox = MagicMock(id="sandbox-cached", aexecute=AsyncMock())
         mock_sandbox.aexecute = AsyncMock()
@@ -675,8 +686,19 @@ class TestRefreshProxyOnSandboxReuse:
             )
 
     @pytest.mark.asyncio
-    async def test_refreshes_proxy_when_reconnecting_to_existing_langsmith_sandbox(self) -> None:
+    async def test_refreshes_proxy_when_reconnecting_to_existing_langsmith_sandbox(
+        self, monkeypatch
+    ) -> None:
         """Reconnected sandboxes should also get a fresh proxy token."""
+        monkeypatch.setattr(
+            langgraph_sdk,
+            "get_client",
+            lambda: SimpleNamespace(
+                threads=SimpleNamespace(
+                    get=AsyncMock(return_value={"metadata": {"visibility": "public"}})
+                )
+            ),
+        )
         config = self._execution_config()
         mock_sandbox = MagicMock(id="sandbox-existing", aexecute=AsyncMock())
         mock_sandbox.aexecute = AsyncMock()

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -163,6 +163,8 @@ def test_upsert_accumulates_participants_and_pins_source_context(
     assert metadata["participant_logins"] == {"commenter-gh": True, "first-gh": True}
     assert metadata["source_context"] == opening_context
     assert metadata["title"] == metadata["title_seed"] == "first-gh"
+    assert metadata["owner_type"] == "user"
+    assert metadata["owner_login"] == "first-gh"
 
 
 def test_upsert_stamps_visibility_and_owner_only_on_creation(
@@ -185,7 +187,7 @@ def test_upsert_stamps_visibility_and_owner_only_on_creation(
         )
     )
     assert created["visibility"] == "private"
-    assert created["owner_login"] == "alice"
+    assert created["owner_login"] == "Alice"
 
     asyncio.run(
         webhook_common.upsert_agent_thread_metadata(
@@ -194,7 +196,24 @@ def test_upsert_stamps_visibility_and_owner_only_on_creation(
     )
     metadata = cast(dict, threads.thread)["metadata"]
     assert metadata["visibility"] == "private"
-    assert metadata["owner_login"] == "alice"
+    assert metadata["owner_login"] == "Alice"
+
+
+@pytest.mark.parametrize("source", ["github", "linear"])
+def test_upsert_keeps_original_github_initiator(
+    monkeypatch: pytest.MonkeyPatch, source: str
+) -> None:
+    threads = _FakeThreadsClient({"metadata": {}})
+    monkeypatch.setattr(webhook_common, "get_client", lambda url: _FakeClient(threads))
+    for login in ("FirstUser", "second-user"):
+        asyncio.run(
+            webhook_common.upsert_agent_thread_metadata(
+                "thread-id", source=source, github_login=login
+            )
+        )
+    metadata = cast(dict, threads.thread)["metadata"]
+    assert metadata["owner_type"] == "user"
+    assert metadata["owner_login"] == "FirstUser"
 
 
 def test_upsert_stamps_stub_thread_created_by_helper(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/tools/test_automations.py
+++ b/tests/tools/test_automations.py
@@ -1,4 +1,5 @@
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -8,7 +9,7 @@ from agent.tools import automations
 
 @pytest.fixture(autouse=True)
 def admin(monkeypatch) -> None:  # noqa: ANN001
-    monkeypatch.setattr(automations, "require_admin", lambda action: None)
+    monkeypatch.setattr(automations, "require_admin", AsyncMock(return_value=None))
     monkeypatch.setattr(
         automations,
         "configurable",
@@ -34,13 +35,16 @@ async def test_create_automation_uses_trusted_admin_identity(monkeypatch) -> Non
     assert called["kwargs"] == {
         "email": "alice@example.com",
         "allow_admin_thread": True,
+        "use_workspace_credentials": False,
     }
     assert called["body"].repo == "langchain-ai/open-swe"
 
 
 async def test_automation_tools_recheck_admin(monkeypatch) -> None:  # noqa: ANN001
     monkeypatch.setattr(
-        automations, "require_admin", lambda action: "Only workspace admins can manage automations."
+        automations,
+        "require_admin",
+        AsyncMock(return_value="Only workspace admins can manage automations."),
     )
 
     result = await automations.delete_automation("schedule-1")

--- a/tests/tools/test_notion_mcp_tools.py
+++ b/tests/tools/test_notion_mcp_tools.py
@@ -1,6 +1,8 @@
+from types import SimpleNamespace
 from typing import Any, Literal, cast
 from unittest.mock import AsyncMock, patch
 
+import langgraph_sdk
 import pytest
 from langchain_core.tools import StructuredTool
 
@@ -8,7 +10,22 @@ from agent.tool_loaders import notion_mcp
 
 
 @pytest.fixture(autouse=True)
-def _resolve_participant():
+def _resolve_participant(monkeypatch):
+    monkeypatch.setattr(
+        "agent.run_config.get_config",
+        lambda: {"configurable": {"thread_id": "notion-thread", "github_login": "alice"}},
+    )
+    monkeypatch.setattr(
+        langgraph_sdk,
+        "get_client",
+        lambda: SimpleNamespace(
+            threads=SimpleNamespace(
+                get=AsyncMock(
+                    return_value={"metadata": {"visibility": "private", "owner_login": "alice"}}
+                )
+            )
+        ),
+    )
     with patch.object(notion_mcp, "resolve_participant", AsyncMock(return_value="alice")):
         yield
 


### PR DESCRIPTION
Public conversations currently resolve personal integration credentials even though other workspace members can participate. Saved thread visibility now determines integration access, while saved ownership determines PR authorship.

Public agents use the workspace GitHub App, workspace MCP connections, and organization/bundled skills. PRs from user-owned public threads are opened with the original initiator’s OAuth, even when another participant starts the run. The target must belong to the configured workspace installation before any repository request uses the initiator’s OAuth. Private threads retain the verified owner’s personal credentials, skills, and instructions. Missing owner credentials stop the operation without falling back to the bot.

Scheduled automations create public system-owned threads and open PRs as the App. Repository access at launch uses the workspace App; the creator is retained for auditing without supplying a personal execution identity. Admin schedules carry authorization tied to their specific invocation; graph assembly and tool execution recheck the saved grant and the creator’s current admin status. They manage automations with workspace credentials. Ownership is saved at creation and cannot be replaced by later participants or client run metadata. Older owner records resolve the canonical OAuth login independently of the current participant. Existing threads without recorded ownership retain bot PR authorship.

LangSmith sandbox GitHub proxy access continues to use the App token for both public and private threads. The local-shell development provider inherits host credentials and does not provide this isolation.

Built on main after #2601. General user-scoped MCP support remains separate in #2594.
