### PR TITLE
fix: keep non-image bytes out of `read_file` image blocks

### DIFF
--- a/agent/middleware/__init__.py
+++ b/agent/middleware/__init__.py
@@ -30,6 +30,7 @@ _MIDDLEWARE_MODULES = {
     "task_retry_on": ".task_retry",
     "TimeoutWrapupMiddleware": ".timeout_wrapup",
     "ToolErrorMiddleware": ".tool_error_handler",
+    "ValidateImageReadsMiddleware": ".validate_image_reads",
     "WorkflowPushGuardMiddleware": ".workflow_push_guard",
 }
 
@@ -54,6 +55,7 @@ __all__ = [
     "SubdirAgentsReadMiddleware",
     "ToolErrorMiddleware",
     "TimeoutWrapupMiddleware",
+    "ValidateImageReadsMiddleware",
     "WorkflowPushGuardMiddleware",
     "check_message_queue_before_model",
     "notify_step_limit_reached",
@@ -89,6 +91,7 @@ if TYPE_CHECKING:
     from agent.middleware.task_retry import task_on_failure, task_retry_on
     from agent.middleware.timeout_wrapup import TimeoutWrapupMiddleware
     from agent.middleware.tool_error_handler import ToolErrorMiddleware
+    from agent.middleware.validate_image_reads import ValidateImageReadsMiddleware
     from agent.middleware.workflow_push_guard import WorkflowPushGuardMiddleware
 
 

--- a/agent/middleware/validate_image_reads.py
+++ b/agent/middleware/validate_image_reads.py
@@ -30,6 +30,9 @@ _IMAGE_SIGNATURES: tuple[tuple[bytes, ...], ...] = (
 
 
 def is_image_bytes(head: bytes) -> bool:
+    # HEIC/HEIF (and AVIF) are ISO-BMFF containers: the `ftyp` box sits at offset 4.
+    if head[4:8] == b"ftyp":
+        return True
     for parts in _IMAGE_SIGNATURES:
         if len(parts) == 1:
             if head.startswith(parts[0]):

--- a/agent/middleware/validate_image_reads.py
+++ b/agent/middleware/validate_image_reads.py
@@ -1,0 +1,87 @@
+"""Keep non-image bytes out of ``read_file`` image blocks.
+
+``read_file`` picks the content-block type from the file extension, so a
+``.png`` holding something else (for example the JSON error body an expired
+download link returns) is sent to the model as an image. Providers reject the
+request with HTTP 400, and because the tool message is checkpointed, every
+later turn on the thread fails the same way. This middleware checks the magic
+bytes and downgrades a mismatch to a plain-text tool result.
+"""
+
+import base64
+import binascii
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from langchain.agents.middleware.types import AgentState
+from langchain_core.messages import ToolMessage
+from langgraph.prebuilt.tool_node import ToolCallRequest
+from langgraph.types import Command
+
+from agent.middleware.trace import OpenSWEMiddleware
+
+_IMAGE_SIGNATURES: tuple[tuple[bytes, ...], ...] = (
+    (b"\x89PNG\r\n\x1a\n",),
+    (b"\xff\xd8\xff",),
+    (b"GIF87a",),
+    (b"GIF89a",),
+    (b"RIFF", b"WEBP"),
+)
+
+
+def is_image_bytes(head: bytes) -> bool:
+    for parts in _IMAGE_SIGNATURES:
+        if len(parts) == 1:
+            if head.startswith(parts[0]):
+                return True
+        elif head.startswith(parts[0]) and head[8:12] == parts[1]:
+            return True
+    return False
+
+
+def _image_block_head(block: Any) -> bytes | None:
+    if not isinstance(block, dict) or block.get("type") != "image":
+        return None
+    encoded = block.get("base64")
+    if not isinstance(encoded, str):
+        return None
+    try:
+        return base64.b64decode(encoded[:24] + "==")[:12]
+    except binascii.Error, ValueError:
+        return b""
+
+
+def validate_read_file_message(message: ToolMessage) -> ToolMessage:
+    if not isinstance(message.content, list):
+        return message
+    for block in message.content:
+        head = _image_block_head(block)
+        if head is None or is_image_bytes(head):
+            continue
+        path = message.additional_kwargs.get("read_file_path", "the file")
+        return ToolMessage(
+            content=(
+                f"read_file: {path} has an image extension but its contents are not a "
+                f"valid image (starts with {head[:8]!r}). It was not attached; inspect "
+                "it as text or re-download it."
+            ),
+            name=message.name,
+            tool_call_id=message.tool_call_id,
+            status="error",
+        )
+    return message
+
+
+class ValidateImageReadsMiddleware(OpenSWEMiddleware):
+    state_schema = AgentState
+
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command]],
+    ) -> ToolMessage | Command:
+        result = await handler(request)
+        tool_call = request.tool_call
+        if isinstance(result, ToolMessage) and tool_call.get("name") == "read_file":
+            return validate_read_file_message(result)
+        return result

