### PR TITLE
fix(slack): keep thinking status active for the whole run

### DIFF
--- a/agent/completion.py
+++ b/agent/completion.py
@@ -29,6 +29,7 @@ from agent.review.findings import REVIEWER_THREAD_KIND
 from agent.review.publish import settle_review_check_run
 from agent.session_cost import schedule_session_cost_refresh
 from agent.slack.client import post_slack_thread_reply
+from agent.slack.client import set_slack_thread_status as clear_slack_thread_status
 from agent.slack.code_channels import is_code_channel_session, set_session_status
 from agent.source_context import SourceContext
 from agent.thread_feedback import schedule_answer_feedback
@@ -297,6 +298,28 @@ async def _finalize_agent_usage_telemetry(
     )
 
 
+async def _settle_slack_thread_status(
+    client: LangGraphClient, thread_id: str, metadata: dict[str, Any]
+) -> None:
+    """Clear the animated "Thinking..." thread status once no run is left.
+
+    The status persists for a whole run (Slack drops it on each assistant
+    message, so the observer keeps refreshing it); a completion that arrives
+    while another run is still active must not clear that run's status.
+    """
+    try:
+        for status in ("pending", "running"):
+            if await client.runs.list(thread_id, status=status, limit=1):
+                return
+    except Exception:  # noqa: BLE001
+        logger.debug("run-complete: could not list runs for %s", thread_id, exc_info=True)
+        return
+    slack_thread = SourceContext.from_metadata(metadata).slack_thread
+    if slack_thread is None or not slack_thread.channel_id or not slack_thread.thread_ts:
+        return
+    await clear_slack_thread_status(slack_thread.channel_id, slack_thread.thread_ts)
+
+
 async def _settle_code_channel_session(
     client: LangGraphClient, thread_id: str, metadata: dict[str, Any]
 ) -> None:
