### PR TITLE
fix(slack): read subtype off the parsed event, not with dict.get

### DIFF
--- a/agent/slack/routes.py
+++ b/agent/slack/routes.py
@@ -433,7 +433,7 @@ async def slack_webhook(
     if event.is_from_bot or updated_message.is_from_bot:
         return ignored("Event from a bot")
 
-    if {event.get("subtype"), updated_message.get("subtype")} & _MEMBERSHIP_SUBTYPES:
+    if {event.subtype, updated_message.subtype} & _MEMBERSHIP_SUBTYPES:
         if in_code_channel and await common.claim_slack_event(event_id, channel_id, event_ts):
             background_tasks.add_task(_queue_channel_housekeeping, channel_id, text)
         return {"status": "ignored", "reason": "Slack channel housekeeping, not a request"}

--- a/tests/slack/test_channel_housekeeping.py
+++ b/tests/slack/test_channel_housekeeping.py
@@ -40,7 +40,7 @@ def _request(event: dict[str, Any]) -> Request:
 def webhook(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     calls: dict[str, Any] = {
         "verify_slack_signature": lambda **_: True,
-        "_get_slack_channel_context": AsyncMock(
+        "resolve_slack_channel_context": AsyncMock(
             return_value={"id": "C-code", "is_ext_shared": False, "is_pending_ext_shared": False}
         ),
         "slack_channel_allows_operations": lambda _context: True,
@@ -121,7 +121,8 @@ async def test_a_join_in_an_unbound_channel_queues_nothing(webhook: dict[str, An
 
 
 async def test_an_ordinary_message_still_reaches_the_session(webhook: dict[str, Any]) -> None:
-    await _post({**JOIN, "subtype": None, "text": "what is the status?"})
+    ordinary = {key: value for key, value in JOIN.items() if key != "subtype"}
+    await _post({**ordinary, "text": "what is the status?"})
 
     webhook["process_slack_mention"].assert_awaited_once()
     webhook["queue_message_for_thread"].assert_not_awaited()


### PR DESCRIPTION
Every Slack message that got as far as the channel-housekeeping check raised `AttributeError: 'SlackEvent' object has no attribute 'get'` and the webhook returned 500, so mentions stopped triggering runs. `event` and `updated_message` are parsed pydantic models (`SlackEvent` / `SlackMessage`), both of which already declare `subtype: str = ""`.

```
File "/deps/open-swe/agent/slack/routes.py", line 436, in slack_webhook
  if {event.get("subtype"), updated_message.get("subtype")} & _MEMBERSHIP_SUBTYPES:
AttributeError: 'SlackEvent' object has no attribute 'get'
```

Introduced in #2418 and live on prod since it promoted.

`tests/slack/test_channel_housekeeping.py` covers exactly this branch, but its fixture patched `common._get_slack_channel_context`, which #2506 had already renamed to `resolve_slack_channel_context`. Every test in the file errored at setup, so the file never guarded the route it was written for. Repointing the patch makes all ten run, and `test_a_join_does_not_start_a_run` fails against the old line.

One of those tests also sent `"subtype": None`, a shape Slack never sends (it omits the key), which `SlackEvent` rightly rejects; the payload now omits it.

## Test Plan

- [x] `tests/slack` — 379 passed
