### PR TITLE
fix: preserve cached models across app shutdown

### DIFF
--- a/agent/api/app.py
+++ b/agent/api/app.py
@@ -26,16 +26,13 @@ pin_single_event_loop()
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     from agent.dashboard.oauth import validate_github_login_allowlist
     from agent.sandboxes.providers.registry import validate_sandbox_startup_config
-    from agent.utils.model import close_cached_models, validate_local_dev_llm_config
+    from agent.utils.model import validate_local_dev_llm_config
 
     pin_single_event_loop()
     validate_github_login_allowlist()
     validate_sandbox_startup_config()
     validate_local_dev_llm_config()
-    try:
-        yield
-    finally:
-        await close_cached_models()
+    yield
 
 
 def create_app() -> FastAPI:

--- a/tests/models/test_model_cache_lifecycle.py
+++ b/tests/models/test_model_cache_lifecycle.py
@@ -1,0 +1,59 @@
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from agent.api.app import app, lifespan
+from agent.utils import model
+
+
+class _Model:
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+    async def ainvoke(self) -> str:
+        if self.closed:
+            raise RuntimeError("Cannot send a request, as the client has been closed")
+        return "ok"
+
+
+@pytest.fixture(autouse=True)
+def _clear_model_cache() -> Iterator[None]:
+    model._MODEL_CACHE.clear()
+    yield
+    model._MODEL_CACHE.clear()
+
+
+@pytest.mark.asyncio
+async def test_app_shutdown_preserves_cached_model_references(monkeypatch) -> None:
+    cached_model = _Model()
+    monkeypatch.setattr(model, "init_chat_model", lambda **_kwargs: cached_model)
+
+    retained_model = model.make_model("fireworks:test", use_gateway=False)
+    async with lifespan(app):
+        pass
+
+    assert await retained_model.ainvoke() == "ok"
+
+
+@pytest.mark.asyncio
+async def test_explicit_cache_shutdown_replaces_closed_models(monkeypatch) -> None:
+    models: list[_Model] = []
+
+    def create_model(**_kwargs: Any) -> _Model:
+        created = _Model()
+        models.append(created)
+        return created
+
+    monkeypatch.setattr(model, "init_chat_model", create_model)
+
+    first = model.make_model("fireworks:test", use_gateway=False)
+    await model.close_cached_models()
+    second = model.make_model("fireworks:test", use_gateway=False)
+
+    assert first.closed is True
+    assert second is not first
+    assert await second.ainvoke() == "ok"


### PR DESCRIPTION
The FastAPI lifespan was closing the process-wide model cache even though compiled LangGraph graphs can retain references to those model instances. Fireworks then retried requests through an irreversibly closed async client before falling back to Anthropic.

Stop treating FastAPI as the owner of the shared model cache so graph-held models remain usable across app lifespan boundaries. Preserve explicit cache cleanup for true owners and cover both behaviors with lifecycle regression tests.

<!-- langsmith-issue {"id":"a0cf323a-20a2-4ee0-9a47-14287aa24773"} -->

Made by [Open SWE](https://openswe.vercel.app/agents/701c9a04-16cc-536e-a3e7-d8416643e443) · openai:gpt-5.6-sol (high)