--- a/agent/server.py
+++ b/agent/server.py
@@ -104,6 +104,7 @@ from agent.middleware import (
     SubdirAgentsReadMiddleware,
     TimeoutWrapupMiddleware,
     ToolErrorMiddleware,
+    ValidateImageReadsMiddleware,
     WorkflowPushGuardMiddleware,
     check_message_queue_before_model,
     notify_step_limit_reached,
@@ -1233,6 +1234,7 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                 ),
                 *([dynamic_tool_middleware] if dynamic_tool_middleware else []),
                 SanitizeToolInputsMiddleware(),
+                ValidateImageReadsMiddleware(),
                 ModelCallLimitMiddleware(run_limit=MODEL_CALL_RECURSION_LIMIT, exit_behavior="end"),
                 ToolErrorMiddleware(),
                 ExcludeToolsMiddleware(

--- a/tests/middleware/test_validate_image_reads.py
+++ b/tests/middleware/test_validate_image_reads.py
@@ -36,11 +36,12 @@ def test_real_image_bytes_pass_through_unchanged() -> None:
     assert validate_read_file_message(message) is message
 
 
-def test_webp_and_jpeg_are_recognised() -> None:
+def test_webp_jpeg_and_heic_are_recognised() -> None:
     webp = b"RIFF\x00\x00\x00\x00WEBPVP8 "
     jpeg = b"\xff\xd8\xff\xe0" + b"\x00" * 8
-    for payload in (webp, jpeg):
-        message = _read_file_image(payload, mime_type="image/webp")
+    heic = b"\x00\x00\x00\x18ftypheic\x00\x00\x00\x00"
+    for payload in (webp, jpeg, heic):
+        message = _read_file_image(payload, mime_type="image/heic")
         assert validate_read_file_message(message) is message
 
 

--- a/tests/middleware/test_validate_image_reads.py
+++ b/tests/middleware/test_validate_image_reads.py
@@ -1,0 +1,50 @@
+import base64
+
+from langchain_core.messages import ToolMessage
+
+from agent.middleware.validate_image_reads import validate_read_file_message
+
+PNG_HEAD = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+
+
+def _read_file_image(payload: bytes, mime_type: str = "image/png") -> ToolMessage:
+    return ToolMessage(
+        content_blocks=[
+            {"type": "image", "base64": base64.b64encode(payload).decode(), "mime_type": mime_type}
+        ],
+        name="read_file",
+        tool_call_id="call-1",
+        additional_kwargs={"read_file_path": "/tmp/pr-assets/offload.png"},
+    )
+
+
+def test_json_body_saved_as_png_becomes_text_error() -> None:
+    # Production trace: an expired download link wrote a JSON error body to offload.png.
+    message = _read_file_image(b'{"detail":{"error":"Download link is not valid"}}')
+
+    result = validate_read_file_message(message)
+
+    assert isinstance(result.content, str)
+    assert "/tmp/pr-assets/offload.png" in result.content
+    assert result.status == "error"
+    assert result.tool_call_id == "call-1"
+
+
+def test_real_image_bytes_pass_through_unchanged() -> None:
+    message = _read_file_image(PNG_HEAD)
+
+    assert validate_read_file_message(message) is message
+
+
+def test_webp_and_jpeg_are_recognised() -> None:
+    webp = b"RIFF\x00\x00\x00\x00WEBPVP8 "
+    jpeg = b"\xff\xd8\xff\xe0" + b"\x00" * 8
+    for payload in (webp, jpeg):
+        message = _read_file_image(payload, mime_type="image/webp")
+        assert validate_read_file_message(message) is message
+
+
+def test_text_reads_are_untouched() -> None:
+    message = ToolMessage(content="1\thello", name="read_file", tool_call_id="call-2")
+
+    assert validate_read_file_message(message) is message


### PR DESCRIPTION
## Summary

- Add `ValidateImageReadsMiddleware`, which checks the magic bytes (PNG, JPEG, GIF, WEBP) of any `image` block returned by `read_file` and downgrades a mismatch to a plain-text tool result.
- Register it next to `SanitizeToolInputsMiddleware` in the main agent.

## Why

`read_file` picks the content-block type from the file extension. In Slack thread `19cada89-fa6a-53e7-a2a2-d7969683fd3c` (open-swe-v3), the agent `curl`ed a PR screenshot from an expired signed download link, which wrote a 118-byte JSON error body to `offload.png`. `read_file` then attached that JSON to the model as `image/png`. Fireworks and OpenAI both rejected the request with HTTP 400, and because the `ToolMessage` is checkpointed, every later turn on the thread failed the same way, including after model fallback.

With this change the model instead sees a text tool result saying the file is not a valid image and can inspect it as text or re-download it.