### PR TITLE
feat(ui): move the thread visibility picker into the header

### DIFF
--- a/tests/e2e/tests/private_threads.spec.ts
+++ b/tests/e2e/tests/private_threads.spec.ts
@@ -44,7 +44,9 @@ test("private threads are owner-only and visibility is fixed at creation", async
     await page.request.post("/control/login", { data: { login: "alice" } });
     await page.goto("/agents");
     await dismissOnboardingIfShown(page);
-    await expect(page.getByLabel("Visibility")).toHaveValue("private");
+    await expect(
+      page.getByRole("button", { name: "Thread visibility" }),
+    ).toHaveText(/Private/);
     const editor = page.getByTestId("composer-editor");
     await editor.fill("Private planning notes");
     await editor.press("Enter");
@@ -58,7 +60,14 @@ test("private threads are owner-only and visibility is fixed at creation", async
         return response.ok() ? (await response.json()).visibility : null;
       })
       .toBe("private");
-    await expect(page.getByText("Private", { exact: true })).toBeVisible();
+    await page.getByRole("button", { name: "Thread visibility" }).click();
+    await expect(
+      page.getByRole("menuitemradio", { name: "Private" }),
+    ).toHaveAttribute("aria-checked", "true");
+    await expect(
+      page.getByRole("menuitemradio", { name: "Workspace" }),
+    ).toBeDisabled();
+    await page.keyboard.press("Escape");
 
     // Visibility cannot be changed in place; the PATCH only knows titles.
     const flip = await page.request.patch(
@@ -72,8 +81,8 @@ test("private threads are owner-only and visibility is fixed at creation", async
 
     // A shared thread continues privately as a new thread; the source is untouched.
     await page.goto(`/agents/${sharedId}`);
-    await page.getByRole("button", { name: "Thread actions" }).click();
-    await page.getByRole("menuitem", { name: "Continue privately" }).click();
+    await page.getByRole("button", { name: "Thread visibility" }).click();
+    await page.getByRole("menuitemradio", { name: "Private" }).click();
     await expect(page).toHaveURL(new RegExp(`/agents/(?!${sharedId})[^/]+$`));
     continuedId = new URL(page.url()).pathname.split("/").pop()!;
     const continued = await (

--- a/ui/src/features/agents/components/AgentThreadHeader.tsx
+++ b/ui/src/features/agents/components/AgentThreadHeader.tsx
@@ -1,6 +1,6 @@
 import { ContextMenu } from "@base-ui/react/context-menu"
 import { Menu } from "@base-ui/react/menu"
-import { DotsThreeIcon, LockIcon } from "@phosphor-icons/react"
+import { DotsThreeIcon } from "@phosphor-icons/react"
 import { Folder } from "lucide-react"
 import { useRef, useState } from "react"
 
@@ -14,6 +14,7 @@ import { useSidebarCollapsed } from "@/components/sidebar-layout"
 import { Tooltip, TooltipPopup, TooltipTrigger } from "@/components/ui/tooltip"
 import { DeleteThreadDialog } from "@/features/agents/components/DeleteThreadDialog"
 import { ThreadMenuItems } from "@/features/agents/components/ThreadMenuItems"
+import { ThreadVisibilityMenu } from "@/features/agents/components/ThreadVisibilityMenu"
 import type { AgentThread } from "@/features/agents/lib/types"
 import {
   useContinueThreadPrivately,
@@ -23,6 +24,7 @@ import {
   useSidebarPinnedThreads,
   useSidebarProjects,
 } from "@/features/agents/lib/queries"
+import type { ThreadVisibility } from "@/lib/api"
 import { useSession } from "@/lib/session"
 import { cn } from "@/lib/utils"
 
@@ -75,6 +77,8 @@ export function AgentThreadHeader({
   thread,
   onRename,
   localThread,
+  visibility,
+  onVisibilityChange,
 }: {
   title?: string | null
   target: "Cloud" | "This Mac"
@@ -82,6 +86,10 @@ export function AgentThreadHeader({
   onRename?: (title: string) => Promise<unknown>
   localThread?: DesktopLocalThreadSummary
   thread?: AgentThread
+  // Visibility of a thread that does not exist yet; existing threads read it
+  // from `thread` and can only continue privately.
+  visibility?: ThreadVisibility
+  onVisibilityChange?: (next: ThreadVisibility) => void
 }) {
   const navigate = useNavigate()
   const refreshLocalThreads = useRefreshLocalThreads()
@@ -165,6 +173,38 @@ export function AgentThreadHeader({
     editingRef.current = true
     setDraft(title)
   }
+  const continueThreadPrivately = () => {
+    if (!thread || localThread || continuePrivately.isPending) return
+    setRenameError(null)
+    continuePrivately.mutate(thread.id, {
+      onError: (error) =>
+        setRenameError(
+          error instanceof Error
+            ? error.message
+            : "Could not continue privately"
+        ),
+    })
+  }
+  const visibilityMenu = thread ? (
+    <ThreadVisibilityMenu
+      value={thread.visibility ?? "public"}
+      onChange={(next) => {
+        if (next === "private") continueThreadPrivately()
+      }}
+      disabledValues={thread.visibility === "private" ? ["public"] : []}
+      busy={continuePrivately.isPending}
+    />
+  ) : visibility ? (
+    <ThreadVisibilityMenu
+      value={visibility}
+      onChange={(next) => onVisibilityChange?.(next)}
+      disabledValues={
+        onVisibilityChange
+          ? []
+          : [visibility === "private" ? "public" : "private"]
+      }
+    />
+  ) : null
   const menuItems = (
     <ThreadMenuItems
       thread={thread ?? null}
@@ -190,22 +230,6 @@ export function AgentThreadHeader({
         }
       }}
       onDelete={() => setDeleteOpen(true)}
-      onContinuePrivately={
-        thread && !localThread
-          ? () => {
-              if (continuePrivately.isPending) return
-              setRenameError(null)
-              continuePrivately.mutate(thread.id, {
-                onError: (error) =>
-                  setRenameError(
-                    error instanceof Error
-                      ? error.message
-                      : "Could not continue privately"
-                  ),
-              })
-            }
-          : undefined
-      }
     />
   )
 
@@ -271,15 +295,6 @@ export function AgentThreadHeader({
                 {title}
               </span>
             )}
-            {thread?.visibility === "private" && (
-              <span
-                className="inline-flex shrink-0 items-center gap-1 rounded-md bg-muted px-2 py-1 text-xs"
-                title="Only you can prompt this thread. Visibility is fixed for the life of a thread."
-              >
-                <LockIcon className="size-3" />
-                Private
-              </span>
-            )}
             {(thread || localThread) && (
               <Menu.Root>
                 <Menu.Trigger
@@ -317,9 +332,10 @@ export function AgentThreadHeader({
             )}
           </div>
         )}
-        <span className="ml-auto shrink-0 text-xs text-muted-foreground">
-          {target}
-        </span>
+        <div className="ml-auto flex shrink-0 items-center gap-3">
+          <span className="text-xs text-muted-foreground">{target}</span>
+          {!localThread && visibilityMenu}
+        </div>
       </div>
     </header>
   )

--- a/ui/src/features/agents/components/AgentsHome.tsx
+++ b/ui/src/features/agents/components/AgentsHome.tsx
@@ -491,13 +491,15 @@ export function AgentsHome({
     <>
       <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
         {session.data && !routePending && <OnboardingDialog />}
-        {optimisticDraftThread && (
-          <AgentThreadHeader
-            title={optimisticDraftThread.title}
-            target={runTarget === "local" ? "This Mac" : "Cloud"}
-            panelCollapsed={panelCollapsed}
-          />
-        )}
+        <AgentThreadHeader
+          title={optimisticDraftThread?.title}
+          target={runTarget === "local" ? "This Mac" : "Cloud"}
+          panelCollapsed={panelCollapsed}
+          visibility={runTarget === "cloud" ? visibility : undefined}
+          onVisibilityChange={
+            submittedDraft ? undefined : setVisibilityOverride
+          }
+        />
         {optimisticDraftThread ? (
           <Messages
             messages={optimisticDraftThread.messages}
@@ -519,30 +521,6 @@ export function AgentsHome({
           </div>
         )}
         <AgentComposerDock>
-          {runTarget === "cloud" && !submittedDraft && (
-            <div className="mb-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-              <label htmlFor="thread-visibility">Visibility</label>
-              <select
-                id="thread-visibility"
-                value={visibility}
-                onChange={(event) =>
-                  setVisibilityOverride(
-                    event.target.value as "public" | "private"
-                  )
-                }
-                className="rounded-md border border-border bg-background px-2 py-1 text-foreground focus-visible:ring-2 focus-visible:ring-ring"
-              >
-                <option value="private">Private · only you</option>
-                <option value="public">Workspace</option>
-              </select>
-              <span>
-                {visibility === "private"
-                  ? "Only you can view or prompt it; your personal integrations are available."
-                  : "Anyone in the workspace can view and prompt it; personal integrations stay off."}{" "}
-                Visibility cannot change later.
-              </span>
-            </div>
-          )}
           {localError && (
             <div className="mb-3 w-full rounded-xl border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
               {localError}

--- a/ui/src/features/agents/components/ThreadMenuItems.tsx
+++ b/ui/src/features/agents/components/ThreadMenuItems.tsx
@@ -3,7 +3,6 @@ import {
   ArchiveIcon,
   ArrowCounterClockwiseIcon,
   CopyIcon,
-  LockIcon,
   PushPinIcon,
   PushPinSlashIcon,
   TrashIcon,
@@ -21,7 +20,6 @@ export function ThreadMenuItems({
   onTogglePin,
   onToggleArchived,
   onDelete,
-  onContinuePrivately,
 }: {
   thread: AgentThread | null
   pinned: boolean
@@ -30,7 +28,6 @@ export function ThreadMenuItems({
   onTogglePin: () => void
   onToggleArchived: () => void
   onDelete: () => void
-  onContinuePrivately?: () => void
 }) {
   return (
     <>
@@ -80,16 +77,6 @@ export function ThreadMenuItems({
         >
           <CopyIcon className="size-3.5" />
           Copy sandbox ID
-        </Menu.Item>
-      )}
-      {thread && thread.visibility !== "private" && onContinuePrivately && (
-        <Menu.Item
-          onClick={onContinuePrivately}
-          title="Copy this transcript into a new private thread that only you can prompt"
-          className="flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-xs outline-none select-none data-highlighted:bg-muted"
-        >
-          <LockIcon className="size-3.5" />
-          Continue privately
         </Menu.Item>
       )}
       <Menu.Item

--- a/ui/src/features/agents/components/ThreadVisibilityMenu.tsx
+++ b/ui/src/features/agents/components/ThreadVisibilityMenu.tsx
@@ -1,0 +1,73 @@
+import { CaretDownIcon, GlobeIcon, LockIcon } from "@phosphor-icons/react"
+
+import {
+  Menu,
+  MenuPopup,
+  MenuRadioGroup,
+  MenuRadioItem,
+  MenuTrigger,
+} from "@/components/ui/menu"
+import type { ThreadVisibility } from "@/lib/api"
+
+const OPTIONS: Record<
+  ThreadVisibility,
+  { label: string; Icon: typeof LockIcon }
+> = {
+  private: { label: "Private", Icon: LockIcon },
+  public: { label: "Workspace", Icon: GlobeIcon },
+}
+const ORDER: ThreadVisibility[] = ["private", "public"]
+
+export function ThreadVisibilityMenu({
+  value,
+  onChange,
+  disabledValues = [],
+  busy = false,
+}: {
+  value: ThreadVisibility
+  onChange: (next: ThreadVisibility) => void
+  disabledValues?: ThreadVisibility[]
+  busy?: boolean
+}) {
+  const current = OPTIONS[value]
+  return (
+    <Menu>
+      <MenuTrigger
+        aria-label="Thread visibility"
+        aria-busy={busy}
+        disabled={busy}
+        data-no-drag=""
+        className="inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-border/60 px-2 text-xs text-foreground transition-colors hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none disabled:opacity-60"
+      >
+        <current.Icon className="size-3.5" />
+        {current.label}
+        <CaretDownIcon className="size-3 text-muted-foreground" />
+      </MenuTrigger>
+      <MenuPopup align="end" className="min-w-36">
+        <MenuRadioGroup
+          value={value}
+          onValueChange={(next) => {
+            if (next !== value) onChange(next as ThreadVisibility)
+          }}
+        >
+          {ORDER.map((option) => {
+            const { label, Icon } = OPTIONS[option]
+            return (
+              <MenuRadioItem
+                key={option}
+                value={option}
+                disabled={disabledValues.includes(option)}
+                closeOnClick
+              >
+                <span className="inline-flex items-center gap-2">
+                  <Icon className="size-3.5 text-muted-foreground" />
+                  {label}
+                </span>
+              </MenuRadioItem>
+            )
+          })}
+        </MenuRadioGroup>
+      </MenuPopup>
+    </Menu>
+  )
+}


### PR DESCRIPTION
## Summary

Moves the thread visibility picker out of the new-thread composer and into a Claude-chat-style button in the top-right corner of the thread header, and drops all of the explanatory copy.

## What changed

- New `ThreadVisibilityMenu`: a compact pill button showing the current visibility (lock for Private, globe for Workspace) that opens a two-item radio popup. Labels only, no descriptions.
- `AgentThreadHeader` renders the control at the far right next to the Cloud label and no longer shows the inline "Private" badge beside the title.
- `AgentsHome` always renders the header, so the picker is in the same place on the new-thread screen. The `<select>` and its copy are removed from the composer dock; the chosen value still flows into the thread's creation config as before.
- `ThreadMenuItems` drops "Continue privately" since the header control covers it.
- The private-threads e2e spec uses the new button and `menuitemradio` roles.

## Reviewer notes

Visibility is still fixed at thread creation on the backend, and this PR keeps that contract. On a workspace thread, choosing Private in the popup runs the existing continue-privately flow, which opens a new owner-only copy. On a private thread the Workspace option is disabled. True in-place switching would be a backend change and is out of scope here.

The Settings page copy under the default-visibility preference is unchanged.

## Screenshots
<img width="255" height="137" alt="Screenshot 2026-09-10 at 5 35 00 PM" src="https://github.com/user-attachments/assets/a9908df7-4237-401b-a347-2b39742824d3" />
