### PR TITLE
fix(ui): refocus composer after submit

### DIFF
--- a/ui/src/features/agents/components/composer/ChatComposer.test.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.test.tsx
@@ -68,6 +68,25 @@ function renderComposer(
   )
 }
 
+describe("ChatComposer submit", () => {
+  it("returns focus to the editor after submitting", async () => {
+    const onSubmit = vi.fn()
+    renderComposer(false, { onSubmit })
+    const editor = screen.getByTestId("composer-editor")
+    const fileInput =
+      document.querySelector<HTMLInputElement>('input[type="file"]')!
+    const image = new File(["image"], "image.png", { type: "image/png" })
+
+    fireEvent.change(fileInput, { target: { files: [image] } })
+    const sendButton = screen.getByRole("button", { name: "Send message" })
+    await waitFor(() => expect(sendButton.hasAttribute("disabled")).toBe(false))
+    fireEvent.click(sendButton)
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce())
+    expect(document.activeElement).toBe(editor)
+  })
+})
+
 describe("ChatComposer stop button", () => {
   it("offers to stop a run this client never joined", async () => {
     renderComposer(true)

--- a/ui/src/features/agents/components/composer/ChatComposer.tsx
+++ b/ui/src/features/agents/components/composer/ChatComposer.tsx
@@ -492,6 +492,7 @@ export const ChatComposer = memo(function ChatComposer({
     applyPrompt("", 0)
     setPendingImages([])
     setDictationError(null)
+    queueMicrotask(() => editorRef.current?.focus())
     try {
       await onSubmit?.(trimmed, images)
     } catch {


### PR DESCRIPTION
Restores the composer focus lifecycle lost when the prompt UI moved to the current Lexical composer. After submission, focus now returns immediately so users can continue typing without clicking back into the input.

Includes regression coverage for attachment-only submissions.

[Screenshot](https://01a08dc1-d509-7793-9c39-bff8506727b6--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGt3T0RVek9EVXNJbXAwYVNJNklqQXhZVEE0WkdOakxUZ3paV1V0Tnprek9DMWhNelUxTFdReVltSmpZekZsTkRrM09TSXNJbk5wWkNJNklqQXhZVEE0WkdNeExXUTFNRGt0TnpjNU15MDVZek01TFdKbVpqZzFNRFkzTWpkaU5pSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMeTV2Y0dWdUxYTjNaUzloY25ScFptRmpkSE12WVhWMGIyWnZZM1Z6TFdGbWRHVnlMWE4xWW0xcGRDNXdibWNpTENKamRDSTZJbWx0WVdkbEwzQnVaeUlzSW1Oa0lqb2lhVzVzYVc1bEluMC5hUWFud3BUc0hweVdmbnluY04tWkZBVmYtanZwV1BSNFBXRjlXWDNqQ1dLaUZIZ0llWmRvRE5NaWlTTlM1aU5xTzRWSjh5M3NBOXVjZ3ZUckdrZkpBZw)

Made by [Open SWE](https://openswe.vercel.app/agents/e6ea3097-e360-5176-ab12-69bf28713c8a) · openai:gpt-5.6-sol (medium)