### PR TITLE
fix: preview PR links throughout messages

### DIFF
--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -37,7 +37,11 @@ from e2e_env import (  # noqa: E402
     BOT_USER_ID,
     DEMO_CHANNEL,
     HUMAN_USER,
+    OWNER,
+    REPO,
     REPO_ROOT,
+    SECOND_OWNER,
+    SECOND_REPO,
     TEST_USERS,
 )
 from fastapi import HTTPException, Request  # noqa: E402
@@ -618,6 +622,15 @@ def _gh_pr_json(pr: dict[str, Any]) -> dict[str, Any]:
         "changed_files": len(pr["files"]),
         "created_at": pr["created_at"],
     }
+
+
+@app.get("/fake-gh/installation/repositories")
+async def gh_list_installation_repositories() -> JSONResponse:
+    repositories = [
+        {"full_name": f"{OWNER}/{REPO}"},
+        {"full_name": f"{SECOND_OWNER}/{SECOND_REPO}"},
+    ]
+    return JSONResponse({"total_count": len(repositories), "repositories": repositories})
 
 
 @app.get("/fake-gh/repos/{owner}/{repo}")

--- a/tests/e2e/tests/dashboard.spec.ts
+++ b/tests/e2e/tests/dashboard.spec.ts
@@ -39,8 +39,13 @@ test.describe("Slack → web handoff (real dashboard UI)", () => {
     ).toBeVisible();
 
     // The transcript that started in Slack is here too (incl. the PR link).
+    const pullRequestLink = page
+      .getByRole("link", { name: "Add greet() helper" })
+      .first();
+    await expect(pullRequestLink).toBeVisible();
+    await pullRequestLink.hover();
     await expect(
-      page.getByRole("link", { name: "Add greet() helper" }).first(),
+      page.getByTestId("pr-hover-card-fakeorg/demo-1"),
     ).toBeVisible();
   });
 

--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -19,6 +19,7 @@ import { AgentThreadHeader } from "@/features/agents/components/AgentThreadHeade
 import { SIBLING_COLUMN_MIN_WIDTH } from "@/features/agents/components/panel/RightPanelShell"
 import { AgentPromptBar } from "@/features/agents/components/AgentPromptBar"
 import { AgentComposerDock } from "@/features/agents/components/composer/AgentComposerDock"
