### PR TITLE
chore(desktop): bump version to 0.2.9

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "open-swe-desktop",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": true,
   "description": "Experimental Open SWE desktop client",
   "main": "build/main.cjs",


### PR DESCRIPTION
Bumps the desktop app version from 0.2.8 to 0.2.9 (patch).

- `desktop/package.json` is the only tracked file carrying the authoritative desktop version; no other synchronized version metadata needed edits.
- JSON validity, the exact new version, and `git diff --check` were verified.

Made by [Open SWE](https://openswe.vercel.app/agents/20fe1f7d-7a94-52ed-bf56-a08dad366b05) · fireworks:accounts/fireworks/models/glm-5p3-flash (max)