### PR TITLE
fix: scope answered-question feedback to dashboard

### DIFF
--- a/agent/server.py
+++ b/agent/server.py
@@ -398,6 +398,7 @@ def _is_subagent_excluded_tool(tool: Any) -> bool:
         "manage_code_channel",
         "list_threads",
         "manage_thread",
+        "mark_question_answered",
         "notify_automation_channel",
         "read_user_settings",
     }
@@ -1143,6 +1144,8 @@ async def get_agent(config: RunnableConfig) -> Pregel:
         static_tools = [tool for tool in static_tools if tool not in personal_tools]
     if not _slack_tools_enabled(cfg):
         static_tools = [tool for tool in static_tools if tool not in slack_tools]
+    if source != "dashboard":
+        static_tools = [tool for tool in static_tools if tool is not mark_question_answered]
     static_tools = apply_tool_descriptions(static_tools)
     if local_run:
         static_tools = apply_tool_descriptions([http_request, fetch_url, web_search])

--- a/agent/tools/mark_question_answered.py
+++ b/agent/tools/mark_question_answered.py
@@ -23,6 +23,8 @@ async def mark_question_answered() -> dict[str, Any]:
     """
     config = get_config()
     cfg = RunConfig.from_config(config)
+    if cfg.source != "dashboard":
+        return {"success": False, "error": "Only dashboard runs can mark answered questions"}
     run_id = str(config.get("run_id") or cfg.run_id or "")
     if not cfg.thread_id or not run_id:
         return {"success": False, "error": "No active thread and run"}

--- a/tests/agent/test_agent_assembly_context.py
+++ b/tests/agent/test_agent_assembly_context.py
@@ -554,6 +554,42 @@ async def test_dashboard_agent_excludes_slack_tools() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("source", ["slack", "schedule"])
+async def test_non_dashboard_agent_excludes_question_feedback_tool(source: str) -> None:
+    config = _base_config()
+    configurable = config.get("configurable")
+    assert isinstance(configurable, dict)
+    configurable["source"] = source
+
+    captured = await _capture_create_deep_agent_kwargs(config)
+    tools = captured["tools"]
+    subagents = captured["subagents"]
+    assert isinstance(tools, list)
+    assert isinstance(subagents, list)
+
+    assert "mark_question_answered" not in {_registered_tool_name(tool) for tool in tools}
+    general_purpose = next(item for item in subagents if item["name"] == "general-purpose")
+    assert "mark_question_answered" not in {
+        _registered_tool_name(tool) for tool in general_purpose["tools"]
+    }
+
+
+@pytest.mark.asyncio
+async def test_dashboard_question_feedback_tool_is_parent_only() -> None:
+    captured = await _capture_create_deep_agent_kwargs()
+    tools = captured["tools"]
+    subagents = captured["subagents"]
+    assert isinstance(tools, list)
+    assert isinstance(subagents, list)
+
+    assert "mark_question_answered" in {_registered_tool_name(tool) for tool in tools}
+    general_purpose = next(item for item in subagents if item["name"] == "general-purpose")
+    assert "mark_question_answered" not in {
+        _registered_tool_name(tool) for tool in general_purpose["tools"]
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("source", ["slack", "schedule"])
 async def test_slack_source_context_includes_slack_tools(source: str) -> None:
     config = _base_config()
     configurable = config.get("configurable")

--- a/tests/tools/test_mark_question_answered.py
+++ b/tests/tools/test_mark_question_answered.py
@@ -17,12 +17,32 @@ async def test_missing_run_context_cannot_qualify_feedback(monkeypatch, config):
 
 
 @pytest.mark.asyncio
-async def test_qualifies_only_current_thread_and_run(monkeypatch):
+@pytest.mark.parametrize("source", ["slack", "schedule", "linear", "github", "desktop"])
+async def test_non_dashboard_run_cannot_qualify_feedback(monkeypatch, source):
     mark = AsyncMock()
     monkeypatch.setattr(
         answered,
         "get_config",
-        lambda: {"run_id": "current-run", "configurable": {"thread_id": "current-thread"}},
+        lambda: {
+            "run_id": "current-run",
+            "configurable": {"thread_id": "current-thread", "source": source},
+        },
+    )
+    monkeypatch.setattr(answered, "mark_answered_question", mark)
+    assert (await answered.mark_question_answered())["success"] is False
+    mark.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_qualifies_only_current_dashboard_thread_and_run(monkeypatch):
+    mark = AsyncMock()
+    monkeypatch.setattr(
+        answered,
+        "get_config",
+        lambda: {
+            "run_id": "current-run",
+            "configurable": {"thread_id": "current-thread", "source": "dashboard"},
+        },
     )
     monkeypatch.setattr(answered, "mark_answered_question", mark)
     assert await answered.mark_question_answered() == {"success": True}


### PR DESCRIPTION
`mark_question_answered` is a dashboard-only feedback signal, but it was exposed on every agent surface and inherited by general-purpose subagents. On Slack, an accidental call could reserve the run's feedback event before the completion path attached Slack delivery metadata, leaving the delayed prompt undeliverable.

This change exposes the tool only on dashboard runs, keeps it out of all subagents, and adds a runtime source check as defense in depth. It covers both graph assembly and direct invocation so non-dashboard runs cannot claim dashboard feedback events.

<!-- langsmith-issue {"id":"1d8d861b-95cc-4b67-b035-32de20eb18c9"} -->

Made by [Open SWE](https://openswe.vercel.app/agents/a95f438c-c6cf-5a0d-8208-c5aaa9d249f6) · openai:gpt-5.6-sol (high)