### PR TITLE
feat(ui): highlight New Thread as a primary sidebar action

### DIFF
--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -673,7 +673,7 @@ export function AgentsSidebar({
         <Link
           to="/agents"
           onClick={layout.closeOnMobile}
-          className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-sidebar-row-hover"
+          className="flex w-full items-center gap-2.5 rounded-md bg-sidebar-primary/10 px-2.5 py-1.5 text-sm font-medium text-sidebar-primary transition-colors hover:bg-sidebar-primary/20"
         >
           <NotePencilIcon className="size-4" />
           New Thread


### PR DESCRIPTION
## Summary

Gives the sidebar **New Thread** link a highlighted treatment — a light LangChain-blue background with blue text — so it reads as the primary sidebar action instead of blending in with the nav items. Follow-up to the discussion in #team-open-swe about the button not being obvious enough (alternative considered: subtle grey background; this ships the blue variant).

![screenshot](https://01a08d9b-c471-7b17-a4fe-48d5d38d991d--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGt3T0RVMU56UXNJbXAwYVNJNklqQXhZVEE0WkdObUxUWXpZamt0TnpNM05DMDRNREEwTFRBelpqWTBZams0T1RNNE9DSXNJbk5wWkNJNklqQXhZVEE0WkRsaUxXTTBOekV0TjJJeE55MWhOR1psTFRRNFpEVmtNemhrT1RreFpDSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMeTV2Y0dWdUxYTjNaUzloY25ScFptRmpkSE12Ym1WM0xYUm9jbVZoWkMxaWJIVmxMWE5qY21WbGJuTm9iM1F1Y0c1bklpd2lZM1FpT2lKcGJXRm5aUzl3Ym1jaUxDSmpaQ0k2SW1sdWJHbHVaU0o5LlRKQ3lod2JDUzdhN2xTMkhQT2xRWTVWR01KSU1vOE5MM0lualJ6UzlXZkZBaHNEMTJkSkZ3dWt4WXFFejNReTk1VGJzQnlueVJNMFlEV1Z1bjJTS0J3)

## Changes

- `ui/src/features/agents/components/AgentsSidebar.tsx`: styled the New Thread link with `bg-sidebar-primary/10`, `text-sidebar-primary`, and a `bg-sidebar-primary/20` hover state (uses the existing theme tokens, so dark mode is covered).

Made by [Open SWE](https://openswe.vercel.app/agents/420ce5cc-6b10-5842-9d3c-e3fb7095203b) · openai:gpt-5.6-sol (high)