### PR TITLE
fix(ui): collapse long user messages with show more instead of nested scroll

### DIFF
--- a/ui/src/features/agents/components/messages/UserMessage.tsx
+++ b/ui/src/features/agents/components/messages/UserMessage.tsx
@@ -1,11 +1,13 @@
 import { ChevronDown, ChevronRight } from "lucide-react"
 import { IoLogoSlack } from "react-icons/io5"
-import { useCallback, useLayoutEffect, useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 
 import { SkillPromptText } from "../SkillBadge"
 import { MessageTimestamp } from "./MessageTimestamp"
 import { SlackMrkdwn } from "./SlackMrkdwn"
 import type { Message } from "@/features/agents/lib/types"
+
+const COLLAPSED_MAX_HEIGHT_PX = 250
 
 export function UserMessage({ message }: { message: Message }) {
   const isSystem = message.structuredSenderKind === "system"
@@ -17,29 +19,19 @@ export function UserMessage({ message }: { message: Message }) {
 
   const images = message.chunks.filter((c) => c.kind === "image")
   const [expanded, setExpanded] = useState(false)
+  const [isTruncated, setIsTruncated] = useState(false)
   const textRef = useRef<HTMLDivElement>(null)
-  const [scrolledFromTop, setScrolledFromTop] = useState(false)
-  const [scrolledFromBottom, setScrolledFromBottom] = useState(false)
 
-  const updateScrollIndicators = useCallback(() => {
+  useEffect(() => {
     const el = textRef.current
     if (!el) return
-    setScrolledFromTop(el.scrollTop > 0)
-    setScrolledFromBottom(el.scrollTop < el.scrollHeight - el.clientHeight - 1)
-  }, [])
-
-  useLayoutEffect(() => {
-    updateScrollIndicators()
-  }, [text, updateScrollIndicators])
-
-  const topStop = scrolledFromTop ? "transparent 0, black 24px" : "black 0"
-  const bottomStop = scrolledFromBottom
-    ? "black calc(100% - 24px), transparent 100%"
-    : "black 100%"
-  const textEdgeMask =
-    scrolledFromTop || scrolledFromBottom
-      ? `linear-gradient(to bottom, ${topStop}, ${bottomStop})`
-      : undefined
+    const measure = () =>
+      setIsTruncated(el.scrollHeight > COLLAPSED_MAX_HEIGHT_PX + 1)
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [text])
 
   return (
     <div
@@ -114,12 +106,12 @@ export function UserMessage({ message }: { message: Message }) {
             {text && (
               <div
                 ref={textRef}
-                onScroll={updateScrollIndicators}
-                className="max-h-[250px] overflow-auto text-[14px] leading-[1.6] break-words whitespace-pre-wrap text-accent-foreground"
-                style={{
-                  maskImage: textEdgeMask,
-                  WebkitMaskImage: textEdgeMask,
-                }}
+                className={`text-[14px] leading-[1.6] break-words whitespace-pre-wrap text-accent-foreground ${
+                  !expanded ? "overflow-hidden" : ""
+                }`}
+                style={
+                  !expanded ? { maxHeight: COLLAPSED_MAX_HEIGHT_PX } : undefined
+                }
               >
                 {isSlack ? (
                   <SlackMrkdwn text={text} />
@@ -127,6 +119,17 @@ export function UserMessage({ message }: { message: Message }) {
                   <SkillPromptText text={text} />
                 )}
               </div>
+            )}
+            {isTruncated && (
+              <button
+                type="button"
+                onClick={() => setExpanded((value) => !value)}
+                aria-expanded={expanded}
+                data-testid="user-message-show-more"
+                className="mt-1 text-[13px] text-muted-foreground transition-colors hover:text-foreground"
+              >
+                {expanded ? "Show less" : "Show more"}
+              </button>
             )}
           </div>
         )}


### PR DESCRIPTION
A user message taller than 250px rendered as an internal scroll container, so reading the whole message meant nested scrolling inside the bubble. Replace that with the show more/less collapse the other agent chats use:

- Text caps at 250px while collapsed; a `Show more` toggle expands it fully in place (no internal scroll), `Show less` collapses again.
- The toggle only renders when the content actually overflows, measured against the collapse cap and re-measured via `ResizeObserver`.
- The scroll-indicator edge masks go away with the scroller they belonged to.

Verified against the e2e mock harness as Alice — long message collapsed, expanded, and re-collapsed:

Collapsed: https://01a08d46-cb95-77d0-8a4a-9b79008a6840--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGt3TnpnM01qUXNJbXAwYVNJNklqQXhZVEE0WkRZMkxXVXhORFl0TjJKaFppMWlObVZoTFRneFpqRm1OVGsxTWpCa01TSXNJbk5wWkNJNklqQXhZVEE0WkRRMkxXTmlPVFV0Tnpka01DMDRZVFJoTFRsaU56a3dNRGhoTmpnME1DSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMeTV2Y0dWdUxYTjNaUzloY25ScFptRmpkSE12ZFhObGNpMXRaWE56WVdkbExXTnZiR3hoY0hObFpDNXdibWNpTENKamRDSTZJbWx0WVdkbEwzQnVaeUlzSW1Oa0lqb2lhVzVzYVc1bEluMC55RjhmN3ktUEExa1Nfc2ttSGJGSVhwS3R1WnF1V0xWaXhteVZJanlqWkdDRHFMZ1dkVFRDS3Q0UGpmRjcyUTYyT0JmWUFJMG5QMnJuNjVURkhmbWFDUQ

Expanded: https://01a08d46-cb95-77d0-8a4a-9b79008a6840--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGt3TnpnM01qUXNJbXAwYVNJNklqQXhZVEE0WkRZMkxXVXhNakl0TnpsbVpDMDRZV000TFRJeE1qTTBZalV3T1dSa09TSXNJbk5wWkNJNklqQXhZVEE0WkRRMkxXTmlPVFV0Tnpka01DMDRZVFJoTFRsaU56a3dNRGhoTmpnME1DSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMeTV2Y0dWdUxYTjNaUzloY25ScFptRmpkSE12ZFhObGNpMXRaWE56WVdkbExXVjRjR0Z1WkdWa0xuQnVaeUlzSW1OMElqb2lhVzFoWjJVdmNHNW5JaXdpWTJRaU9pSnBibXhwYm1VaWZRLjFDM3M5aWl3OV80d3N5TV9kbTF4eGN4WnNMcDhNbXBIWDBkd080REdLd3U4ZWtvYjFUb3pheHFPaGEyQVNmSllWV2p5elJBQ3lFdEVjWEtKOG5LTERR

Closes OPE-67's UI half; composer-side large-paste handling stays tracked there.

Made by [Open SWE](https://openswe.vercel.app/agents/e34b4ac6-1eb7-5f30-b650-981f9b13046c) · fireworks:accounts/fireworks/models/glm-5p3-flash (max)

## References
- Plan: https://openswe.vercel.app/agents/e34b4ac6-1eb7-5f30-b650-981f9b13046c/plan
Closes OPE-67