### PR TITLE
ci: typecheck main before promoting it to prod

### DIFF
--- a/.github/workflows/promote_main_to_prod.yml
+++ b/.github/workflows/promote_main_to_prod.yml
@@ -13,26 +13,40 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  promote:
+  typecheck:
+    name: Typecheck the commit to promote
     runs-on: ubuntu-latest
     outputs:
-      promoted_sha: ${{ steps.promoted.outputs.sha }}
+      sha: ${{ steps.candidate.outputs.sha }}
     steps:
       - uses: actions/checkout@v7.0.1
         with:
           ref: main
-          fetch-depth: 0
-      - name: Record promoted commit
-        id: promoted
+      - name: Record candidate commit
+        id: candidate
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-      - name: Force-push main to prod
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      - name: Install dependencies
+        run: uv sync --locked --extra dev
+      - name: Run typecheck
+        run: make typecheck
+
+  promote:
+    needs: typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          ref: ${{ needs.typecheck.outputs.sha }}
+          fetch-depth: 0
+      - name: Force-push the typechecked commit to prod
         run: |
           git push --force origin HEAD:refs/heads/prod
 
   release-desktop-nightly:
-    needs: promote
+    needs: [typecheck, promote]
     uses: ./.github/workflows/desktop-release.yml
     with:
-      release_ref: ${{ needs.promote.outputs.promoted_sha }}
+      release_ref: ${{ needs.typecheck.outputs.sha }}
       nightly: true
     secrets: inherit


### PR DESCRIPTION
Promotion force-pushed `main` to `prod` without ever consulting CI, so a red commit reaches production on the next 08:00 UTC run.

That is how the Slack webhook broke. `d7203932a` has been failing **Agent typecheck** on `main` since it merged:

```
error[unresolved-attribute]: Object of type `SlackEvent` has no attribute `get`
   --> agent/slack/routes.py:436:9
```

`ty` catches it and exits 1, but nothing was looking. Worse, `ci.yml` sets `cancel-in-progress: true` keyed on the branch, so the main-push runs for the two commits before it were cancelled outright by the next merge — a merge can land broken and never get a completed run at all.

`promote` now depends on a typecheck job. That job resolves the candidate sha itself and `prod` is pushed from that exact sha, so main moving mid-run cannot slip an unchecked commit through.

Depends on #2669 to go green: this branch is off `main`, and `main`'s typecheck is red until that fix lands. The failure is the gate working.

Separately worth a look: `cancel-in-progress` on main pushes means most main commits never finish a CI run, and `Agent unit tests` is red on main too.

## Test Plan

- [x] `actionlint .github/workflows/promote_main_to_prod.yml`
- [x] `ty` flags the shipped defect and exits 1, verified against the reverted line
