### PR TITLE
feat(slack): send thread feedback by DM

### DIFF
--- a/agent/slack/client.py
+++ b/agent/slack/client.py
@@ -673,6 +673,35 @@ async def post_slack_top_level_message_with_ts(
     )
 
 
+async def open_slack_direct_message(user_id: str) -> tuple[str | None, str | None]:
+    """Open the app's direct-message conversation with a Slack user."""
+    if not SLACK_BOT_TOKEN:
+        return None, "missing_slack_bot_token"
+    async with httpx2.AsyncClient(timeout=DEFAULT_HTTP_TIMEOUT) as http_client:
+        try:
+            response = await http_client.post(
+                f"{SLACK_API_BASE_URL}/conversations.open",
+                headers=slack_headers(),
+                json={"users": user_id},
+            )
+            error = _slack_response_error(response)
+            if error:
+                logger.warning("Slack conversations.open failed", extra={"slack_error": error})
+                return None, error
+            data = response.json()
+            channel = data.get("channel")
+            channel_id = channel.get("id") if isinstance(channel, Mapping) else None
+            if isinstance(channel_id, str) and channel_id:
+                return channel_id, None
+            return None, "missing_channel_id"
+        except httpx2.HTTPError as exc:
+            logger.warning("Slack conversations.open request failed", exc_info=True)
+            return None, f"http_error: {type(exc).__name__}"
+        except TypeError, ValueError:
+            logger.warning("Slack conversations.open returned an invalid response", exc_info=True)
+            return None, "invalid_slack_response"
+
+
 class SlackStreamError(Exception):
     def __init__(self, code: str, *, retry_after: float | None = None) -> None:
         super().__init__(code)

--- a/agent/slack/thread_feedback.py
+++ b/agent/slack/thread_feedback.py
@@ -13,8 +13,9 @@ from pydantic import BaseModel, Field
 from agent.slack.client import (
     get_slack_channel_context,
     lookup_slack_run_message_mapping,
+    open_slack_direct_message,
     open_slack_modal,
-    post_slack_ephemeral_message,
+    post_slack_top_level_message_with_ts,
     respond_to_slack_interaction,
     slack_channel_allows_operations,
     slack_thread_mutation_lock,
@@ -42,6 +43,7 @@ class ThreadFeedback(BaseModel):
     thread_ts: str
     message_ts: str
     user_id: str
+    dm_channel_id: str = ""
     prompted: bool = False
     dismissed: bool = False
     rating: int | None = Field(default=None, ge=1, le=5)
@@ -68,12 +70,13 @@ async def _locked_feedback(
         yield await _store(record.channel_id).get(record.run_id)
 
 
-def _dismiss_button(run_id: str) -> dict[str, Any]:
+def _dismiss_button(run_id: str, channel_id: str = "") -> dict[str, Any]:
+    value = json.dumps({"run_id": run_id, "channel_id": channel_id}) if channel_id else run_id
     return {
         "type": "button",
         "text": {"type": "plain_text", "text": "Dismiss"},
         "action_id": _DISMISS_ACTION,
-        "value": run_id,
+        "value": value,
     }
 
 
@@ -94,7 +97,7 @@ def _comment_input() -> dict[str, Any]:
     }
 
 
-def feedback_blocks(run_id: str, thread_id: str) -> list[dict[str, Any]]:
+def feedback_blocks(run_id: str, thread_id: str, channel_id: str = "") -> list[dict[str, Any]]:
     url = dashboard_thread_url(thread_id)
     thread_link = f"<{url}|this thread>" if url else "this thread"
     return [
@@ -110,18 +113,22 @@ def feedback_blocks(run_id: str, thread_id: str) -> list[dict[str, Any]]:
                     "action_id": _FEEDBACK_ACTION,
                     "positive_button": {
                         "text": {"type": "plain_text", "text": "Good"},
-                        "value": json.dumps({"run_id": run_id, "choice": "good"}),
+                        "value": json.dumps(
+                            {"run_id": run_id, "channel_id": channel_id, "choice": "good"}
+                        ),
                         "accessibility_label": "Rate this thread Good",
                     },
                     "negative_button": {
                         "text": {"type": "plain_text", "text": "Bad"},
-                        "value": json.dumps({"run_id": run_id, "choice": "bad"}),
+                        "value": json.dumps(
+                            {"run_id": run_id, "channel_id": channel_id, "choice": "bad"}
+                        ),
                         "accessibility_label": "Rate this thread Bad",
                     },
                 }
             ],
         },