+import { PullRequestPreviewProvider } from "@/features/agents/components/PullRequestPreview"
 import { ThreadPullRequests } from "@/features/agents/components/ThreadPullRequests"
 import { ThreadFeedbackCard } from "@/features/agents/components/ThreadFeedbackCard"
 import {
@@ -314,54 +315,61 @@ export function AgentThreadView({
               />
             </div>
           ) : (
-            <Messages
-              messages={visibleMessages}
-              threadId={thread.id}
-              scrollKey={thread.id}
-              showPlanArtifact={
-                thread.planStatus === "ready" || thread.planStatus === "shared"
-              }
-              emptyState={
-                <div className="flex min-h-60 items-center justify-center">
-                  {hydrationFailed ? (
-                    <Alert variant="error" className="max-w-3xl">
-                      <CircleAlertIcon />
-                      <AlertDescription>
-                        <span>
-                          This thread&apos;s messages could not be loaded.
-                          Reload to try again.
-                        </span>
-                      </AlertDescription>
-                    </Alert>
-                  ) : (
-                    <p className="text-xs text-muted-foreground/70">
-                      This thread has no messages yet.
-                    </p>
-                  )}
-                </div>
-              }
-              onOpenFile={handleOpenFile}
-              queuedMessages={queuedMessages}
-              isStreaming={isStreaming}
-              streamIsLoading={stream.isLoading}
-              scrollControlRef={scrollControlRef}
-              isThinking={isThinking}
-              isOffloading={stream.isOffloading}
-              settingUpSandbox={settingUpSandbox}
-              pollWorkflowApprovalsWhileActive={isStreaming}
-              contentWidthClass="max-w-3xl"
-              footer={
-                !isStreaming &&
-                !sendMessage.isPending &&
-                queuedMessages.length === 0 && (
-                  <ThreadFeedbackCard
-                    key={`${thread.id}:${session.data?.login ?? ""}`}
-                    threadId={thread.id}
-                    login={session.data?.login ?? null}
-                  />
-                )
-              }
-            />
+            <PullRequestPreviewProvider
+              pullRequests={thread.pullRequests ?? []}
+              health={pullRequestHealth}
+              healthUnavailable={pullRequestStatus.isError}
+            >
+              <Messages
+                messages={visibleMessages}
+                threadId={thread.id}
+                scrollKey={thread.id}
+                showPlanArtifact={
+                  thread.planStatus === "ready" ||
+                  thread.planStatus === "shared"
+                }
+                emptyState={
+                  <div className="flex min-h-60 items-center justify-center">
+                    {hydrationFailed ? (
+                      <Alert variant="error" className="max-w-3xl">
+                        <CircleAlertIcon />
+                        <AlertDescription>
+                          <span>
+                            This thread&apos;s messages could not be loaded.
+                            Reload to try again.
+                          </span>
+                        </AlertDescription>
+                      </Alert>
+                    ) : (
+                      <p className="text-xs text-muted-foreground/70">
+                        This thread has no messages yet.
+                      </p>
+                    )}
+                  </div>
+                }
+                onOpenFile={handleOpenFile}
+                queuedMessages={queuedMessages}
+                isStreaming={isStreaming}
+                streamIsLoading={stream.isLoading}
+                scrollControlRef={scrollControlRef}
+                isThinking={isThinking}
+                isOffloading={stream.isOffloading}
+                settingUpSandbox={settingUpSandbox}
+                pollWorkflowApprovalsWhileActive={isStreaming}
+                contentWidthClass="max-w-3xl"
+                footer={
+                  !isStreaming &&
+                  !sendMessage.isPending &&
+                  queuedMessages.length === 0 && (
+                    <ThreadFeedbackCard
+                      key={`${thread.id}:${session.data?.login ?? ""}`}
+                      threadId={thread.id}
+                      login={session.data?.login ?? null}
+                    />
+                  )
+                }
+              />
+            </PullRequestPreviewProvider>
           )}
           {!isHydrating && (
             <AgentComposerDock>

--- a/ui/src/features/agents/components/PullRequestPreview.test.tsx
+++ b/ui/src/features/agents/components/PullRequestPreview.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest"
+
+import { parseGitHubPullRequestUrl } from "./PullRequestPreview"
+
+describe("parseGitHubPullRequestUrl", () => {
+  it("parses GitHub pull request links anywhere in text renderers", () => {
+    expect(
+      parseGitHubPullRequestUrl(
+        "https://github.com/langchain-ai/open-swe/pull/123?diff=split#discussion"
+      )
+    ).toEqual({ repoFullName: "langchain-ai/open-swe", number: 123 })
+    expect(
+      parseGitHubPullRequestUrl("https://www.github.com/org/repo/pull/7/")
+    ).toEqual({ repoFullName: "org/repo", number: 7 })
+  })
+
+  it("ignores non-PR and non-GitHub links", () => {
+    expect(
+      parseGitHubPullRequestUrl("https://github.com/org/repo/issues/123")
+    ).toBeNull()
+    expect(
+      parseGitHubPullRequestUrl("https://example.com/org/repo/pull/123")
+    ).toBeNull()
+  })
+})

--- a/ui/src/features/agents/components/PullRequestPreview.tsx
+++ b/ui/src/features/agents/components/PullRequestPreview.tsx
@@ -1,0 +1,133 @@
+import { createContext, useContext, useMemo } from "react"
+import type { ComponentProps, ReactNode } from "react"
+
+import { PullRequestHoverCard } from "@/features/agents/components/ThreadPullRequests"
+import type {
+  AgentPullRequest,
+  AgentPullRequestHealth,
+} from "@/features/agents/lib/types"
+import { Tooltip, TooltipPopup, TooltipTrigger } from "@/components/ui/tooltip"
+
+interface PullRequestPreviewContextValue {
+  pullRequests: Map<string, AgentPullRequest>
+  pullRequestUrls: Map<string, AgentPullRequest>
+  health: Map<string, AgentPullRequestHealth>
+  healthUnavailable: boolean
+}
+
+const PullRequestPreviewContext =
+  createContext<PullRequestPreviewContextValue | null>(null)
+
+function pullRequestKey(repoFullName: string, number: number): string {
+  return `${repoFullName.toLowerCase()}#${number}`
+}
+
+export function parseGitHubPullRequestUrl(
+  href: string | undefined
+): { repoFullName: string; number: number } | null {
+  if (!href) return null
+  try {
+    const url = new URL(href)
+    if (url.hostname !== "github.com" && url.hostname !== "www.github.com") {
+      return null
+    }
+    const match = /^\/([^/]+)\/([^/]+)\/pull\/(\d+)\/?$/.exec(url.pathname)
+    if (!match) return null
+    return {
+      repoFullName: `${match[1]}/${match[2]}`,
+      number: Number(match[3]),
+    }
+  } catch {
+    return null
+  }
+}
+
+export function PullRequestPreviewProvider({
+  pullRequests,
+  health,
+  healthUnavailable,
+  children,
+}: {
+  pullRequests: Array<AgentPullRequest>
+  health?: Array<AgentPullRequestHealth>
+  healthUnavailable: boolean
+  children: ReactNode
+}) {
+  const value = useMemo(
+    () => ({
+      pullRequests: new Map(
+        pullRequests.map((pullRequest) => [
+          pullRequestKey(pullRequest.repoFullName, pullRequest.number),
+          pullRequest,
+        ])
+      ),
+      pullRequestUrls: new Map(
+        pullRequests.map((pullRequest) => [pullRequest.url, pullRequest])
+      ),
+      health: new Map(
+        (health ?? []).map((item) => [
+          pullRequestKey(item.repoFullName ?? "", item.number ?? -1),
+          item,
+        ])
+      ),
+      healthUnavailable,
+    }),
+    [health, healthUnavailable, pullRequests]
+  )
+
+  return (
+    <PullRequestPreviewContext value={value}>
+      {children}
+    </PullRequestPreviewContext>
+  )
+}
+
+export function PreviewablePullRequestLink({
+  href,
+  children,
+  ...props
+}: ComponentProps<"a">) {
+  const previews = useContext(PullRequestPreviewContext)
+  const parsed = parseGitHubPullRequestUrl(href)
+  const pullRequest =
+    (href && previews?.pullRequestUrls.get(href)) ||
+    (parsed &&
+      previews?.pullRequests.get(
+        pullRequestKey(parsed.repoFullName, parsed.number)
+      ))
+
+  if (!pullRequest || !previews) {
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    )
+  }
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <a href={href} {...props}>
+            {children}
+          </a>
+        }
+      />
+      <TooltipPopup
+        variant="glass"
+        side="top"
+        align="start"
+        sideOffset={8}
+        className="rounded-xl p-3 shadow-2xl"
+      >
+        <PullRequestHoverCard
+          pullRequest={pullRequest}
+          health={previews.health.get(
+            pullRequestKey(pullRequest.repoFullName, pullRequest.number)
+          )}
+          healthUnavailable={previews.healthUnavailable}
+        />
+      </TooltipPopup>
+    </Tooltip>
+  )
+}

