### PR TITLE
fix: persist web model choice across Slack turns

### DIFF
--- a/agent/slack/webhook.py
+++ b/agent/slack/webhook.py
@@ -828,6 +828,11 @@ async def _process_slack_mention_impl(request: SlackRequest, repo: Repo | None) 
     if thread_plan_mode is not None:
         configurable["plan_mode"] = thread_plan_mode
 
+    thread_model_choice = await common.get_thread_model_choice(thread_id)
+    if thread_model_choice and not image_model_override:
+        configurable["agent_model_id"], configurable["agent_effort"] = thread_model_choice
+        configurable["model_selection"] = "explicit"
+
     is_first_mention = not await common.thread_exists(thread_id)
     langgraph_client = get_langgraph_client()
     # Pass the login resolved above (from the stable Slack user id) so the thread is

--- a/agent/slack/webhook.py
+++ b/agent/slack/webhook.py
@@ -719,10 +719,15 @@ async def _process_slack_mention_impl(request: SlackRequest, repo: Repo | None) 
     )
 
     mapped_login = await _slack_login(user_id, user_email)
+    thread_model_choice = await common.get_thread_model_choice(thread_id)
 
     image_model_override: tuple[str, str] | None = None
     if image_urls:
-        resolved_model_id = await common.resolve_agent_model_id(mapped_login)
+        resolved_model_id = (
+            thread_model_choice[0]
+            if thread_model_choice
+            else await common.resolve_agent_model_id(mapped_login)
+        )
         if not common.model_supports_images(resolved_model_id):
             fallback_model_id, fallback_effort = common.default_vision_model_pair()
             common.logger.info(
@@ -828,7 +833,6 @@ async def _process_slack_mention_impl(request: SlackRequest, repo: Repo | None) 
     if thread_plan_mode is not None:
         configurable["plan_mode"] = thread_plan_mode
 
-    thread_model_choice = await common.get_thread_model_choice(thread_id)
     if thread_model_choice and not image_model_override:
         configurable["agent_model_id"], configurable["agent_effort"] = thread_model_choice
         configurable["model_selection"] = "explicit"

--- a/agent/webhooks/common.py
+++ b/agent/webhooks/common.py
@@ -23,7 +23,11 @@ from agent.dashboard.agent_overrides import (
 from agent.dashboard.agent_usage import update_agent_pr_usage_from_webhook
 from agent.dashboard.enabled_repos import is_review_repo_enabled
 from agent.dashboard.oauth import build_settings_url
-from agent.dashboard.options import default_vision_model_pair, model_supports_images  # noqa: F401
+from agent.dashboard.options import (
+    default_vision_model_pair,
+    model_supports_images,  # noqa: F401
+    normalize_model_choice,
+)
 from agent.dashboard.profiles import (  # noqa: F401
     get_profile,
     get_valid_access_token,
@@ -194,6 +198,7 @@ __all__ = [
     "resolve_slack_channel_context",
     "get_thread_metadata_safe",
     "get_thread_environment",
+    "get_thread_model_choice",
     "get_thread_plan_mode",
     "is_not_found_error",
     "is_pr_diff_unchanged_since_last_review",
@@ -764,6 +769,22 @@ async def get_thread_plan_mode(thread_id: str) -> bool | None:
         return None
     value = metadata.get("plan_mode")
     return value if isinstance(value, bool) else None
+
+
+async def get_thread_model_choice(thread_id: str) -> tuple[str, str] | None:
+    """Return the explicit model choice persisted for a thread, if any."""
+    langgraph_client = get_client(url=LANGGRAPH_URL)
+    try:
+        thread = await langgraph_client.threads.get(thread_id)
+    except Exception as exc:  # noqa: BLE001
+        if not is_not_found_error(exc):
+            logger.warning("Failed to fetch model metadata for thread %s", thread_id)
+        return None
+    metadata = thread.get("metadata") if isinstance(thread, dict) else None
+    if not isinstance(metadata, dict) or metadata.get("model_selection") != "explicit":
+        return None
+    model_id, effort = normalize_model_choice(metadata.get("model"), metadata.get("effort"))
+    return (model_id, effort) if model_id and effort else None
 
 
 async def get_thread_environment(thread_id: str) -> str | None:

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -596,6 +596,18 @@ async def mock_github_pr(owner: str, repo: str, number: int) -> HTMLResponse:  #
 
 
 # --- fake GitHub REST API (open_pull_request hits this) --------------------
+@app.get("/fake-gh/installation/repositories")
+async def gh_installation_repositories() -> JSONResponse:
+    return JSONResponse(
+        {
+            "repositories": [
+                {"full_name": "fakeorg/demo"},
+                {"full_name": "anotherorg/companion"},
+            ]
+        }
+    )
+
+
 def _gh_pr_json(pr: dict[str, Any]) -> dict[str, Any]:
     return {
         "number": pr["number"],

--- a/tests/e2e/tests/dashboard_transcript.spec.ts
+++ b/tests/e2e/tests/dashboard_transcript.spec.ts
@@ -229,6 +229,48 @@ test.describe("transcript rendering", () => {
     ).toHaveCount(1);
   });
 
+  test("keeps a web model override on the next Slack turn", async ({
+    page,
+  }) => {
+    await loginAs(page, SAME_USER);
+    await openThreadViaSlackLink(page);
+    const threadId = threadIdFromUrl(page);
+    await waitForThreadIdle(page, threadId);
+    await waitForThreadNotBusy(page, threadId);
+
+    await page.getByRole("button", { name: /GPT-5\.6 Sol/ }).click();
+    await page.getByText("GPT-5.6 Sol", { exact: true }).last().hover();
+    await page.getByRole("option", { name: /Opus 5/ }).click();
+    await typeIntoComposer(page, "Use Opus for this thread");
+    await waitForThreadIdle(page, threadId);
+    await waitForThreadNotBusy(page, threadId);
+
+    const slackState = (await (
+      await page.request.get("/control/state")
+    ).json()) as { thread_ts: string };
+    const response = await page.request.post("/mock/slack/send", {
+      data: {
+        text: "<@U0BOT> continue with the selected model",
+        mention_bot: true,
+        thread_ts: slackState.thread_ts,
+      },
+    });
+    expect(response.ok()).toBeTruthy();
+
+    await expect
+      .poll(async () => {
+        const runs = (await (
+          await page.request.get(`/threads/${threadId}/runs`)
+        ).json()) as Array<{
+          kwargs?: {
+            config?: { configurable?: { agent_model_id?: string } };
+          };
+        }>;
+        return runs[0]?.kwargs?.config?.configurable?.agent_model_id;
+      })
+      .toBe("anthropic:claude-opus-5");
+  });
+
   test("renders structured input envelopes safely and keeps legacy messages", async ({
     page,
   }) => {

--- a/tests/slack/test_slack_context.py
+++ b/tests/slack/test_slack_context.py
@@ -1645,6 +1645,43 @@ def test_thread_environment_round_trips_through_metadata(
     assert asyncio.run(webhook_common.get_thread_environment("thread-id")) == "staging"
 
 
+def test_thread_model_choice_round_trips_explicit_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    threads = _FakeThreadsClient(
+        {
+            "metadata": {
+                "model_selection": "explicit",
+                "model": "anthropic:claude-opus-5",
+                "effort": "high",
+            }
+        }
+    )
+    monkeypatch.setattr(webhook_common, "get_client", lambda url: _FakeClient(threads))
+
+    assert asyncio.run(webhook_common.get_thread_model_choice("thread-id")) == (
+        "anthropic:claude-opus-5",
+        "high",
+    )
+
+
+def test_thread_model_choice_is_none_for_auto_selection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    threads = _FakeThreadsClient(
+        {
+            "metadata": {
+                "model_selection": "auto",
+                "model": "anthropic:claude-opus-5",
+                "effort": "high",
+            }
+        }
+    )
+    monkeypatch.setattr(webhook_common, "get_client", lambda url: _FakeClient(threads))
+
+    assert asyncio.run(webhook_common.get_thread_model_choice("thread-id")) is None
+
+
 def test_thread_environment_is_none_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     threads = _FakeThreadsClient({"metadata": {}})
     monkeypatch.setattr(webhook_common, "get_client", lambda url: _FakeClient(threads))


### PR DESCRIPTION
A model selected from the Web UI for a Slack-originated thread was persisted in thread metadata, but later Slack mentions rebuilt run configuration without that explicit choice.

This forwards a valid explicit thread model and effort into subsequent Slack runs while preserving image-model fallbacks and Auto routing. It also adds a full Playwright Slack → Web model change → Slack follow-up regression test and focused metadata coverage.

Made by [Open SWE](https://openswe.vercel.app/agents/ae23754f-46f8-5c86-91d1-ddfe87146e62) · openai:gpt-5.6-sol (high)