-        {"type": "actions", "elements": [_dismiss_button(run_id)]},
+        {"type": "actions", "elements": [_dismiss_button(run_id, channel_id)]},
     ]
 
 
@@ -193,14 +200,16 @@ async def post_slack_feedback_prompt(
 
                 if not await feedback_event_is_ready(thread_id, expected_event_id):
                     return
-            posted = await post_slack_ephemeral_message(
-                channel_id,
-                record.user_id,
+            dm_channel_id, _ = await open_slack_direct_message(record.user_id)
+            if not dm_channel_id:
+                return
+            message_ts, _ = await post_slack_top_level_message_with_ts(
+                dm_channel_id,
                 "How did Open SWE do on this thread? Choose Good or Bad.",
-                thread_ts=record.thread_ts if record.thread_ts != "0" else None,
-                blocks=feedback_blocks(run_id, thread_id),
+                blocks=feedback_blocks(run_id, thread_id, channel_id),
             )
-            if posted:
+            if message_ts:
+                record.dm_channel_id = dm_channel_id
                 record.prompted = True
                 await store.put(run_id, record)
     except Exception:
@@ -225,6 +234,15 @@ def _action(payload: dict[str, Any]) -> dict[str, Any]:
     return {}
 
 
+def _action_value(payload: dict[str, Any]) -> dict[str, Any]:
+    value = _action(payload).get("value")
+    try:
+        parsed = json.loads(value) if isinstance(value, str) else None
+    except json.JSONDecodeError:
+        parsed = None
+    return parsed if isinstance(parsed, dict) else {"run_id": value}
+
+
 def is_slack_feedback_payload(payload: dict[str, Any]) -> bool:
     return (payload.get("type") == "block_actions" and bool(_action(payload))) or (
         payload.get("type") == "view_submission"
@@ -232,11 +250,18 @@ def is_slack_feedback_payload(payload: dict[str, Any]) -> bool:
     )
 
 
-async def _load_feedback(channel_id: str, run_id: str, user_id: str) -> ThreadFeedback | None:
+async def _load_feedback(
+    channel_id: str, run_id: str, user_id: str, *, interaction_channel_id: str = ""
+) -> ThreadFeedback | None:
     if not channel_id or not run_id or not user_id:
         return None
     record = await _store(channel_id).get(run_id)
     if record is None or record.user_id != user_id or record.channel_id != channel_id:
+        return None
+    if interaction_channel_id and interaction_channel_id not in {
+        record.channel_id,
+        record.dm_channel_id,
+    }:
         return None
     context = await get_slack_channel_context(channel_id, use_cache=False)
     return record if slack_channel_allows_operations(context) else None
@@ -300,15 +325,17 @@ async def _acknowledge(record: ThreadFeedback, *, response_url: str) -> None:
                 return
             async with asyncio.timeout(8):
                 if not current.acknowledged:
-                    # Ephemeral response_url updates can also appear at the channel root.
-                    posted = await post_slack_ephemeral_message(
-                        current.channel_id,
-                        current.user_id,
-                        "✅ Feedback completed. Thanks!",
-                        thread_ts=current.thread_ts if current.thread_ts != "0" else None,
-                    )
-                    if not posted:
+                    dm_channel_id = current.dm_channel_id
+                    if not dm_channel_id:
+                        dm_channel_id, _ = await open_slack_direct_message(current.user_id)
+                    if not dm_channel_id:
                         return
+                    message_ts, _ = await post_slack_top_level_message_with_ts(
+                        dm_channel_id, "✅ Feedback completed. Thanks!"
+                    )
+                    if not message_ts:
+                        return
+                    current.dm_channel_id = dm_channel_id
                     async with _locked_feedback(current) as latest:
                         if latest is None:
                             return
@@ -320,10 +347,17 @@ async def _acknowledge(record: ThreadFeedback, *, response_url: str) -> None:
 
 
 async def _dismiss_feedback(payload: dict[str, Any]) -> None:
-    channel_id = str(_object(payload.get("channel")).get("id") or "")
+    interaction_channel_id = str(_object(payload.get("channel")).get("id") or "")
+    selection = _action_value(payload)
+    channel_id = str(selection.get("channel_id") or interaction_channel_id)
     user_id = str(_object(payload.get("user")).get("id") or "")
     try:
-        record = await _load_feedback(channel_id, str(_action(payload).get("value") or ""), user_id)
+        record = await _load_feedback(
+            channel_id,
+            str(selection.get("run_id") or ""),
+            user_id,
+            interaction_channel_id=interaction_channel_id,
+        )
         if record is None:
             return
         async with _locked_feedback(record, purpose="feedback_response") as current:
@@ -379,14 +413,16 @@ def _comment_error(text: str) -> FeedbackResponse:
 async def _record_rating(payload: dict[str, Any], background_tasks: BackgroundTasks) -> None:
     try:
         async with asyncio.timeout(2.5):
-            selection = _object(json.loads(str(_action(payload).get("value") or "{}")))
+            selection = _action_value(payload)
             choice = selection.get("choice")
             if choice not in {"good", "bad"}:
                 return
+            interaction_channel_id = str(_object(payload.get("channel")).get("id") or "")
             record = await _load_feedback(
-                str(_object(payload.get("channel")).get("id") or ""),
+                str(selection.get("channel_id") or interaction_channel_id),
                 str(selection.get("run_id") or ""),
                 str(_object(payload.get("user")).get("id") or ""),
+                interaction_channel_id=interaction_channel_id,
             )
             if record is None:
                 return

--- a/tests/slack/test_slack_message_api.py
+++ b/tests/slack/test_slack_message_api.py
@@ -356,6 +356,32 @@ async def test_post_slack_thread_reply_with_ts_sends_blocks(
 
 
 @pytest.mark.asyncio
+async def test_open_slack_direct_message_returns_channel(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(slack_utils, "SLACK_BOT_TOKEN", "xoxb-test")
+    response = _ok_response()
+    response.json.return_value = {"ok": True, "channel": {"id": "D1"}}
+    client_cm = _async_client_cm(response)
+    with patch.object(slack_utils.httpx2, "AsyncClient", return_value=client_cm):
+        result = await slack_utils.open_slack_direct_message("U1")
+
+    assert result == ("D1", None)
+    assert client_cm.post.await_args.args[0].endswith("/conversations.open")
+    assert client_cm.post.await_args.kwargs["json"] == {"users": "U1"}
+
+
+@pytest.mark.asyncio
+async def test_open_slack_direct_message_returns_slack_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(slack_utils, "SLACK_BOT_TOKEN", "xoxb-test")
+    client_cm = _async_client_cm(_err_response("cannot_dm_bot"))
+    with patch.object(slack_utils.httpx2, "AsyncClient", return_value=client_cm):
+        result = await slack_utils.open_slack_direct_message("U1")
+
+    assert result == (None, "cannot_dm_bot")
+
+
+@pytest.mark.asyncio
 async def test_post_slack_top_level_message_with_ts_omits_thread_ts(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/slack/test_slack_thread_feedback.py
+++ b/tests/slack/test_slack_thread_feedback.py
@@ -60,6 +60,7 @@ def context(monkeypatch: pytest.MonkeyPatch, fake_store: Any) -> dict[str, Any]:
         "thread_ts": "1.0",
         "message_ts": "2.0",
         "user_id": "U1",
+        "dm_channel_id": "D1",
         "prompted": True,
     }
     fake_store.seed(("slack_thread_feedback", "C1"), "run-1", record)
@@ -69,7 +70,10 @@ def context(monkeypatch: pytest.MonkeyPatch, fake_store: Any) -> dict[str, Any]:
         "get_slack_channel_context",
         AsyncMock(return_value={"is_ext_shared": False, "is_pending_ext_shared": False}),
     )
-    monkeypatch.setattr(feedback, "post_slack_ephemeral_message", AsyncMock(return_value=True))
+    monkeypatch.setattr(feedback, "open_slack_direct_message", AsyncMock(return_value=("D1", None)))
+    monkeypatch.setattr(
+        feedback, "post_slack_top_level_message_with_ts", AsyncMock(return_value=("3.0", None))
+    )
     monkeypatch.setattr(feedback, "respond_to_slack_interaction", AsyncMock(return_value=True))
     monkeypatch.setattr(feedback, "open_slack_modal", AsyncMock(return_value=True))
     monkeypatch.setattr(feedback, "create_langsmith_thread_feedback", AsyncMock(return_value=True))
@@ -181,7 +185,7 @@ async def test_empty_optional_comment_preserves_bad_rating(context: Any, fake_st
     saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
     assert saved["choice"] == "bad" and saved["completed"] and saved["comment"] == ""
     assert feedback.create_langsmith_thread_feedback.await_args.kwargs["score"] == 0.0
-    feedback.post_slack_ephemeral_message.assert_awaited_once()
+    feedback.post_slack_top_level_message_with_ts.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -218,15 +222,15 @@ async def test_prompt_uses_exact_run_mapping_and_deduplicates(
     monkeypatch.setattr(feedback, "lookup_slack_run_message_mapping", lookup)
     for _ in range(2):
         await feedback.post_slack_feedback_prompt("thread-1", "run-1", "C1")
-    feedback.post_slack_ephemeral_message.assert_awaited_once()
-    call = feedback.post_slack_ephemeral_message.await_args
+    feedback.post_slack_top_level_message_with_ts.assert_awaited_once()
+    call = feedback.post_slack_top_level_message_with_ts.await_args
     blocks = call.kwargs["blocks"]
     assert not any(block["type"] == "input" for block in blocks)
     controls = next(block["elements"][0] for block in blocks if block["type"] == "context_actions")
     tasks = BackgroundTasks()
-    await routes.slack_interactivity(
-        _request(_action(controls["action_id"], controls["positive_button"]["value"])), tasks
-    )
+    payload = _action(controls["action_id"], controls["positive_button"]["value"])
+    payload["channel"]["id"] = "D1"
+    await routes.slack_interactivity(_request(payload), tasks)
     await tasks()
     assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["choice"] == "good"
     assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["prompted"] is True
@@ -265,7 +269,7 @@ async def test_success_completion_only_prompts_for_answered_question(
         {"thread_id": "thread-1", "run_id": "run-1", "status": "success"}
     )
     assert schedule.await_count == int(should_ask_for_feedback)
-    feedback.post_slack_ephemeral_message.assert_not_awaited()
+    feedback.post_slack_top_level_message_with_ts.assert_not_awaited()
     if should_ask_for_feedback:
         assert schedule.await_args.kwargs["answer_run_id"] == "run-1"
         assert schedule.await_args.kwargs["slack_run_id"] == "run-1"
@@ -330,14 +334,14 @@ async def test_dismiss_removes_prompt_without_saving_feedback(
             _RESPONSE_URL, {"delete_original": True}
         )
     feedback.create_langsmith_thread_feedback.assert_not_awaited()
-    feedback.post_slack_ephemeral_message.assert_not_awaited()
+    feedback.post_slack_top_level_message_with_ts.assert_not_awaited()
     saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
     assert all(saved[key] == value for key, value in context.items())
     assert saved.get("dismissed", False) is not other_user
     assert saved.get("rating") is None
     assert not saved.get("comment")
     await feedback.post_slack_feedback_prompt("thread-1", "run-1", "C1")
-    feedback.post_slack_ephemeral_message.assert_not_awaited()
+    feedback.post_slack_top_level_message_with_ts.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -355,10 +359,10 @@ async def test_prompt_cleanup_failure_preserves_saved_feedback_and_confirmation(
     assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["rating"] == 5
     feedback.create_langsmith_thread_feedback.assert_awaited_once()
     if missing_url:
-        feedback.post_slack_ephemeral_message.assert_not_awaited()
+        feedback.post_slack_top_level_message_with_ts.assert_not_awaited()
     else:
-        feedback.post_slack_ephemeral_message.assert_awaited_once_with(
-            "C1", "U1", "✅ Feedback completed. Thanks!", thread_ts="1.0"
+        feedback.post_slack_top_level_message_with_ts.assert_awaited_once_with(
+            "D1", "✅ Feedback completed. Thanks!"
         )
 
 
@@ -370,7 +374,7 @@ async def test_dismiss_failure_keeps_feedback_submittable(context: Any, fake_sto
     await tasks()
     saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
     assert not saved.get("dismissed")
-    feedback.post_slack_ephemeral_message.assert_not_awaited()
+    feedback.post_slack_top_level_message_with_ts.assert_not_awaited()
     feedback.create_langsmith_thread_feedback.assert_not_awaited()
     await _submit_rating()
     saved = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
@@ -452,14 +456,14 @@ async def test_dismiss_during_failed_submission_update_prevents_later_acknowledg
         await asyncio.gather(rating_task, dismiss_task)
     assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["dismissed"] is True
     response_mock.reset_mock()
-    feedback.post_slack_ephemeral_message.assert_awaited_once()
-    feedback.post_slack_ephemeral_message.reset_mock()
+    feedback.post_slack_top_level_message_with_ts.assert_awaited_once()
+    feedback.post_slack_top_level_message_with_ts.reset_mock()
     await feedback._acknowledge(
         feedback.ThreadFeedback(**context, rating=5, completed=True),
         response_url=_RESPONSE_URL,
     )
     response_mock.assert_not_awaited()
-    feedback.post_slack_ephemeral_message.assert_not_awaited()
+    feedback.post_slack_top_level_message_with_ts.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -512,8 +516,8 @@ async def test_failed_prompt_can_be_retried(
     context: Any, fake_store: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     fake_store.seed(("slack_thread_feedback", "C1"), "run-1", {**context, "prompted": False})
-    post = AsyncMock(side_effect=[False, True])
-    monkeypatch.setattr(feedback, "post_slack_ephemeral_message", post)
+    post = AsyncMock(side_effect=[(None, "failed"), ("4.0", None)])
+    monkeypatch.setattr(feedback, "post_slack_top_level_message_with_ts", post)
     await feedback.post_slack_feedback_prompt("thread-1", "run-1", "C1")
     assert not fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["prompted"]
     await feedback.post_slack_feedback_prompt("thread-1", "run-1", "C1")
@@ -527,7 +531,7 @@ async def test_prompt_exception_leaves_feedback_unsent(
     fake_store.seed(("slack_thread_feedback", "C1"), "run-1", {**context, "prompted": False})
     monkeypatch.setattr(
         feedback,
-        "post_slack_ephemeral_message",
+        "post_slack_top_level_message_with_ts",
         AsyncMock(side_effect=RuntimeError("Slack unavailable")),
     )
 
@@ -576,7 +580,7 @@ async def test_scheduled_prompt_rechecks_readiness_after_channel_lookup(
     await feedback.post_slack_feedback_prompt(
         "thread-1", "run-1", "C1", expected_event_id="answer:run-1"
     )
-    feedback.post_slack_ephemeral_message.assert_not_awaited()
+    feedback.post_slack_top_level_message_with_ts.assert_not_awaited()
     assert not fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["prompted"]
 
 
@@ -598,7 +602,7 @@ async def test_missing_exact_response_does_not_prompt(
         feedback, "lookup_slack_run_message_mapping", AsyncMock(return_value=mapping)
     )
     await feedback.post_slack_feedback_prompt("thread-1", "run-1", "C1")
-    feedback.post_slack_ephemeral_message.assert_not_awaited()
+    feedback.post_slack_top_level_message_with_ts.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -659,12 +663,12 @@ async def test_concurrent_completion_callbacks_post_one_prompt(
             },
         )
 
-    async def post(*args: Any, **kwargs: Any) -> bool:
+    async def post(*args: Any, **kwargs: Any) -> tuple[str, None]:
         await asyncio.sleep(0.01)
-        return True
+        return "4.0", None
 
     post_mock = AsyncMock(side_effect=post)
-    monkeypatch.setattr(feedback, "post_slack_ephemeral_message", post_mock)
+    monkeypatch.setattr(feedback, "post_slack_top_level_message_with_ts", post_mock)
     await asyncio.gather(
         feedback.post_slack_feedback_prompt("thread-1", "run-1", "C1"),
         feedback.post_slack_feedback_prompt("thread-1", second_run, "C1"),
@@ -718,7 +722,7 @@ async def test_prompt_deduplicates_existing_records_by_requester_and_slack_threa
         current["agent_thread_id"], current["run_id"], current["channel_id"]
     )
 
-    assert feedback.post_slack_ephemeral_message.await_count == int(should_prompt)
+    assert feedback.post_slack_top_level_message_with_ts.await_count == int(should_prompt)
     assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"] == previous
     assert ("run-2" in fake_store.values(("slack_thread_feedback", current["channel_id"]))) == (
         should_prompt
@@ -748,8 +752,9 @@ async def test_followup_prompts_only_thread_initiator(
         "thread-1", "run-1", "C1", require_answer=not merged_pr
     )
 
-    feedback.post_slack_ephemeral_message.assert_awaited_once()
-    assert feedback.post_slack_ephemeral_message.await_args.args[:2] == ("C1", "U1")
+    feedback.post_slack_top_level_message_with_ts.assert_awaited_once()
+    feedback.open_slack_direct_message.assert_awaited_once_with("U1")
+    assert feedback.post_slack_top_level_message_with_ts.await_args.args[0] == "D1"
     record = fake_store.values(("slack_thread_feedback", "C1"))["run-1"]
     assert record["user_id"] == "U1"
     other_user_rating = _rating()
@@ -778,7 +783,7 @@ async def test_prompt_requires_known_initiator_at_same_slack_location(
         "metadata": {"source_context": {"slack_thread": origin}}
     }
     await feedback.post_slack_feedback_prompt("thread-1", "run-1", "C1")
-    feedback.post_slack_ephemeral_message.assert_not_awaited()
+    feedback.post_slack_top_level_message_with_ts.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -788,7 +793,7 @@ async def test_old_unsent_prompt_for_other_user_is_not_reassigned(
     previous = {**context, "user_id": "U2", "prompted": False, "rating": 4}
     fake_store.seed(("slack_thread_feedback", "C1"), "run-1", previous)
     await feedback.post_slack_feedback_prompt("thread-1", "run-1", "C1")
-    feedback.post_slack_ephemeral_message.assert_not_awaited()
+    feedback.post_slack_top_level_message_with_ts.assert_not_awaited()
     assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"] == previous
 
 
@@ -800,13 +805,15 @@ async def test_submission_during_prompt_delivery_is_preserved(
     started = asyncio.Event()
     finish_post = asyncio.Event()
 
-    async def post(*args: Any, **kwargs: Any) -> bool:
+    async def post(*args: Any, **kwargs: Any) -> tuple[str, None]:
         if kwargs.get("blocks"):
             started.set()
             await finish_post.wait()
-        return True
+        return "4.0", None
 
-    monkeypatch.setattr(feedback, "post_slack_ephemeral_message", AsyncMock(side_effect=post))
+    monkeypatch.setattr(
+        feedback, "post_slack_top_level_message_with_ts", AsyncMock(side_effect=post)
+    )
     async with asyncio.timeout(2):
         prompt_task = asyncio.create_task(
             feedback.post_slack_feedback_prompt("thread-1", "run-1", "C1")
@@ -853,11 +860,11 @@ async def test_native_rating_saves_immediately_and_only_bad_opens_comment(
     feedback.respond_to_slack_interaction.assert_awaited_once_with(
         _RESPONSE_URL, {"delete_original": True}
     )
-    feedback.post_slack_ephemeral_message.assert_awaited_once()
-    confirmation = feedback.post_slack_ephemeral_message.await_args
-    assert confirmation.args[:2] == ("C1", "U1")
-    assert "completed" in confirmation.args[2].lower()
-    assert confirmation.kwargs["thread_ts"] == (None if thread_ts == "0" else "1.0")
+    feedback.post_slack_top_level_message_with_ts.assert_awaited_once()
+    confirmation = feedback.post_slack_top_level_message_with_ts.await_args
+    assert confirmation.args[0] == "D1"
+    assert "completed" in confirmation.args[1].lower()
+    assert not confirmation.kwargs
     assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["acknowledged"]
 
 
@@ -868,7 +875,7 @@ async def test_native_bad_comment_updates_rating_without_overwriting_first_comme
     rating = _action("open_swe_feedback", json.dumps({"run_id": "run-1", "choice": "bad"}))
     await routes.slack_interactivity(_request(rating), tasks)
     await tasks()
-    feedback.post_slack_ephemeral_message.assert_awaited_once()
+    feedback.post_slack_top_level_message_with_ts.assert_awaited_once()
     feedback.respond_to_slack_interaction.reset_mock()
     payload = _submission("  The tests still fail.  ")
     payload["view"]["private_metadata"] = feedback.open_slack_modal.await_args.args[1][
@@ -885,7 +892,7 @@ async def test_native_bad_comment_updates_rating_without_overwriting_first_comme
     feedback.respond_to_slack_interaction.assert_awaited_once_with(
         _RESPONSE_URL, {"delete_original": True}
     )
-    feedback.post_slack_ephemeral_message.assert_awaited_once()
+    feedback.post_slack_top_level_message_with_ts.assert_awaited_once()
     assert (
         feedback.create_langsmith_thread_feedback.await_args.kwargs["comment"]
         == "The tests still fail."
@@ -936,7 +943,7 @@ async def test_native_rating_retry_removes_controls_without_reopening_modal(cont
         for call in feedback.respond_to_slack_interaction.await_args_list
     )
     feedback.open_slack_modal.assert_awaited_once()
-    feedback.post_slack_ephemeral_message.assert_awaited_once()
+    feedback.post_slack_top_level_message_with_ts.assert_awaited_once()
     assert fake_store.values(("slack_thread_feedback", "C1"))["run-1"]["choice"] == "bad"
     assert feedback.create_langsmith_thread_feedback.await_args.kwargs["score"] == 0.0
 
@@ -945,7 +952,10 @@ async def test_native_rating_retry_removes_controls_without_reopening_modal(cont
 async def test_confirmation_failure_can_retry_without_repeating_success(
     context, fake_store, failure
 ):
-    feedback.post_slack_ephemeral_message.side_effect = [failure, True]
+    feedback.post_slack_top_level_message_with_ts.side_effect = [
+        failure if isinstance(failure, BaseException) else (None, "failed"),
+        ("4.0", None),
+    ]
     payload = _action("open_swe_feedback", json.dumps({"run_id": "run-1", "choice": "good"}))
     for deletions, expected_acknowledged in enumerate((False, True, True)):
         tasks = BackgroundTasks()
@@ -955,21 +965,21 @@ async def test_confirmation_failure_can_retry_without_repeating_success(
         assert saved["completed"] and saved["rating"] == 5
         assert saved.get("acknowledged", False) is expected_acknowledged
         assert feedback.respond_to_slack_interaction.await_count == deletions
-    assert feedback.post_slack_ephemeral_message.await_count == 2
+    assert feedback.post_slack_top_level_message_with_ts.await_count == 2
 
 
 @pytest.mark.parametrize(
-    "slow_call", ["post_slack_ephemeral_message", "create_langsmith_thread_feedback"]
+    "slow_call", ["post_slack_top_level_message_with_ts", "create_langsmith_thread_feedback"]
 )
 async def test_comment_saved_during_slow_confirmation_or_export_is_preserved(
     context: Any, fake_store: Any, slow_call: str
 ) -> None:
     started, finish = asyncio.Event(), asyncio.Event()
 
-    async def wait_for_network(*args: Any, **kwargs: Any) -> bool:
+    async def wait_for_network(*args: Any, **kwargs: Any) -> Any:
         started.set()
         await finish.wait()
-        return True
+        return ("4.0", None) if slow_call == "post_slack_top_level_message_with_ts" else True
 
     getattr(feedback, slow_call).side_effect = wait_for_network
     async with asyncio.timeout(2):
@@ -993,4 +1003,4 @@ async def test_comment_saved_during_slow_confirmation_or_export_is_preserved(
     )
     exported = feedback.create_langsmith_thread_feedback.await_args.kwargs
     assert exported["score"] == 0.0 and exported["comment"] == "Missing tests"
-    feedback.post_slack_ephemeral_message.assert_awaited_once()
+    feedback.post_slack_top_level_message_with_ts.assert_awaited_once()


### PR DESCRIPTION
Send delayed Slack feedback prompts to the initiating user’s Open SWE DM instead of inserting an ephemeral message into the source thread. Keep feedback associated with the original thread, preserve the thread link, and validate interactions against both the source and DM channel.

Made by [Open SWE](https://openswe.vercel.app/agents/e2c9c9e7-b19c-50bb-bf03-e0dd950563ba) · openai:gpt-5.6-sol (high)