--- a/ui/src/features/agents/components/ThreadPullRequests.tsx
+++ b/ui/src/features/agents/components/ThreadPullRequests.tsx
@@ -231,7 +231,7 @@ function HealthDetails({
   )
 }
 
-function PullRequestHoverCard({
+export function PullRequestHoverCard({
   pullRequest,
   health,
   healthUnavailable,

--- a/ui/src/features/agents/components/chat/Markdown.tsx
+++ b/ui/src/features/agents/components/chat/Markdown.tsx
@@ -14,6 +14,7 @@ import {
   TriangleAlert,
 } from "lucide-react"
 import "streamdown/styles.css"
+import { PreviewablePullRequestLink } from "@/features/agents/components/PullRequestPreview"
 import { CodeBlock } from "./CodeBlock"
 import {
   orderedListGutterStyle,
@@ -202,9 +203,9 @@ const COMPONENTS: Components = {
     children,
     ...props
   }: ExtraProps & ComponentProps<"a">) => (
-    <a {...props} target="_blank" rel="noreferrer">
+    <PreviewablePullRequestLink {...props} target="_blank" rel="noreferrer">
       {children}
-    </a>
+    </PreviewablePullRequestLink>
   ),
 }
 

--- a/ui/src/features/agents/components/messages/SlackMrkdwn.tsx
+++ b/ui/src/features/agents/components/messages/SlackMrkdwn.tsx
@@ -1,6 +1,8 @@
 import { Fragment } from "react"
 import type { ReactNode } from "react"
 
+import { PreviewablePullRequestLink } from "@/features/agents/components/PullRequestPreview"
+
 const ALLOWED_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"])
 const LINK_CLASS =
   "text-foreground/90 underline decoration-foreground/40 break-words [overflow-wrap:anywhere]"
@@ -113,7 +115,7 @@ function slackTokenNode(token: string, key: string): ReactNode {
 
   const linkText = rawLabel || rawTarget
   return (
-    <a
+    <PreviewablePullRequestLink
       key={key}
       href={href}
       target="_blank"
@@ -121,7 +123,7 @@ function slackTokenNode(token: string, key: string): ReactNode {
       className={LINK_CLASS}
     >
       {renderRange(linkText, 0, linkText.length, `${key}-label`)}
-    </a>
+    </PreviewablePullRequestLink>
   )
 }
 


### PR DESCRIPTION
PR hover previews now apply to tracked pull-request links anywhere in rendered message text, including Markdown and Slack mrkdwn, while non-PR links keep their existing behavior.

The browser harness now exposes its fake installation repositories so E2E PR creation succeeds, and the Slack-to-web test verifies the inline message link opens its hover card.

### Verification
- `uv run ruff format --check tests/e2e/harness.py`
- `uv run ruff check tests/e2e/harness.py`
- `pnpm exec oxfmt --check tests/e2e/tests/dashboard.spec.ts`
- `pnpm exec oxlint tests/e2e/tests/dashboard.spec.ts`
- Targeted `full_flow.spec.ts` PR creation flow
- Targeted `dashboard.spec.ts` Slack-to-web flow with inline PR hover assertion

### Screenshot

![Inline PR hover card](https://01a09110-941c-7664-9fbf-f901f33eda31--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGt5TURRMk5UVXNJbXAwYVNJNklqQXhZVEE1TkdVNExUWm1NR1V0TjJVeU1pMDVOamxrTFRKaFl6TXdPRGRqTTJFMFl5SXNJbk5wWkNJNklqQXhZVEE1TVRFd0xUazBNV010TnpZMk5DMDVabUptTFdZNU1ERm1Nek5sWkdFek1TSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkRzF3TDNCeUxXaHZkbVZ5TFdGdWVTMTBaWGgwTFd4cGJtc3VjRzVuSWl3aVkzUWlPaUpwYldGblpTOXdibWNpTENKalpDSTZJbWx1YkdsdVpTSXNJbk55WXlJNk1UVjkucUpfVllubzNXMkdQVzhwTE1kYTI0aVdjZ1JTaTY1ZnYzSzAyUDZvTlNXcm03SUkxMjJXUEdRUkdPdWFSWHE3WTZleWtsaXdXUWpneEZMRmFxRmZLQVE)

Made by [Open SWE](https://openswe.vercel.app/agents/528e86f9-5e5f-5883-910a-2b1d064d5637) · openai:gpt-5.6-sol (high)