### PR TITLE
docs: document PR-URL thread lookup in list_threads tool description

### DIFF
--- a/agent/resources/prompts/tools/list_threads.md
+++ b/agent/resources/prompts/tools/list_threads.md
@@ -1,1 +1,3 @@
 List surfaced threads by locator, participant, admin mode, status, source, or text.
+
+Passing a GitHub pull request URL as the query finds the thread associated with that PR, so you can link users from a PR back to its originating thread.


### PR DESCRIPTION
## Summary

`list_threads` already resolves a GitHub PR URL into the threads associated with that PR (`parse_github_pr_url` + `_summary_matches_pr` in `agent/tools/threads.py`), but the tool's prompt description (`agent/resources/prompts/tools/list_threads.md`) never mentioned it — so the agent doesn't know it can answer "which thread belongs to this PR?". This documents the capability in the tool description so the agent can use it, e.g. linking a user from a PR back to its originating thread.

Follow-up on the broader UI discoverability gap is tracked in [OPE-69](https://linear.app/langchain/issue/OPE-69/easy-way-to-find-the-open-swe-thread-associated-with-a-pr-ui-agent).

Made by [Open SWE](https://openswe.vercel.app/agents/d4d81cb1-4562-5f9a-a8de-b6d0b29eed53) · openai:gpt-5.6-sol (high)