@@ -334,6 +357,7 @@ async def _handle_successful_run(
     if metadata.get("kind") == REVIEWER_THREAD_KIND:
         return {"status": "ignored", "reason": "not an agent Slack run"}
     await _settle_code_channel_session(client, thread_id, metadata)
+    await _settle_slack_thread_status(client, thread_id, metadata)
     payload_metadata = payload.get("metadata")
     automated = (
         isinstance(payload_metadata, dict) and payload_metadata.get("kind") == "thread_wakeup"
@@ -435,6 +459,7 @@ async def handle_run_completion(payload: dict[str, Any]) -> dict[str, str]:
     metadata = metadata if isinstance(metadata, dict) else {}
     await _settle_failed_reviewer_check(thread_id, metadata)
     await _settle_code_channel_session(client, thread_id, metadata)
+    await _settle_slack_thread_status(client, thread_id, metadata)
     if run_id is None:
         # Payloads without run ids fall back to the old per-thread flag; run-scoped
         # dedupe intentionally does not read it so future runs can still report.

--- a/agent/completion.py
+++ b/agent/completion.py
@@ -317,7 +317,7 @@ async def _settle_slack_thread_status(
     slack_thread = SourceContext.from_metadata(metadata).slack_thread
     if slack_thread is None or not slack_thread.channel_id or not slack_thread.thread_ts:
         return
-    await clear_slack_thread_status(slack_thread.channel_id, slack_thread.thread_ts)
+    await clear_slack_thread_status(slack_thread.channel_id, slack_thread.thread_ts, "")
 
 
 async def _settle_code_channel_session(

--- a/agent/slack/thinking.py
+++ b/agent/slack/thinking.py
@@ -306,16 +306,15 @@ async def stream_slack_thinking_steps(
 async def show_slack_thinking_status(
     *, client: LangGraphClient, thread_id: str, run_id: str, channel_id: str, thread_ts: str
 ) -> None:
-    """Keep Slack's animated "Thinking..." thread status alive until the run ends."""
+    """Keep Slack's animated "Thinking..." thread status alive until the run ends.
+
+    Slack stops the animation when the assistant posts a message, so the status
+    is refreshed in the background for the whole run and cleared by the run
+    completion webhook once no run is left.
+    """
     if not await set_slack_thread_status(channel_id, thread_ts, _THINKING_STATUS):
         return
-
-    async def refresh() -> None:
-        while True:
-            await asyncio.sleep(_STATUS_REFRESH_SECONDS)
-            await set_slack_thread_status(channel_id, thread_ts, _THINKING_STATUS)
-
-    refresher = asyncio.create_task(refresh())
+    refresher = asyncio.create_task(_refresh_thinking_status(channel_id, thread_ts))
     try:
         async with client.threads.stream(thread_id, assistant_id="agent") as thread_stream:
             async for event in thread_stream.subscribe(["lifecycle"]):
@@ -330,15 +329,10 @@ async def show_slack_thinking_status(
         logger.warning("Slack thinking status observer failed for run %s", run_id, exc_info=True)
     finally:
         refresher.cancel()
-        if not await asyncio.shield(_thread_has_active_runs(client, thread_id)):
-            await asyncio.shield(set_slack_thread_status(channel_id, thread_ts, ""))
 
 
-async def _thread_has_active_runs(client: LangGraphClient, thread_id: str) -> bool:
-    try:
-        for status in ("pending", "running"):
-            if await client.runs.list(thread_id, status=status, limit=1):
-                return True
-    except Exception:  # noqa: BLE001
-        logger.debug("Could not list runs for thread %s", thread_id, exc_info=True)
-    return False
+async def _refresh_thinking_status(channel_id: str, thread_ts: str) -> None:
+    """Re-assert the status periodically; Slack drops it on each assistant message."""
+    while True:
+        await asyncio.sleep(_STATUS_REFRESH_SECONDS)
+        await set_slack_thread_status(channel_id, thread_ts, _THINKING_STATUS)

--- a/tests/slack/test_slack_thinking.py
+++ b/tests/slack/test_slack_thinking.py
@@ -1,4 +1,5 @@
-from unittest.mock import AsyncMock
+import asyncio
+from unittest.mock import AsyncMock, call
 
 from agent.slack import thinking as slack_thinking
 
@@ -186,3 +187,47 @@ def test_namespaced_tool_events_have_stable_distinct_ids() -> None:
     assert len(stream.steps) == 2
     assert {step.title for step in stream.steps.values()} == {"Reading auth.py"}
     assert len({step.task_id for step in stream.steps.values()}) == 2
+
+
+async def test_thinking_status_refreshes_until_the_run_ends(monkeypatch) -> None:
+    set_status = AsyncMock(return_value=True)
+    monkeypatch.setattr(slack_thinking, "set_slack_thread_status", set_status)
+    monkeypatch.setattr(slack_thinking, "_STATUS_REFRESH_SECONDS", 0.0)
+
+    class ThreadStream:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            pass
+
+        def subscribe(self, channels):
+            assert channels == ["lifecycle"]
+
+            async def iterator():
+                running = _event("lifecycle", {"event": "running"})
+                running["event_id"] = "synth:run-1:lc||running"
+                yield running
+                await asyncio.sleep(0)
+                await asyncio.sleep(0)
+                completed = _event("lifecycle", {"event": "completed"})
+                completed["event_id"] = "synth:run-1:lc||completed"
+                yield completed
+
+            return iterator()
+
+    client = AsyncMock()
+    client.threads.stream = lambda *_args, **_kwargs: ThreadStream()
+
+    await slack_thinking.show_slack_thinking_status(
+        client=client,
+        thread_id="thread-1",
+        run_id="run-1",
+        channel_id="C1",
+        thread_ts="1.0",
+    )
+
+    assert set_status.await_args_list == [
+        call("C1", "1.0", slack_thinking._THINKING_STATUS),
+        call("C1", "1.0", slack_thinking._THINKING_STATUS),
+    ]

--- a/tests/webhooks/test_completion_webhook.py
+++ b/tests/webhooks/test_completion_webhook.py
@@ -468,6 +468,76 @@ async def test_no_reply_channel_does_not_flag(monkeypatch: pytest.MonkeyPatch) -
     assert client.threads.updates == []
 
 
+class _FakeRuns:
+    def __init__(self, active: bool) -> None:
+        self._active = active
+
+    async def list(self, thread_id: str, status: str, limit: int) -> list[dict[str, Any]]:
+        return [{"run_id": "run-2"}] if self._active else []
+
+
+class _FakeActiveRunClient(_FakeClient):
+    def __init__(self, metadata: dict[str, Any], active: bool) -> None:
+        super().__init__(metadata)
+        self.runs = _FakeRuns(active)
+
+
+def _slack_metadata() -> dict[str, Any]:
+    return {
+        "source": "slack",
+        "source_context": {"slack_thread": {"channel_id": "C1", "thread_ts": "123.45"}},
+    }
+
+
+@pytest.mark.asyncio
+async def test_success_clears_thinking_status_when_no_run_is_left(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeActiveRunClient(_slack_metadata(), active=False)
+    monkeypatch.setattr(completion, "langgraph_client", lambda: client)
+    cleared = AsyncMock()
+    monkeypatch.setattr(completion, "clear_slack_thread_status", cleared)
+
+    await completion.handle_run_completion(
+        {"thread_id": "t1", "run_id": "run-1", "status": "success"}
+    )
+
+    cleared.assert_awaited_once_with("C1", "123.45")
+
+
+@pytest.mark.asyncio
+async def test_success_keeps_thinking_status_while_another_run_is_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeActiveRunClient(_slack_metadata(), active=True)
+    monkeypatch.setattr(completion, "langgraph_client", lambda: client)
+    cleared = AsyncMock()
+    monkeypatch.setattr(completion, "clear_slack_thread_status", cleared)
+
+    await completion.handle_run_completion(
+        {"thread_id": "t1", "run_id": "run-1", "status": "success"}
+    )
+
+    cleared.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_error_clears_thinking_status_when_no_run_is_left(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _FakeActiveRunClient(_slack_metadata(), active=False)
+    monkeypatch.setattr(completion, "langgraph_client", lambda: client)
+    monkeypatch.setattr(completion, "post_slack_thread_reply", AsyncMock(return_value=True))
+    cleared = AsyncMock()
+    monkeypatch.setattr(completion, "clear_slack_thread_status", cleared)
+
+    await completion.handle_run_completion(
+        {"thread_id": "t1", "run_id": "run-1", "status": "error"}
+    )
+
+    cleared.assert_awaited_once_with("C1", "123.45")
+
+
 @pytest.mark.asyncio
 async def test_automated_wakeup_failure_preserves_prior_silent_behavior(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/webhooks/test_completion_webhook.py
+++ b/tests/webhooks/test_completion_webhook.py
@@ -1,5 +1,5 @@
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, create_autospec
 
 import pytest
 from langchain_core.messages import AIMessage
@@ -495,14 +495,14 @@ async def test_success_clears_thinking_status_when_no_run_is_left(
 ) -> None:
     client = _FakeActiveRunClient(_slack_metadata(), active=False)
     monkeypatch.setattr(completion, "langgraph_client", lambda: client)
-    cleared = AsyncMock()
+    cleared = create_autospec(completion.clear_slack_thread_status)
     monkeypatch.setattr(completion, "clear_slack_thread_status", cleared)
 
     await completion.handle_run_completion(
         {"thread_id": "t1", "run_id": "run-1", "status": "success"}
     )
 
-    cleared.assert_awaited_once_with("C1", "123.45")
+    cleared.assert_awaited_once_with("C1", "123.45", "")
 
 
 @pytest.mark.asyncio
@@ -511,7 +511,7 @@ async def test_success_keeps_thinking_status_while_another_run_is_active(
 ) -> None:
     client = _FakeActiveRunClient(_slack_metadata(), active=True)
     monkeypatch.setattr(completion, "langgraph_client", lambda: client)
-    cleared = AsyncMock()
+    cleared = create_autospec(completion.clear_slack_thread_status)
     monkeypatch.setattr(completion, "clear_slack_thread_status", cleared)
 
     await completion.handle_run_completion(
@@ -528,14 +528,14 @@ async def test_error_clears_thinking_status_when_no_run_is_left(
     client = _FakeActiveRunClient(_slack_metadata(), active=False)
     monkeypatch.setattr(completion, "langgraph_client", lambda: client)
     monkeypatch.setattr(completion, "post_slack_thread_reply", AsyncMock(return_value=True))
-    cleared = AsyncMock()
+    cleared = create_autospec(completion.clear_slack_thread_status)
     monkeypatch.setattr(completion, "clear_slack_thread_status", cleared)
 
     await completion.handle_run_completion(
         {"thread_id": "t1", "run_id": "run-1", "status": "error"}
     )
 
-    cleared.assert_awaited_once_with("C1", "123.45")
+    cleared.assert_awaited_once_with("C1", "123.45", "")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

The animated "Thinking..." thread status in Slack was cleared as soon as the assistant posted its first message, even though the run was still working. Users saw the indicator disappear while Open SWE kept running — Slack shows the status as done while the web dashboard still reports the thread as running.

## Solution

- `agent/slack/thinking.py`: the status observer keeps refreshing "Thinking..." in the background for the whole run (Slack drops the animation on every assistant message). Merged with main's session-anchor work: DM/code-channel sessions release the anchor on run end; a thread's indicator is cleared only when no run is left.
- `agent/completion.py`: the run-completion webhook clears the status only after `client.runs.list` shows no pending/running run, so a follow-up run keeps its status. Session threads (ts `0`) are skipped — their status is anchored to the newest message, and clearing ts `0` would drop a live run's indicator.
- Removed the inline observer clear that raced the completion webhook.

## E2E

- Branch was missing main's fake GitHub `/installation/repositories` endpoint, so every PR-creation spec failed with `workspace_repo` access errors (the spec runs here reproduced it). Merging main in restored PR creation: `dashboard_pull_requests` PR-body specs and the PR-creation path now pass locally (Postgres + harness up).
- `dashboard.spec.ts` "SAME user continues" still fails on the `pr-hover-card` tooltip assertion on this checkout and on plain `origin/main` locally too — unrelated to this change.

Made by [Open SWE](https://openswe.vercel.app/agents/8e32418d-8d8e-5fa5-bbeb-434405f81a03) · fireworks:accounts/fireworks/models/glm-5p3-flash (max)