### PR TITLE
feat: add Auto mode to the model picker

### DIFF
--- a/agent/dashboard/threads/runs.py
+++ b/agent/dashboard/threads/runs.py
@@ -216,6 +216,7 @@ async def _create_dashboard_thread_record(
     model_id: str | None = None,
     effort: str | None = None,
     plan_mode: bool = False,
+    model_selection: str = "auto",
     admin_thread: bool = False,
     visibility: Literal["public", "private"] = "public",
     environment: str | None = None,
@@ -256,6 +257,7 @@ async def _create_dashboard_thread_record(
         "resolved_model": resolved_model,
         "resolved_effort": resolved_effort,
         "plan_mode": plan_mode,
+        "model_selection": model_selection,
         "created_at_ms": now_ms,
         "updated_at_ms": now_ms,
     }
@@ -306,6 +308,9 @@ async def _build_dashboard_configurable(
         configurable.setdefault(key, value)
     if metadata.get("plan_mode") is True:
         configurable["plan_mode"] = True
+    model_selection = metadata.get("model_selection")
+    if model_selection in {"auto", "explicit"}:
+        configurable["model_selection"] = model_selection
     # The agent re-checks the requesting user against CONFIGURED_ADMINS before it
     # hands out the environment tools, so this only marks intent.
     if metadata.get("admin_thread") is True:
@@ -448,6 +453,15 @@ async def _enrich_run_start_command(
         client_configurable.get("agent_effort"),
     )
     plan_mode_requested = client_configurable.get("plan_mode") is True
+    model_selection = (
+        "explicit"
+        if client_configurable.get("model_selection") == "explicit"
+        or (
+            client_configurable.get("model_selection") is None
+            and bool(client_configurable.get("agent_model_id"))
+        )
+        else "auto"
+    )
     offload_requested = client_configurable.get("offload_conversation") is True
     content = _command_message_content(params)
     if isinstance(content, str) and content.strip() == "/offload":
@@ -485,6 +499,7 @@ async def _enrich_run_start_command(
             model_id=client_configurable.get("agent_model_id"),
             effort=client_configurable.get("agent_effort"),
             plan_mode=plan_mode_requested,
+            model_selection=model_selection,
             admin_thread=(
                 client_configurable.get("admin_thread") is True and is_admin(email, login=login)
             ),
@@ -583,6 +598,7 @@ async def _enrich_run_start_command(
     metadata_update: dict[str, Any] = {
         "source": _DASHBOARD_SOURCE,
         "plan_mode": plan_mode_requested,
+        "model_selection": model_selection,
         PARTICIPANT_LOGINS_KEY: merge_participants(metadata.get(PARTICIPANT_LOGINS_KEY), login),
         PARTICIPANT_EMAILS_KEY: merge_participants(metadata.get(PARTICIPANT_EMAILS_KEY), email),
         "injected_dynamic_context_hashes": sorted(injected),
@@ -624,6 +640,7 @@ async def _enrich_run_start_command(
         metadata = {**metadata, **metadata_update}
         await client.threads.update(thread_id=thread_id, metadata=metadata_update)
 
+    overrides["model_selection"] = model_selection
     merged_configurable = await _build_dashboard_configurable(
         thread_id,
         login,

--- a/agent/dashboard/threads/runs.py
+++ b/agent/dashboard/threads/runs.py
@@ -496,7 +496,7 @@ async def _enrich_run_start_command(
             model_id=client_configurable.get("agent_model_id"),
             effort=client_configurable.get("agent_effort"),
             plan_mode=plan_mode_requested,
-            model_selection=model_selection,
+            model_selection=model_selection or "auto",
             admin_thread=(
                 client_configurable.get("admin_thread") is True and is_admin(email, login=login)
             ),

--- a/agent/dashboard/threads/runs.py
+++ b/agent/dashboard/threads/runs.py
@@ -453,15 +453,12 @@ async def _enrich_run_start_command(
         client_configurable.get("agent_effort"),
     )
     plan_mode_requested = client_configurable.get("plan_mode") is True
-    model_selection = (
-        "explicit"
-        if client_configurable.get("model_selection") == "explicit"
-        or (
-            client_configurable.get("model_selection") is None
-            and bool(client_configurable.get("agent_model_id"))
-        )
-        else "auto"
-    )
+    model_selection = client_configurable.get("model_selection")
+    if model_selection not in {"auto", "explicit"}:
+        if client_configurable.get("agent_model_id"):
+            model_selection = "explicit"
+        else:
+            model_selection = "auto" if creating else metadata.get("model_selection")
     offload_requested = client_configurable.get("offload_conversation") is True
     content = _command_message_content(params)
     if isinstance(content, str) and content.strip() == "/offload":

--- a/agent/dashboard/threads/summary.py
+++ b/agent/dashboard/threads/summary.py
@@ -374,6 +374,11 @@ async def _thread_summary(
         "model": model,
         "effort": effort,
         "planMode": metadata.get("plan_mode") is True,
+        "modelSelection": (
+            metadata.get("model_selection")
+            if metadata.get("model_selection") in {"auto", "explicit"}
+            else None
+        ),
         "adminThread": metadata.get("admin_thread") is True,
         "visibility": metadata.get("visibility", "public"),
         "ownerLogin": metadata.get("owner_login"),

--- a/agent/run_config.py
+++ b/agent/run_config.py
@@ -143,6 +143,7 @@ class RunConfig(BaseModel):
     # Model selection
     agent_model_id: str | None = None
     agent_effort: str | None = None
+    model_selection: str | None = None
     reviewer_model_id: str | None = None
     reviewer_reasoning_effort: str | None = None
     reviewer_subagent_model_id: str | None = None

--- a/agent/server.py
+++ b/agent/server.py
@@ -925,6 +925,9 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         adaptive_model_routing = thread_settings.get("model_routing_enabled", False)
         logger.info("Using stored thread settings: model=%s effort=%s", model_id, profile_effort)
 
+    if cfg.source == "dashboard" and cfg.model_selection in {"auto", "explicit"}:
+        adaptive_model_routing = cfg.model_selection == "auto"
+
     # An explicit per-run model choice is the one thing allowed to move a thread
     # off its stored settings; the new choice is then stored in turn.
     per_thread_model = cfg.agent_model_id

--- a/tests/dashboard/test_dashboard_thread_api.py
+++ b/tests/dashboard/test_dashboard_thread_api.py
@@ -1023,6 +1023,18 @@ async def test_enrich_run_start_command_allowlists_client_configurable(monkeypat
     assert configurable["agent_effort"] == "medium"
     assert updates[-1]["model"] == _VISION_MODEL
 
+    offloaded = await thread_runs._enrich_run_start_command(
+        "tid",
+        "octocat",
+        {
+            "method": "run.start",
+            "params": {"config": {"configurable": {"offload_conversation": True}}},
+        },
+        metadata=updates[-1],
+    )
+    assert offloaded["params"]["config"]["configurable"]["model_selection"] == "explicit"
+    assert updates[-1]["model_selection"] == "explicit"
+
 
 async def test_proxy_run_start_from_slack_thread_updates_trace_reply(monkeypatch) -> None:
     captured: dict[str, object] = {}

--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -113,7 +113,17 @@ export function AgentThreadView({
     return { modelId: thread.model, effort: thread.effort }
   }, [models, thread.model, thread.effort])
   const [selection, setSelection] = useState<ModelSelection | null>(null)
-  const activeSelection = selection ?? threadSelection ?? defaultSelection
+  const [autoSelected, setAutoSelected] = useState(false)
+  const activeSelection = autoSelected
+    ? null
+    : (selection ??
+      (thread.modelSelection === "auto"
+        ? null
+        : (threadSelection ?? defaultSelection)))
+  const handleSelectionChange = (next: ModelSelection | null) => {
+    setAutoSelected(next === null)
+    setSelection(next)
+  }
   const [planMode, setPlanMode] = useState<boolean | null>(null)
   const [planFeedbackPending, setPlanFeedbackPending] =
     useState(autoFocusComposer)
@@ -380,7 +390,7 @@ export function AgentThreadView({
                 onSubmit={submitMessage}
                 models={models}
                 selection={activeSelection}
-                onSelectionChange={setSelection}
+                onSelectionChange={handleSelectionChange}
                 planMode={activePlanMode}
                 onPlanModeChange={setPlanMode}
                 mentionPaths={mentionPaths}

--- a/ui/src/features/agents/components/AgentsHome.tsx
+++ b/ui/src/features/agents/components/AgentsHome.tsx
@@ -79,8 +79,10 @@ export function AgentsHome({
   })
   const { models, defaultSelection } = useModelOptions()
   const [selection, setSelection] = useState<ModelSelection | null>(null)
-  const activeSelection = selection ?? defaultSelection
-  const handleSelectionChange = (next: ModelSelection) => {
+  const [autoSelected, setAutoSelected] = useState(false)
+  const activeSelection = autoSelected ? null : (selection ?? defaultSelection)
+  const handleSelectionChange = (next: ModelSelection | null) => {
+    setAutoSelected(next === null)
     setSelection(next)
     persistModelSelection(next, session.data?.login ?? "")
   }

--- a/ui/src/features/agents/components/LocalAgentThreadView.tsx
+++ b/ui/src/features/agents/components/LocalAgentThreadView.tsx
@@ -86,10 +86,12 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
   } = useModelOptions()
   const [sessionSelection, setSessionSelection] = useState<{
     sessionId: string
-    selection: ModelSelection | null
-  }>({ sessionId, selection: null })
+    selection: ModelSelection | null | undefined
+  }>({ sessionId, selection: undefined })
   const selection =
-    sessionSelection.sessionId === sessionId ? sessionSelection.selection : null
+    sessionSelection.sessionId === sessionId
+      ? sessionSelection.selection
+      : undefined
   const setSelection = (next: ModelSelection | null) =>
     setSessionSelection({ sessionId, selection: next })
   const threadModelId = thread?.modelId
@@ -103,7 +105,8 @@ export function LocalAgentThreadView({ sessionId }: { sessionId: string }) {
       ? { modelId: threadModelId, effort: threadEffort }
       : null
   }, [models, threadEffort, threadModelId])
-  const activeSelection = selection ?? threadSelection ?? defaultSelection
+  const activeSelection =
+    selection === undefined ? (threadSelection ?? defaultSelection) : selection
   const initialPromptRef = useRef<string | null>(null)
   const scrollControlRef = useRef<MessagesScrollControl | null>(null)
   const streamRef = useRef(stream)

--- a/ui/src/features/agents/components/ModelPicker.test.tsx
+++ b/ui/src/features/agents/components/ModelPicker.test.tsx
@@ -60,6 +60,27 @@ function openModelPane() {
 }
 
 describe("ModelPicker", () => {
+  it("reaches Auto and models with the keyboard while routing automatically", () => {
+    const { onSelectionChange, panel } = openPicker({ selection: null })
+
+    fireEvent.keyDown(panel, { key: "ArrowRight" })
+    fireEvent.keyDown(panel, { key: "ArrowDown" })
+    fireEvent.keyDown(panel, { key: "Enter" })
+    expect(onSelectionChange).toHaveBeenLastCalledWith({
+      modelId: "openai:gpt-5.6-sol",
+      effort: "xhigh",
+    })
+
+    fireEvent.click(screen.getByRole("button", { expanded: false }))
+    fireEvent.keyDown(screen.getByTestId("model-picker-panel"), {
+      key: "ArrowRight",
+    })
+    fireEvent.keyDown(screen.getByTestId("model-picker-panel"), {
+      key: "Enter",
+    })
+    expect(onSelectionChange).toHaveBeenLastCalledWith(null)
+  })
+
   it("labels the trigger with the selected model and effort", () => {
     render(
       <ModelPicker
@@ -123,7 +144,12 @@ describe("ModelPicker", () => {
       within(models)
         .getAllByRole("option")
         .map((option) => option.textContent)
-    ).toEqual(["GPT-5.6 Sol High", "Gemini 3.8 Flash Medium", "Kimi K3 High"])
+    ).toEqual([
+      "Auto",
+      "GPT-5.6 Sol High",
+      "Gemini 3.8 Flash Medium",
+      "Kimi K3 High",
+    ])
 
     fireEvent.change(screen.getByLabelText("Search models"), {
       target: { value: "kimi" },

--- a/ui/src/features/agents/components/ModelPicker.tsx
+++ b/ui/src/features/agents/components/ModelPicker.tsx
@@ -21,7 +21,7 @@ import { cn } from "@/lib/utils"
 export interface ModelPickerProps {
   models: Array<ModelOption>
   selection: ModelSelection | null
-  onSelectionChange?: (next: ModelSelection) => void
+  onSelectionChange?: (next: ModelSelection | null) => void
   disabled?: boolean
   /** Disables models that cannot accept image input (used when images are attached). */
   requireImageSupport?: boolean
@@ -33,6 +33,8 @@ export interface ModelPickerProps {
 }
 
 type Pane = "main" | "models"
+
+const AUTO_ID = "__auto__"
 
 function effortForModel(
   model: ModelOption,
@@ -139,8 +141,8 @@ export function ModelPicker({
 
   const pickerDisabled = disabled || models.length === 0 || !onSelectionChange
 
-  const selectedModel =
-    models.find((model) => model.id === selection?.modelId) ?? models[0]
+  const selectedModel = models.find((model) => model.id === selection?.modelId)
+  const selectedEntryId = selectedModel?.id ?? AUTO_ID
   const efforts = selectedModel?.efforts ?? []
   const currentEffort = selectedModel
     ? effortForModel(selectedModel, selection)
@@ -157,10 +159,18 @@ export function ModelPicker({
     )
   }, [models, query])
 
-  const focusedModel =
-    filteredModels.find((model) => model.id === focusedModelId) ??
-    filteredModels.find((model) => model.id === selectedModel?.id) ??
-    filteredModels[0]
+  const showAuto = !query.trim()
+  const entryIds = useMemo(
+    () => [
+      ...(showAuto ? [AUTO_ID] : []),
+      ...filteredModels.map((model) => model.id),
+    ],
+    [filteredModels, showAuto]
+  )
+  const focusedEntryId =
+    [focusedModelId, selectedEntryId].find(
+      (id): id is string => id != null && entryIds.includes(id)
+    ) ?? entryIds[0]
 
   useEffect(() => {
     if (!open) return
@@ -244,10 +254,27 @@ export function ModelPicker({
     [close, modelDisabled, onSelectionChange, selection]
   )
 
+  const selectAuto = useCallback(() => {
+    onSelectionChange?.(null)
+    close()
+  }, [close, onSelectionChange])
+
+  const selectEntry = useCallback(
+    (id: string) => {
+      if (id === AUTO_ID) {
+        selectAuto()
+        return
+      }
+      const model = filteredModels.find((entry) => entry.id === id)
+      if (model) selectModel(model)
+    },
+    [filteredModels, selectAuto, selectModel]
+  )
+
   const openModelPane = useCallback(() => {
     setPane("models")
-    setFocusedModelId(selectedModel?.id ?? null)
-  }, [selectedModel])
+    setFocusedModelId(selectedEntryId)
+  }, [selectedEntryId])
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === "Escape") {
@@ -270,21 +297,19 @@ export function ModelPicker({
       }
       if (e.key === "ArrowDown" || e.key === "ArrowUp") {
         e.preventDefault()
-        if (filteredModels.length === 0) return
+        if (entryIds.length === 0) return
         const step = e.key === "ArrowDown" ? 1 : -1
-        const current = filteredModels.findIndex(
-          (model) => model.id === focusedModel?.id
-        )
+        const current = entryIds.indexOf(focusedEntryId ?? "")
         const nextIndex = Math.min(
           Math.max(current + step, 0),
-          filteredModels.length - 1
+          entryIds.length - 1
         )
-        setFocusedModelId(filteredModels[nextIndex]?.id ?? null)
+        setFocusedModelId(entryIds[nextIndex] ?? null)
         return
       }
-      if (e.key === "Enter" && focusedModel) {
+      if (e.key === "Enter" && focusedEntryId) {
         e.preventDefault()
-        selectModel(focusedModel)
+        selectEntry(focusedEntryId)
       }
       return
     }
@@ -341,7 +366,7 @@ export function ModelPicker({
           <ChevronDown className="size-3.5 shrink-0 opacity-60" />
         )}
       </button>
-      {open && !pickerDisabled && selectedModel && (
+      {open && !pickerDisabled && (
         <div
           data-testid="model-picker-panel"
           onKeyDown={handleKeyDown}
@@ -353,43 +378,51 @@ export function ModelPicker({
             tabIndex={-1}
             className="dropdown-glass flex w-56 flex-col overflow-hidden rounded-xl py-1 outline-none"
           >
-            {contextWindow != null && (
+            {selectedModel ? (
               <>
-                <SectionHeading>Context</SectionHeading>
+                {contextWindow != null && (
+                  <>
+                    <SectionHeading>Context</SectionHeading>
+                    <div
+                      className="flex items-center gap-2 px-3 py-1.5 text-[13px] text-foreground"
+                      title="Context window reported for this model"
+                    >
+                      <span className="min-w-0 flex-1 truncate">
+                        {formatTokenCount(contextWindow)}
+                      </span>
+                    </div>
+                  </>
+                )}
+                <SectionHeading>Reasoning</SectionHeading>
                 <div
-                  className="flex items-center gap-2 px-3 py-1.5 text-[13px] text-foreground"
-                  title="Context window reported for this model"
+                  role="listbox"
+                  aria-label="Reasoning effort"
+                  className="max-h-60 overflow-y-auto"
                 >
-                  <span className="min-w-0 flex-1 truncate">
-                    {formatTokenCount(contextWindow)}
-                  </span>
+                  {efforts.map((effort, index) => (
+                    <OptionRow
+                      key={effort}
+                      label={formatEffort(effort)}
+                      selected={currentEffort === effort}
+                      focused={pane === "main" && mainIndex === index}
+                      onMouseEnter={() => {
+                        setPane("main")
+                        setMainIndex(index)
+                      }}
+                      onClick={() => applyEffort(effort)}
+                    />
+                  ))}
                 </div>
               </>
+            ) : (
+              <p className="px-3 py-1.5 text-[13px] text-muted-foreground/60">
+                Model and reasoning are chosen per request.
+              </p>
             )}
-            <SectionHeading>Reasoning</SectionHeading>
-            <div
-              role="listbox"
-              aria-label="Reasoning effort"
-              className="max-h-60 overflow-y-auto"
-            >
-              {efforts.map((effort, index) => (
-                <OptionRow
-                  key={effort}
-                  label={formatEffort(effort)}
-                  selected={currentEffort === effort}
-                  focused={pane === "main" && mainIndex === index}
-                  onMouseEnter={() => {
-                    setPane("main")
-                    setMainIndex(index)
-                  }}
-                  onClick={() => applyEffort(effort)}
-                />
-              ))}
-            </div>
             <div ref={modelRowRef} className="mt-1 border-t border-border pt-1">
               <SectionHeading>Model</SectionHeading>
               <OptionRow
-                label={selectedModel.label}
+                label={selectedModel?.label ?? "Auto"}
                 selected={false}
                 focused={pane === "models" || mainIndex === modelRowIndex}
                 trailing={
@@ -419,6 +452,15 @@ export function ModelPicker({
                 aria-label="Models"
                 className="max-h-72 overflow-y-auto py-1"
               >
+                {showAuto && (
+                  <OptionRow
+                    label="Auto"
+                    selected={!selectedModel}
+                    focused={focusedEntryId === AUTO_ID}
+                    onMouseEnter={() => setFocusedModelId(AUTO_ID)}
+                    onClick={selectAuto}
+                  />
+                )}
                 {filteredModels.length === 0 ? (
                   <p className="px-3 py-1.5 text-[13px] text-muted-foreground/60">
                     No matches
@@ -427,8 +469,8 @@ export function ModelPicker({
                   filteredModels.map((model) => (
                     <OptionRow
                       key={model.id}
-                      selected={selection?.modelId === model.id}
-                      focused={focusedModel?.id === model.id}
+                      selected={selectedModel?.id === model.id}
+                      focused={focusedEntryId === model.id}
                       disabled={modelDisabled(model)}
                       onMouseEnter={() => setFocusedModelId(model.id)}
                       onClick={() => selectModel(model)}

--- a/ui/src/features/agents/components/composer/ChatComposer.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.tsx
@@ -109,7 +109,7 @@ export interface ChatComposerProps {
   onSubmit?: (value: string, images: Array<ImageChunk>) => void | Promise<void>
   models?: Array<ModelOption>
   selection?: ModelSelection | null
-  onSelectionChange?: (next: ModelSelection) => void
+  onSelectionChange?: (next: ModelSelection | null) => void
   /** Repos the user can target. When provided with onRepoChange, a repo picker is shown. */
   repos?: Array<{ full_name: string }>
   selectedRepo?: string | null

--- a/ui/src/features/agents/lib/provider/useModelOptions.ts
+++ b/ui/src/features/agents/lib/provider/useModelOptions.ts
@@ -23,7 +23,8 @@ function storedSelection(
   try {
     const selection = JSON.parse(
       window.localStorage.getItem(STORAGE_KEY) ?? "null"
-    ) as (Partial<ModelSelection> & { login?: string }) | null
+    ) as (Partial<ModelSelection> & { login?: string; mode?: string }) | null
+    if (selection?.login === login && selection.mode === "auto") return null
     return selection?.login === login &&
       models.some(
         (model) =>
@@ -38,47 +39,26 @@ function storedSelection(
 }
 
 export function persistModelSelection(
-  selection: ModelSelection,
+  selection: ModelSelection | null,
   login: string
 ): void {
   if (typeof window === "undefined" || !login) return
   try {
     window.localStorage.setItem(
       STORAGE_KEY,
-      JSON.stringify({ ...selection, login })
+      JSON.stringify(
+        selection ? { ...selection, login } : { mode: "auto", login }
+      )
     )
   } catch {}
-}
-
-function toSupportedSelection(
-  models: Array<ModelOption>,
-  modelId?: string | null,
-  effort?: string | null
-): ModelSelection | null {
-  if (!modelId || !effort) return null
-  const supported = models.some(
-    (model) => model.id === modelId && model.efforts.includes(effort)
-  )
-  return supported ? { modelId, effort } : null
 }
 
 export function useModelOptions(): ModelOptionsResult {
   const optionsQuery = useOptions()
   const session = useSession()
   const models = optionsQuery.data?.models ?? []
-  const teamDefaultSelection = toSupportedSelection(
-    models,
-    optionsQuery.data?.default_agent_model,
-    optionsQuery.data?.default_agent_reasoning_effort
-  )
-  const firstModel = models[0]
-  const firstSelection = firstModel
-    ? { modelId: firstModel.id, effort: firstModel.default_effort }
-    : null
   const defaultSelection = optionsQuery.data
-    ? (storedSelection(models, session.data?.login ?? "") ??
-      teamDefaultSelection ??
-      firstSelection)
+    ? storedSelection(models, session.data?.login ?? "")
     : null
 
   return {
@@ -106,7 +86,7 @@ export function formatModelSelection(
   models: Array<ModelOption>,
   selection: ModelSelection | null
 ): string {
-  if (!selection) return "Default"
+  if (!selection) return "Auto"
   const model = models.find((m) => m.id === selection.modelId)
   const modelLabel = model?.label ?? selection.modelId
   return `${modelLabel} ${formatEffort(selection.effort)}`

--- a/ui/src/features/agents/lib/stream/promptMessage.ts
+++ b/ui/src/features/agents/lib/stream/promptMessage.ts
@@ -32,6 +32,11 @@ export function modelConfigurable(
     | null
     | undefined
 ): Record<string, unknown> {
-  if (!selection?.modelId || !selection.effort) return {}
-  return { agent_model_id: selection.modelId, agent_effort: selection.effort }
+  if (!selection?.modelId || !selection.effort)
+    return { model_selection: "auto" }
+  return {
+    agent_model_id: selection.modelId,
+    agent_effort: selection.effort,
+    model_selection: "explicit",
+  }
 }

--- a/ui/src/features/agents/lib/types.ts
+++ b/ui/src/features/agents/lib/types.ts
@@ -364,6 +364,7 @@ export interface AgentThread {
   branch: string
   model: string
   effort?: string | null
+  modelSelection?: "auto" | "explicit" | null
   planMode?: boolean
   planStatus?: string | null
   adminThread?: boolean


### PR DESCRIPTION
Extract the Auto picker and persisted selection from https://github.com/langchain-ai/open-swe/pull/2645, without the routing state-machine rewrite. Auto uses the existing model router; explicit selections bypass routing. The original PR is unchanged.

Screenshot (signed in as Alice):
![Auto model picker](https://01a08d9d-94c3-721e-930d-d8baa30e6a4f--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGt3T0RJMU9ERXNJbXAwYVNJNklqQXhZVEE0WkdFeExXSmhOemd0TnpZeFlTMDVZbU15TFdSaVpHUXlaRFZrT1dVNFpTSXNJbk5wWkNJNklqQXhZVEE0WkRsa0xUazBZek10TnpJeFpTMDVNekJrTFdRNFltRmhNekJsTm1FMFppSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkRzF3TDJGMWRHOHRiVzlrWld3dGNHbGphMlZ5TG5CdVp5SXNJbU4wSWpvaWFXMWhaMlV2Y0c1bklpd2lZMlFpT2lKcGJteHBibVVpZlEuck8ydGdWWDdyaHJzRUJQaWRydXdCZVJjWE1vREVfM0dMQ281UDJ4RTZSQ1FPY2QwMFBzMk1sazlzZmpDQnp0aklGMVZFRW42bGY0dWE4dUZyZHQyQlE)

Made by [Open SWE](https://openswe.vercel.app/agents/01a08d9d-9026-7250-aebc-d6a14cd6434c) · openai:gpt-6-astra (low)