### PR TITLE
docs: propose expedited Slack review as OEP-0002

### DIFF
--- a/oeps/0002-expedited-slack-review.md
+++ b/oeps/0002-expedited-slack-review.md
@@ -1,0 +1,296 @@
+# OEP-0002: Expedited Slack review for small pull requests
+
+- **Authors:** Ramon Nogueira (`@ramon-langchain`)
+- **Status:** Draft
+- **Created:** 2026-09-09
+- **Discussion:** https://github.com/langchain-ai/open-swe/issues/2569
+- **Supersedes:** None
+
+## Summary
+
+Allow an agent to nominate a small, low-risk pull request for expedited review in
+Slack. Once checks and automated reviews are complete and clean, publish its full
+diff with approval and rejection buttons. At least two distinct authorized people
+must approve the current round before Open SWE attempts a normal GitHub merge.
+
+Slack is the review interface, not a way around GitHub protections. Non-author
+approvals become real GitHub reviews through each person's linked account. A
+rejection ends the round immediately; feedback returns to the agent, and any
+subsequent round starts with no votes. On confirmed merge, update the Slack
+message, react to the original thread, and resolve the Open SWE job without
+another agent turn.
+
+This OEP proposes product and trust boundaries, not a commitment to specific tool
+names or storage schemas. Publishing this draft does not accept or implement it.
+
+## Motivation
+
+For tiny changes, opening GitHub and finding the relevant diff can take longer
+than reviewing the change. The work and its participants are often already in
+Slack. Presenting a complete, revision-bound diff there can shorten the approval
+loop without removing human review.
+
+Open SWE already has durable CI monitoring in baby-sit, signed Slack interactions,
+linked GitHub identities, automated reviewer state, and tracked-PR thread
+resolution. These pieces should support a deliberate workflow rather than an
+agent polling indefinitely or interpreting ordinary reactions as merge consent.
+
+## Proposal
+
+### Eligibility and enrollment
+
+The feature is disabled by default and enabled per repository. At task completion,
+the agent may call an enrollment tool for a PR tracked by the current Open SWE
+thread, supplying a short explanation of why expedited review is appropriate.
+The backend, not the agent's assertion, enforces eligibility and authorization.
+
+The initial scope is 1–10 total added plus deleted lines in a complete text diff.
+Size is a ceiling, not proof of low risk. Authentication, authorization, secrets,
+workflow, dependency, migration, binary, and otherwise high-risk changes use
+normal review. A truncated or impractically large preview is ineligible even if
+its changed-line count is small. Repository policy may narrow this scope.
+
+Enrollment binds the repository, PR, original Slack location, Open SWE thread,
+head SHA, base/diff fingerprint, and policy version. Each approval round has a
+unique identity, even when a later round reviews the same commit. Draft PRs can
+be monitored, but must explicitly be marked ready and complete resulting checks
+and reviews before approval controls appear.
+
+### Event-driven readiness
+
+Generalize baby-sit's durable subscription infrastructure: PR-to-thread routing,
+event deduplication, distributed serialization, and scheduled reconciliation.
+Keep baby-sit's retry policy separate from expedited review's merge policy, and
+preserve existing watches and scheduler entrypoints during migration.
+
+Watch checks, commit statuses, PR lifecycle and revision changes, review events,
+review-thread resolution, and PR comments, including events without an Open SWE
+mention. Open SWE's own reviewer should expose completion for the reviewed
+revision. Successful events matter as much as failing ones; the current baby-sit
+failure-only webhook path is insufficient. A periodic fallback repairs missed
+events without requiring an agent run for every evaluation.
+
+Before publishing approval controls, the backend must establish:
+
+- The PR is open, ready for review, conflict-free, and still eligible at the
+  enrolled revision. Missing human approvals alone do not prevent showing the
+  controls that collect those approvals.
+- The complete, paginated check set for the current revision is known, its
+  aggregate is successful, and every required check has passed. Pending, missing,
+  cancelled, failed, or unknown states block. Skipped and neutral results are not
+  passes; only explicitly recognized informational checks may be exempted.
+- Every configured review agent, including Open SWE, has finished reviewing this
+  revision successfully. Silence is not proof that a reviewer ran. A reviewer
+  without a reliable completion signal makes the PR ineligible.
+- There are no outstanding review findings, unresolved review threads, or active
+  change requests from humans or bots. Inspect top-level comments and review
+  bodies too, not just inline threads. Resolved historical feedback and known
+  informational messages do not block; ambiguous reviewer output does.
+
+Open SWE's review check currently succeeds even when it surfaces findings. Its
+check conclusion alone cannot establish that the review is clean. Check settling
+also cannot substitute for explicit reviewer completion.
+
+When ready, the subscription wakes the originating agent once for that round.
+The agent can call a publish-approval tool, which reruns the readiness gate and
+builds the message from authoritative state. After publication, approvals,
+merging, and cleanup are backend operations, not new agent turns. Rejection with
+feedback is the deliberate exception.
+
+### Slack review and GitHub approval
+
+The message includes the PR link, filenames, full unified diff with enough
+context to review, revision, check/reviewer summary, named voters, and the
+following controls:
+
+- **Approve this revision**: record this person's consent for this round.
+- **Reject and give feedback**: end the round and request a reason.
+- **Use normal review**: leave expedited mode without asserting a code defect.
+
+Attach a complete patch file when necessary. Do not enable approval over a
+truncated preview, and do not put private code in a publicly accessible artifact.
+Ordinary thumbs-up reactions remain feedback, not approval votes.
+
+An authorized voter is a human with an active Slack-to-GitHub mapping and current
+write, maintain, or admin access to the repository. They need not own or have
+previously participated in the Open SWE thread. Count distinct GitHub user IDs,
+not display names, repeated clicks, or multiple Slack identities for one account.
+
+GitHub's [review API](https://docs.github.com/en/rest/pulls/reviews#create-a-review-for-a-pull-request)
+accepts `event: APPROVE` and `commit_id`. For each non-author click, submit the
+review using that person's linked, refreshable GitHub user token and retain the
+returned review ID. The button must disclose that it submits a GitHub approval
+and authorizes merging once the remaining requirements are met. Count the vote
+only after confirming the review was submitted successfully. A missing token
+requires reconnection; never silently substitute a bot identity.
+
+The PR author may count toward the two-person Slack quorum, but GitHub
+[does not allow authors to approve their own PRs](https://docs.github.com/en/pull-requests/how-tos/review-pull-requests/approving-a-pull-request-with-required-reviews).
+Their click records Slack consent only. Two Slack votes are necessary, not always
+sufficient: required non-author approvals, CODEOWNERS, and other repository rules
+still apply. Show the remaining requirement rather than treating a third click
+as an error. Existing GitHub approvals do not replace the requirement for two
+explicit clicks in the current Slack round.
+
+### Rejection and re-entry
+
+Any authorized voter can reject, regardless of the number of approvals already
+collected or whether they previously approved. A rejection must not depend on
+first completing a modal or posting a comment:
+
+1. Persist the rejection, invalidate every local vote, and disable approval for
+   that round. An old message can never become active again.
+2. Offer a feedback modal and request a reply in the original Slack thread.
+   Cancelling the modal does not undo the rejection. An empty rejection leaves
+   the round stopped and waiting for feedback; it does not start a speculative
+   agent run.
+3. On modal submission, publish the reason in the original thread with explicit
+   attribution to its human author. Alternatively, accept a thread reply from
+   that rejecting user. A scoped pending-feedback marker lets this reply trigger
+   the agent without requiring a mention, including in a multi-person thread.
+   Unrelated replies do not gain this behavior. A further rejector's feedback is
+   also preserved and delivered, not discarded by deduplication.
+4. Dispatch feedback to the original agent exactly once per submission. The agent
+   addresses it, asks for clarification, or leaves the PR in normal review. It
+   must not infer withdrawal of an objection from silence or lack of code changes.
+5. The agent may explicitly enroll a new round after addressing the feedback.
+   Rerun every readiness check and require two fresh votes. Re-entry for an
+   unchanged diff additionally requires the rejecting users to explicitly clear
+   their objections. The agent cannot restart an unchanged proposal repeatedly
+   to bypass a rejection.
+
+A Slack rejection is a veto of this expedited round, not an automatic GitHub
+`REQUEST_CHANGES` review. Posting the latter would impose a different unblock
+process, often requiring the same reviewer to approve again. Existing GitHub
+change requests still block and are never automatically dismissed. Submitted
+GitHub approvals may remain visible, but no approval from an earlier round counts
+toward the new local quorum.
+
+A head/base/diff change, new finding, or regressed check also invalidates the
+round. The backend disables the message immediately and does not resume the
+coding agent just to collect approvals again. Explicit re-enrollment starts a
+new readiness cycle; an explicit feedback message can resume work as above.
+
+### Merge and completion
+
+The following transitions define the important boundaries:
+
+| State | Next action |
+|---|---|
+| Monitoring | Wait for readiness; dispatch one publication opportunity. |
+| Awaiting approval | Accept votes or end the round on rejection/invalidation. |
+| Rejected | Wait for feedback or explicit withdrawal; never reuse old votes. |
+| Invalidated | Require explicit re-enrollment and a fresh round. |
+| Merging | Quorum reached and final gates passed; reconcile the GitHub operation. |
+| Merged | Update Slack, stop subscriptions, and resolve the completed job. |
+| Stopped | Normal review, expiry, disabled policy, or PR closed without merge. |
+
+Serialize vote, rejection, and merge transitions across workers. Immediately
+before merging, revalidate the current revision, voters, GitHub reviews, check
+set, outstanding feedback, and policy. Persist merge intent and make a normal
+merge request conditional on the expected head SHA, using the repository's
+allowed merge method and a narrowly scoped backend credential. Never fall back
+to admin privileges when GitHub rejects the request.
+
+Rejection wins if committed before the final merge transition. Once a merge
+request has been sent to GitHub, it cannot reliably be recalled; controls must
+show that merging is in progress rather than promise a veto. Report a late
+rejection honestly. Likewise, GitHub cannot atomically enforce every Slack-side
+predicate: final reads and head-SHA conditions reduce races but do not prevent a
+new external comment arriving during the merge request.
+
+Honor merge queues where required. Queue admission is not merge completion;
+continue tracking the revision and eligibility, and withdraw a queued request
+when invalidated where supported. Repositories whose queue behavior cannot
+preserve these guarantees remain outside the initial rollout.
+
+Persist review and merge intents before external calls, deduplicate callback
+retries, and reconcile timeouts before repeating a side effect. Do not assume
+that an HTTP error means GitHub did not accept the operation. Stale worker results
+must not resurrect a rejected round or launch a second merge.
+
+Only a confirmed merge updates the card to merged, adds the configured merged
+reaction to the original Slack root, and removes watches and fallback schedules.
+Reuse tracked-PR `resolves_thread` behavior: resolve the Open SWE thread only when
+all its tracked PRs are terminal and no remaining work belongs to the job. Hide
+it from active lists but retain its audit history. Do not delete the thread or
+archive the shared Slack channel. Retry notification and cleanup failures without
+another agent run or this flow's extra post-merge feedback prompt. A PR closed
+without merging must not receive a merged reaction.
+
+### Non-goals
+
+- Automatically enrolling every small PR or treating line count as a safety test.
+- Admin bypass, fake human reviews, or relaxing repository protection rules.
+- Replacing normal review for complex changes or unsupported reviewer integrations.
+- Making Slack vetoes binding on maintainers who merge through other interfaces.
+- Implementing the feature as part of this proposal PR.
+
+## Security and privacy
+
+The agent may nominate a PR, but cannot manufacture votes, choose another user's
+identity, or override the readiness gate. Verify Slack request signatures and
+freshness, workspace and internal-channel eligibility, stored message/round
+identity, active account mapping, token identity, and live repository permissions.
+An Open SWE workspace-admin role alone does not confer GitHub approval authority.
+
+Resolve each clicking user's token independently of the shared thread's prior
+actor. Reuse encrypted credential storage and refresh; keep credentials out of
+watch records, Slack payloads, agent context, and logs. Watch credentials and
+merge credentials should have only their required repository permissions; the
+merge actor must not implicitly bypass protections through its account or App
+configuration. Verify this before enabling a repository.
+
+The full diff is repository data. A Slack channel must be approved for that
+repository's visibility, not merely free of external guests. Reject ineligible
+channels and private/public mismatches. Escape untrusted diff and feedback text;
+feedback is attributed user input subject to existing trust rules, not privileged
+system instructions. Store auditable round IDs, revisions, voters, rejection
+reasons, GitHub review IDs, and merge outcomes with access controls matching the
+original job.
+
+## Alternatives
+
+- **Admin merge after two clicks:** makes the local quorum sufficient but bypasses
+  repository guarantees and requires broader credentials. Prefer real per-user
+  reviews and normal merge; do not use bypass as a hidden fallback.
+- **One bot approval claiming two reviewers:** does not create two independently
+  attributed GitHub reviews and misrepresents who approved.
+- **Require two non-author voters:** simpler alignment with GitHub, but excludes
+  useful author consent. The proposed local quorum permits the author while
+  clearly preserving GitHub's independent requirements.
+- **Use ordinary reactions:** familiar, but ambiguous with evaluation feedback and
+  not clearly tied to a revision, round, or explicit merge authorization.
+- **Post the diff and finish in GitHub:** the safe fallback, but retains the
+  context switch this proposal is intended to remove.
+- **Resume the agent on every event or vote:** adds latency and cost and puts a
+  security-sensitive state machine in an LLM. Keep lifecycle operations in the
+  backend; resume the agent only for publication or deliberate user feedback.
+
+## Unresolved questions
+
+Before acceptance and rollout, settle:
+
+- Whether author consent should count toward the local quorum, or the product
+  should require two non-author voters for a simpler promise.
+- The initial repository/path eligibility policy, maximum preview size, and
+  approval-round expiry. No live round should remain authorized indefinitely.
+- Which reviewer integrations have trustworthy completion and finding-resolution
+  signals, especially reviewers that publish only top-level comments.
+- Which repositories and Slack channels meet the visibility and non-bypassing
+  credential requirements, and whether merge-queue support belongs in the first
+  release.
+
+## Adoption
+
+If accepted, implement separately behind a per-repository flag. Preserve existing
+baby-sit behavior through a compatibility adapter, deploy the listener before
+exposing enrollment, and provide a kill switch that invalidates active rounds.
+
+Focused verification must cover concurrent votes/rejections, author consent,
+revoked access, stale messages and revisions, feedback routing and deduplication,
+re-entry without inherited votes, late reviewer findings despite green checks,
+unknown API results, queue invalidation, and idempotent merge cleanup. Exercise
+the Slack flow with multiple linked human identities before enabling it for real
+merges. No production permissions or repository rules change merely by publishing
+this OEP.

--- a/oeps/0002-expedited-slack-review.md
+++ b/oeps/0002-expedited-slack-review.md
@@ -8,289 +8,143 @@
 
 ## Summary
 
-Allow an agent to nominate a small, low-risk pull request for expedited review in
-Slack. Once checks and automated reviews are complete and clean, publish its full
-diff with approval and rejection buttons. At least two distinct authorized people
-must approve the current round before Open SWE attempts a normal GitHub merge.
-
-Slack is the review interface, not a way around GitHub protections. Non-author
-approvals become real GitHub reviews through each person's linked account. A
-rejection ends the round immediately; feedback returns to the agent, and any
-subsequent round starts with no votes. On confirmed merge, update the Slack
-message, react to the original thread, and resolve the Open SWE job without
-another agent turn.
-
-This OEP proposes product and trust boundaries, not a commitment to specific tool
-names or storage schemas. Publishing this draft does not accept or implement it.
+Let the agent nominate a tiny PR for review in Slack. When CI is green and every
+review agent is done and clean, Open SWE posts the full diff with approve/reject
+buttons. Two distinct authorized people approve; their clicks become real GitHub
+reviews; Open SWE merges normally and resolves the thread. Any rejection kills the
+round.
 
 ## Motivation
 
-For tiny changes, opening GitHub and finding the relevant diff can take longer
-than reviewing the change. The work and its participants are often already in
-Slack. Presenting a complete, revision-bound diff there can shorten the approval
-loop without removing human review.
-
-Open SWE already has durable CI monitoring in baby-sit, signed Slack interactions,
-linked GitHub identities, automated reviewer state, and tracked-PR thread
-resolution. These pieces should support a deliberate workflow rather than an
-agent polling indefinitely or interpreting ordinary reactions as merge consent.
+For a 5-line change, opening GitHub takes longer than reviewing it. The reviewers
+are already in the Slack thread. Open SWE already has the pieces: baby-sit's
+durable PR watching, signed Slack buttons, linked GitHub identities, reviewer
+state, and tracked-PR thread resolution.
 
 ## Proposal
 
-### Eligibility and enrollment
+### Enrollment
 
-The feature is disabled by default and enabled per repository. At task completion,
-the agent may call an enrollment tool for a PR tracked by the current Open SWE
-thread, supplying a short explanation of why expedited review is appropriate.
-The backend, not the agent's assertion, enforces eligibility and authorization.
+- Off by default; enabled per repository.
+- At task completion the agent calls an enrollment tool with a one-line reason.
+  The backend decides eligibility, not the agent.
+- Eligible: 1–10 added+deleted lines, complete text diff. Ineligible regardless of
+  size: auth, secrets, workflows, dependencies, migrations, binaries.
+- Enrollment pins repo, PR, head SHA, diff fingerprint, Slack location, and Open
+  SWE thread. Every round has its own ID.
 
-The initial scope is 1–10 total added plus deleted lines in a complete text diff.
-Size is a ceiling, not proof of low risk. Authentication, authorization, secrets,
-workflow, dependency, migration, binary, and otherwise high-risk changes use
-normal review. A truncated or impractically large preview is ineligible even if
-its changed-line count is small. Repository policy may narrow this scope.
+### Readiness
 
-Enrollment binds the repository, PR, original Slack location, Open SWE thread,
-head SHA, base/diff fingerprint, and policy version. Each approval round has a
-unique identity, even when a later round reviews the same commit. Draft PRs can
-be monitored, but must explicitly be marked ready and complete resulting checks
-and reviews before approval controls appear.
+Generalize baby-sit's subscription infrastructure to watch checks, statuses,
+reviews, review threads, comments, and PR revisions — successes as well as
+failures. A periodic reconcile repairs missed events without running the agent.
 
-### Event-driven readiness
+Approval controls appear only when, for the enrolled revision:
 
-Generalize baby-sit's durable subscription infrastructure: PR-to-thread routing,
-event deduplication, distributed serialization, and scheduled reconciliation.
-Keep baby-sit's retry policy separate from expedited review's merge policy, and
-preserve existing watches and scheduler entrypoints during migration.
+- the PR is open, ready, conflict-free, and still eligible;
+- every check has passed (pending, skipped, neutral, unknown all block);
+- every configured review agent, including Open SWE's, has finished this
+  revision — silence is not completion;
+- no unresolved review threads, findings, or change requests remain.
 
-Watch checks, commit statuses, PR lifecycle and revision changes, review events,
-review-thread resolution, and PR comments, including events without an Open SWE
-mention. Open SWE's own reviewer should expose completion for the reviewed
-revision. Successful events matter as much as failing ones; the current baby-sit
-failure-only webhook path is insufficient. A periodic fallback repairs missed
-events without requiring an agent run for every evaluation.
+Open SWE's review check passes even with findings, so its conclusion alone is not
+a clean signal; the reviewer must expose explicit completion.
 
-Before publishing approval controls, the backend must establish:
+When ready, the agent is woken once to call a publish tool that reruns the gate and
+posts the card. Everything after that is backend state, not agent turns.
 
-- The PR is open, ready for review, conflict-free, and still eligible at the
-  enrolled revision. Missing human approvals alone do not prevent showing the
-  controls that collect those approvals.
-- The complete, paginated check set for the current revision is known, its
-  aggregate is successful, and every required check has passed. Pending, missing,
-  cancelled, failed, or unknown states block. Skipped and neutral results are not
-  passes; only explicitly recognized informational checks may be exempted.
-- Every configured review agent, including Open SWE, has finished reviewing this
-  revision successfully. Silence is not proof that a reviewer ran. A reviewer
-  without a reliable completion signal makes the PR ineligible.
-- There are no outstanding review findings, unresolved review threads, or active
-  change requests from humans or bots. Inspect top-level comments and review
-  bodies too, not just inline threads. Resolved historical feedback and known
-  informational messages do not block; ambiguous reviewer output does.
+### Slack card
 
-Open SWE's review check currently succeeds even when it surfaces findings. Its
-check conclusion alone cannot establish that the review is clean. Check settling
-also cannot substitute for explicit reviewer completion.
+PR link, files, full unified diff (attach a patch if needed; never approve over a
+truncated diff), revision, check summary, current voters, and three buttons:
 
-When ready, the subscription wakes the originating agent once for that round.
-The agent can call a publish-approval tool, which reruns the readiness gate and
-builds the message from authoritative state. After publication, approvals,
-merging, and cleanup are backend operations, not new agent turns. Rejection with
-feedback is the deliberate exception.
+- **Approve this revision**
+- **Reject and give feedback**
+- **Use normal review**
 
-### Slack review and GitHub approval
+Reactions are never votes.
 
-The message includes the PR link, filenames, full unified diff with enough
-context to review, revision, check/reviewer summary, named voters, and the
-following controls:
+### Voting and GitHub reviews
 
-- **Approve this revision**: record this person's consent for this round.
-- **Reject and give feedback**: end the round and request a reason.
-- **Use normal review**: leave expedited mode without asserting a code defect.
+- Authorized voter: a human with a linked GitHub account and write+ access on the
+  repo. Thread participation is not required. Count distinct GitHub user IDs.
+- Each non-author approve click submits `APPROVE` at `commit_id` via that user's
+  own token ([review API](https://docs.github.com/en/rest/pulls/reviews#create-a-review-for-a-pull-request)).
+  The button says so. The vote counts only after GitHub confirms. No token → ask to
+  reconnect; never substitute a bot identity.
+- The author may count toward the two Slack votes, but GitHub
+  [rejects self-approval](https://docs.github.com/en/pull-requests/how-tos/review-pull-requests/approving-a-pull-request-with-required-reviews),
+  so branch protection may still need another reviewer. Show what's missing.
+- Two Slack votes are necessary, not sufficient. Prior GitHub approvals do not
+  count toward the round.
 
-Attach a complete patch file when necessary. Do not enable approval over a
-truncated preview, and do not put private code in a publicly accessible artifact.
-Ordinary thumbs-up reactions remain feedback, not approval votes.
+### Rejection
 
-An authorized voter is a human with an active Slack-to-GitHub mapping and current
-write, maintain, or admin access to the repository. They need not own or have
-previously participated in the Open SWE thread. Count distinct GitHub user IDs,
-not display names, repeated clicks, or multiple Slack identities for one account.
+Any authorized voter can reject at any time, even after approving.
 
-GitHub's [review API](https://docs.github.com/en/rest/pulls/reviews#create-a-review-for-a-pull-request)
-accepts `event: APPROVE` and `commit_id`. For each non-author click, submit the
-review using that person's linked, refreshable GitHub user token and retain the
-returned review ID. The button must disclose that it submits a GitHub approval
-and authorizes merging once the remaining requirements are met. Count the vote
-only after confirming the review was submitted successfully. A missing token
-requires reconnection; never silently substitute a bot identity.
+1. Persist the rejection, void all votes, disable the card. It never reactivates.
+2. Open a feedback modal and accept a thread reply from the rejector as an
+   alternative. Cancelling the modal does not undo the rejection.
+3. Post the reason in the thread, attributed to the human, and dispatch it to the
+   agent exactly once.
+4. The agent may re-enroll after addressing it: full readiness rerun, two fresh
+   votes. An unchanged diff also needs the rejector to clear their objection.
 
-The PR author may count toward the two-person Slack quorum, but GitHub
-[does not allow authors to approve their own PRs](https://docs.github.com/en/pull-requests/how-tos/review-pull-requests/approving-a-pull-request-with-required-reviews).
-Their click records Slack consent only. Two Slack votes are necessary, not always
-sufficient: required non-author approvals, CODEOWNERS, and other repository rules
-still apply. Show the remaining requirement rather than treating a third click
-as an error. Existing GitHub approvals do not replace the requirement for two
-explicit clicks in the current Slack round.
+A Slack rejection is a veto of the round, not a GitHub `REQUEST_CHANGES`. Existing
+GitHub change requests still block and are never dismissed automatically.
 
-### Rejection and re-entry
+A new commit, new finding, or regressed check also invalidates the round and
+disables the card. Re-enrollment is explicit.
 
-Any authorized voter can reject, regardless of the number of approvals already
-collected or whether they previously approved. A rejection must not depend on
-first completing a modal or posting a comment:
+### Merge
 
-1. Persist the rejection, invalidate every local vote, and disable approval for
-   that round. An old message can never become active again.
-2. Offer a feedback modal and request a reply in the original Slack thread.
-   Cancelling the modal does not undo the rejection. An empty rejection leaves
-   the round stopped and waiting for feedback; it does not start a speculative
-   agent run.
-3. On modal submission, publish the reason in the original thread with explicit
-   attribution to its human author. Alternatively, accept a thread reply from
-   that rejecting user. A scoped pending-feedback marker lets this reply trigger
-   the agent without requiring a mention, including in a multi-person thread.
-   Unrelated replies do not gain this behavior. A further rejector's feedback is
-   also preserved and delivered, not discarded by deduplication.
-4. Dispatch feedback to the original agent exactly once per submission. The agent
-   addresses it, asks for clarification, or leaves the PR in normal review. It
-   must not infer withdrawal of an objection from silence or lack of code changes.
-5. The agent may explicitly enroll a new round after addressing the feedback.
-   Rerun every readiness check and require two fresh votes. Re-entry for an
-   unchanged diff additionally requires the rejecting users to explicitly clear
-   their objections. The agent cannot restart an unchanged proposal repeatedly
-   to bypass a rejection.
+Quorum → revalidate everything → persist merge intent → normal merge conditional
+on head SHA, using the repo's allowed method and a narrowly scoped credential.
+GitHub says no → stop. Never fall back to admin bypass.
 
-A Slack rejection is a veto of this expedited round, not an automatic GitHub
-`REQUEST_CHANGES` review. Posting the latter would impose a different unblock
-process, often requiring the same reviewer to approve again. Existing GitHub
-change requests still block and are never automatically dismissed. Submitted
-GitHub approvals may remain visible, but no approval from an earlier round counts
-toward the new local quorum.
+Rejection wins if committed before the merge call. Once the call is sent it cannot
+be recalled; the card says "merging". Persist intents before external calls,
+dedupe retries, and treat an HTTP error as "unknown", not "did not happen".
 
-A head/base/diff change, new finding, or regressed check also invalidates the
-round. The backend disables the message immediately and does not resume the
-coding agent just to collect approvals again. Explicit re-enrollment starts a
-new readiness cycle; an explicit feedback message can resume work as above.
+Merge queues: admission is not completion; keep tracking and withdraw on
+invalidation. Repos whose queue can't honor that are out of scope initially.
 
-### Merge and completion
-
-The following transitions define the important boundaries:
-
-| State | Next action |
-|---|---|
-| Monitoring | Wait for readiness; dispatch one publication opportunity. |
-| Awaiting approval | Accept votes or end the round on rejection/invalidation. |
-| Rejected | Wait for feedback or explicit withdrawal; never reuse old votes. |
-| Invalidated | Require explicit re-enrollment and a fresh round. |
-| Merging | Quorum reached and final gates passed; reconcile the GitHub operation. |
-| Merged | Update Slack, stop subscriptions, and resolve the completed job. |
-| Stopped | Normal review, expiry, disabled policy, or PR closed without merge. |
-
-Serialize vote, rejection, and merge transitions across workers. Immediately
-before merging, revalidate the current revision, voters, GitHub reviews, check
-set, outstanding feedback, and policy. Persist merge intent and make a normal
-merge request conditional on the expected head SHA, using the repository's
-allowed merge method and a narrowly scoped backend credential. Never fall back
-to admin privileges when GitHub rejects the request.
-
-Rejection wins if committed before the final merge transition. Once a merge
-request has been sent to GitHub, it cannot reliably be recalled; controls must
-show that merging is in progress rather than promise a veto. Report a late
-rejection honestly. Likewise, GitHub cannot atomically enforce every Slack-side
-predicate: final reads and head-SHA conditions reduce races but do not prevent a
-new external comment arriving during the merge request.
-
-Honor merge queues where required. Queue admission is not merge completion;
-continue tracking the revision and eligibility, and withdraw a queued request
-when invalidated where supported. Repositories whose queue behavior cannot
-preserve these guarantees remain outside the initial rollout.
-
-Persist review and merge intents before external calls, deduplicate callback
-retries, and reconcile timeouts before repeating a side effect. Do not assume
-that an HTTP error means GitHub did not accept the operation. Stale worker results
-must not resurrect a rejected round or launch a second merge.
-
-Only a confirmed merge updates the card to merged, adds the configured merged
-reaction to the original Slack root, and removes watches and fallback schedules.
-Reuse tracked-PR `resolves_thread` behavior: resolve the Open SWE thread only when
-all its tracked PRs are terminal and no remaining work belongs to the job. Hide
-it from active lists but retain its audit history. Do not delete the thread or
-archive the shared Slack channel. Retry notification and cleanup failures without
-another agent run or this flow's extra post-merge feedback prompt. A PR closed
-without merging must not receive a merged reaction.
+On confirmed merge: mark the card merged, add the merged reaction to the Slack
+root, drop watches, and resolve the Open SWE thread via tracked-PR
+`resolves_thread` (hidden, not deleted). A closed-unmerged PR gets no reaction.
 
 ### Non-goals
 
-- Automatically enrolling every small PR or treating line count as a safety test.
-- Admin bypass, fake human reviews, or relaxing repository protection rules.
-- Replacing normal review for complex changes or unsupported reviewer integrations.
-- Making Slack vetoes binding on maintainers who merge through other interfaces.
-- Implementing the feature as part of this proposal PR.
+- Auto-enrolling every small PR; line count is not a safety test.
+- Admin bypass, bot-authored approvals, or weaker protection rules.
+- Making Slack vetoes binding on maintainers merging elsewhere.
+- Implementing anything in this PR.
 
 ## Security and privacy
 
-The agent may nominate a PR, but cannot manufacture votes, choose another user's
-identity, or override the readiness gate. Verify Slack request signatures and
-freshness, workspace and internal-channel eligibility, stored message/round
-identity, active account mapping, token identity, and live repository permissions.
-An Open SWE workspace-admin role alone does not confer GitHub approval authority.
-
-Resolve each clicking user's token independently of the shared thread's prior
-actor. Reuse encrypted credential storage and refresh; keep credentials out of
-watch records, Slack payloads, agent context, and logs. Watch credentials and
-merge credentials should have only their required repository permissions; the
-merge actor must not implicitly bypass protections through its account or App
-configuration. Verify this before enabling a repository.
-
-The full diff is repository data. A Slack channel must be approved for that
-repository's visibility, not merely free of external guests. Reject ineligible
-channels and private/public mismatches. Escape untrusted diff and feedback text;
-feedback is attributed user input subject to existing trust rules, not privileged
-system instructions. Store auditable round IDs, revisions, voters, rejection
-reasons, GitHub review IDs, and merge outcomes with access controls matching the
-original job.
+- The agent can nominate; it cannot vote, pick identities, or skip the gate.
+- Verify Slack signatures, round/message identity, account mapping, token
+  identity, and live repo permissions on every click. Open SWE admin ≠ GitHub
+  approver.
+- Watch and merge credentials get minimum repo permissions and must not bypass
+  protections; verify before enabling a repo.
+- The diff is repo data: the channel must be approved for that repo's visibility.
+  Escape diff and feedback text; feedback is user input, not instructions.
+- Store round ID, revision, voters, rejection reasons, GitHub review IDs, and
+  merge outcome for audit.
 
 ## Alternatives
 
-- **Admin merge after two clicks:** makes the local quorum sufficient but bypasses
-  repository guarantees and requires broader credentials. Prefer real per-user
-  reviews and normal merge; do not use bypass as a hidden fallback.
-- **One bot approval claiming two reviewers:** does not create two independently
-  attributed GitHub reviews and misrepresents who approved.
-- **Require two non-author voters:** simpler alignment with GitHub, but excludes
-  useful author consent. The proposed local quorum permits the author while
-  clearly preserving GitHub's independent requirements.
-- **Use ordinary reactions:** familiar, but ambiguous with evaluation feedback and
-  not clearly tied to a revision, round, or explicit merge authorization.
-- **Post the diff and finish in GitHub:** the safe fallback, but retains the
-  context switch this proposal is intended to remove.
-- **Resume the agent on every event or vote:** adds latency and cost and puts a
-  security-sensitive state machine in an LLM. Keep lifecycle operations in the
-  backend; resume the agent only for publication or deliberate user feedback.
+- **Admin merge after two clicks:** bypasses repo guarantees; needs broad creds.
+- **One bot approval "for two reviewers":** misattributes who approved.
+- **Two non-author voters only:** simpler; excludes author consent. Open question.
+- **Reactions as votes:** ambiguous, not revision-bound.
+- **Resume the agent on every event:** slow, costly, puts a security state machine
+  in an LLM.
 
 ## Unresolved questions
 
-Before acceptance and rollout, settle:
-
-- Whether author consent should count toward the local quorum, or the product
-  should require two non-author voters for a simpler promise.
-- The initial repository/path eligibility policy, maximum preview size, and
-  approval-round expiry. No live round should remain authorized indefinitely.
-- Which reviewer integrations have trustworthy completion and finding-resolution
-  signals, especially reviewers that publish only top-level comments.
-- Which repositories and Slack channels meet the visibility and non-bypassing
-  credential requirements, and whether merge-queue support belongs in the first
-  release.
-
-## Adoption
-
-If accepted, implement separately behind a per-repository flag. Preserve existing
-baby-sit behavior through a compatibility adapter, deploy the listener before
-exposing enrollment, and provide a kill switch that invalidates active rounds.
-
-Focused verification must cover concurrent votes/rejections, author consent,
-revoked access, stale messages and revisions, feedback routing and deduplication,
-re-entry without inherited votes, late reviewer findings despite green checks,
-unknown API results, queue invalidation, and idempotent merge cleanup. Exercise
-the Slack flow with multiple linked human identities before enabling it for real
-merges. No production permissions or repository rules change merely by publishing
-this OEP.
+- Does author consent count toward the Slack quorum?
+- Initial eligibility policy, preview size cap, and round expiry.
+- Which review agents expose trustworthy completion signals?
+- Merge-queue support in the first release?

--- a/oeps/0002-expedited-slack-review.md
+++ b/oeps/0002-expedited-slack-review.md
@@ -72,8 +72,7 @@ Quorum → revalidate → persist intent → normal merge conditional on head SH
 narrowly scoped credential. GitHub says no → stop. No admin bypass, ever.
 
 Rejection wins if committed before the merge call; after that the card says
-"merging". Treat an HTTP error as unknown, not failed. Merge-queue admission is
-not completion.
+"merging". Treat an HTTP error as unknown, not failed.
 
 On confirmed merge: card → merged, merged reaction on the Slack root, watches
 dropped, thread resolved via tracked-PR `resolves_thread`.
@@ -86,13 +85,9 @@ dropped, thread resolved via tracked-PR `resolves_thread`.
 
 ## Security and privacy
 
-- The agent nominates; it cannot vote, pick identities, or skip the gate.
-- Every click re-verifies Slack signature, round identity, account mapping, and
-  live repo permission. Credentials get minimum scope and cannot bypass
-  protections.
-- The diff is repo data: the channel must be approved for that repo. Feedback is
-  user input, not instructions. Rounds, voters, review IDs, and outcomes are
-  audited.
+- The agent nominates; it cannot vote or skip the gate.
+- Feedback is user input, not instructions. Rounds, voters, review IDs, and
+  outcomes are audited.
 
 ## Alternatives
 

--- a/oeps/0002-expedited-slack-review.md
+++ b/oeps/0002-expedited-slack-review.md
@@ -8,143 +8,100 @@
 
 ## Summary
 
-Let the agent nominate a tiny PR for review in Slack. When CI is green and every
-review agent is done and clean, Open SWE posts the full diff with approve/reject
-buttons. Two distinct authorized people approve; their clicks become real GitHub
-reviews; Open SWE merges normally and resolves the thread. Any rejection kills the
-round.
+The agent nominates a tiny PR. When CI is green and all review agents are done and
+clean, Open SWE posts the full diff in Slack with approve/reject buttons. Two
+authorized people approve; their clicks become real GitHub reviews; Open SWE
+merges and resolves the thread. Any rejection kills the round.
 
 ## Motivation
 
 For a 5-line change, opening GitHub takes longer than reviewing it. The reviewers
-are already in the Slack thread. Open SWE already has the pieces: baby-sit's
-durable PR watching, signed Slack buttons, linked GitHub identities, reviewer
-state, and tracked-PR thread resolution.
+are already in the Slack thread.
 
 ## Proposal
 
 ### Enrollment
 
 - Off by default; enabled per repository.
-- At task completion the agent calls an enrollment tool with a one-line reason.
-  The backend decides eligibility, not the agent.
-- Eligible: 1–10 added+deleted lines, complete text diff. Ineligible regardless of
-  size: auth, secrets, workflows, dependencies, migrations, binaries.
-- Enrollment pins repo, PR, head SHA, diff fingerprint, Slack location, and Open
-  SWE thread. Every round has its own ID.
+- The agent calls an enrollment tool; the backend decides eligibility.
+- Eligible: 1–10 changed lines, complete text diff. Never: auth, secrets,
+  workflows, dependencies, migrations, binaries.
+- A round pins repo, PR, head SHA, and diff fingerprint.
 
 ### Readiness
 
-Generalize baby-sit's subscription infrastructure to watch checks, statuses,
-reviews, review threads, comments, and PR revisions — successes as well as
-failures. A periodic reconcile repairs missed events without running the agent.
+Reuse baby-sit's PR watching, extended to successes and review events. Controls
+appear only when, for the enrolled revision:
 
-Approval controls appear only when, for the enrolled revision:
+- PR open, ready, conflict-free;
+- every check passed (pending/skipped/neutral block);
+- every review agent, including Open SWE's, reports completion — silence is not
+  completion, and a passing review check is not "no findings";
+- no unresolved review threads, findings, or change requests.
 
-- the PR is open, ready, conflict-free, and still eligible;
-- every check has passed (pending, skipped, neutral, unknown all block);
-- every configured review agent, including Open SWE's, has finished this
-  revision — silence is not completion;
-- no unresolved review threads, findings, or change requests remain.
-
-Open SWE's review check passes even with findings, so its conclusion alone is not
-a clean signal; the reviewer must expose explicit completion.
-
-When ready, the agent is woken once to call a publish tool that reruns the gate and
-posts the card. Everything after that is backend state, not agent turns.
+The agent is woken once to publish the card. Everything after is backend state.
 
 ### Slack card
 
-PR link, files, full unified diff (attach a patch if needed; never approve over a
-truncated diff), revision, check summary, current voters, and three buttons:
+PR link, files, full diff, revision, voters, and three buttons: **Approve**,
+**Reject and give feedback**, **Use normal review**. Reactions are never votes.
 
-- **Approve this revision**
-- **Reject and give feedback**
-- **Use normal review**
+### Voting
 
-Reactions are never votes.
-
-### Voting and GitHub reviews
-
-- Authorized voter: a human with a linked GitHub account and write+ access on the
-  repo. Thread participation is not required. Count distinct GitHub user IDs.
-- Each non-author approve click submits `APPROVE` at `commit_id` via that user's
-  own token ([review API](https://docs.github.com/en/rest/pulls/reviews#create-a-review-for-a-pull-request)).
-  The button says so. The vote counts only after GitHub confirms. No token → ask to
-  reconnect; never substitute a bot identity.
-- The author may count toward the two Slack votes, but GitHub
-  [rejects self-approval](https://docs.github.com/en/pull-requests/how-tos/review-pull-requests/approving-a-pull-request-with-required-reviews),
-  so branch protection may still need another reviewer. Show what's missing.
-- Two Slack votes are necessary, not sufficient. Prior GitHub approvals do not
-  count toward the round.
+- Voter: linked GitHub account with write+ on the repo. Distinct GitHub IDs.
+- Each non-author approve submits a GitHub `APPROVE` review at `commit_id` with
+  that user's own token. The button says so. Counts only after GitHub confirms.
+  No token → reconnect; never a bot identity.
+- The author's click counts in Slack but GitHub rejects self-approval, so branch
+  protection may still want another reviewer. Show what's missing.
+- Two votes are necessary, not sufficient. Prior GitHub approvals don't count.
 
 ### Rejection
 
-Any authorized voter can reject at any time, even after approving.
+Any voter can reject at any time. Votes void, card disabled forever. Feedback via
+modal or a thread reply from the rejector is posted with attribution and sent to
+the agent once. Re-enrollment reruns readiness and needs two fresh votes; an
+unchanged diff also needs the rejector to withdraw.
 
-1. Persist the rejection, void all votes, disable the card. It never reactivates.
-2. Open a feedback modal and accept a thread reply from the rejector as an
-   alternative. Cancelling the modal does not undo the rejection.
-3. Post the reason in the thread, attributed to the human, and dispatch it to the
-   agent exactly once.
-4. The agent may re-enroll after addressing it: full readiness rerun, two fresh
-   votes. An unchanged diff also needs the rejector to clear their objection.
-
-A Slack rejection is a veto of the round, not a GitHub `REQUEST_CHANGES`. Existing
-GitHub change requests still block and are never dismissed automatically.
-
-A new commit, new finding, or regressed check also invalidates the round and
-disables the card. Re-enrollment is explicit.
+A Slack rejection is a veto of the round, not a GitHub `REQUEST_CHANGES`.
+New commit, new finding, or regressed check also kills the round.
 
 ### Merge
 
-Quorum → revalidate everything → persist merge intent → normal merge conditional
-on head SHA, using the repo's allowed method and a narrowly scoped credential.
-GitHub says no → stop. Never fall back to admin bypass.
+Quorum → revalidate → persist intent → normal merge conditional on head SHA with a
+narrowly scoped credential. GitHub says no → stop. No admin bypass, ever.
 
-Rejection wins if committed before the merge call. Once the call is sent it cannot
-be recalled; the card says "merging". Persist intents before external calls,
-dedupe retries, and treat an HTTP error as "unknown", not "did not happen".
+Rejection wins if committed before the merge call; after that the card says
+"merging". Treat an HTTP error as unknown, not failed. Merge-queue admission is
+not completion.
 
-Merge queues: admission is not completion; keep tracking and withdraw on
-invalidation. Repos whose queue can't honor that are out of scope initially.
-
-On confirmed merge: mark the card merged, add the merged reaction to the Slack
-root, drop watches, and resolve the Open SWE thread via tracked-PR
-`resolves_thread` (hidden, not deleted). A closed-unmerged PR gets no reaction.
+On confirmed merge: card → merged, merged reaction on the Slack root, watches
+dropped, thread resolved via tracked-PR `resolves_thread`.
 
 ### Non-goals
 
-- Auto-enrolling every small PR; line count is not a safety test.
-- Admin bypass, bot-authored approvals, or weaker protection rules.
-- Making Slack vetoes binding on maintainers merging elsewhere.
+- Auto-enrolling small PRs; line count is not a safety test.
+- Admin bypass, bot-authored approvals, weaker protection rules.
 - Implementing anything in this PR.
 
 ## Security and privacy
 
-- The agent can nominate; it cannot vote, pick identities, or skip the gate.
-- Verify Slack signatures, round/message identity, account mapping, token
-  identity, and live repo permissions on every click. Open SWE admin ≠ GitHub
-  approver.
-- Watch and merge credentials get minimum repo permissions and must not bypass
-  protections; verify before enabling a repo.
-- The diff is repo data: the channel must be approved for that repo's visibility.
-  Escape diff and feedback text; feedback is user input, not instructions.
-- Store round ID, revision, voters, rejection reasons, GitHub review IDs, and
-  merge outcome for audit.
+- The agent nominates; it cannot vote, pick identities, or skip the gate.
+- Every click re-verifies Slack signature, round identity, account mapping, and
+  live repo permission. Credentials get minimum scope and cannot bypass
+  protections.
+- The diff is repo data: the channel must be approved for that repo. Feedback is
+  user input, not instructions. Rounds, voters, review IDs, and outcomes are
+  audited.
 
 ## Alternatives
 
-- **Admin merge after two clicks:** bypasses repo guarantees; needs broad creds.
-- **One bot approval "for two reviewers":** misattributes who approved.
-- **Two non-author voters only:** simpler; excludes author consent. Open question.
+- **Admin merge after two clicks:** bypasses repo guarantees.
 - **Reactions as votes:** ambiguous, not revision-bound.
-- **Resume the agent on every event:** slow, costly, puts a security state machine
-  in an LLM.
+- **Resume the agent on every event:** puts a security state machine in an LLM.
 
 ## Unresolved questions
 
-- Does author consent count toward the Slack quorum?
-- Initial eligibility policy, preview size cap, and round expiry.
-- Which review agents expose trustworthy completion signals?
-- Merge-queue support in the first release?
+- Does author consent count toward the quorum?
+- Eligibility policy, preview size cap, round expiry.
+- Which review agents expose a trustworthy completion signal?

--- a/oeps/README.md
+++ b/oeps/README.md
@@ -6,6 +6,7 @@ They are decision records, not implementation plans or substitutes for normal is
 review.
 
 - [OEP-0000: OEP purpose and process](0000-process.md)
+- [OEP-0002: Expedited Slack review for small pull requests](0002-expedited-slack-review.md) (Draft)
 - [Proposal template](TEMPLATE.md)
 
 Anyone may propose an OEP. Read [OEP-0000](0000-process.md) to decide whether an OEP is appropriate


### PR DESCRIPTION
Draft OEP-0002: expedited Slack review for small, low-risk PRs.

An agent nominates a tracked PR. Once checks are green and automated reviews are clean, Open SWE posts the full diff in Slack with approve/reject buttons. Two distinct authorized people must approve, and their approvals become real GitHub reviews via linked accounts — Slack is the interface, not a bypass of branch protections. A rejection ends the round and returns feedback to the agent; the next round starts at zero votes. On merge, Open SWE updates the message, reacts on the thread, and resolves the job.

Also covers enrollment binding, generalizing baby-sit's durable event subscriptions for readiness, re-entry semantics, and permission boundaries. Admin bypass is not the default.

Merging publishes the draft for discussion; it does not accept the design.

Discussion: #2569
