### PR TITLE
fix: pin compatible GitHub CLI for sandboxes

### DIFF
--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -41,7 +41,7 @@ DEFAULT_SANDBOX_IDLE_TTL_SECONDS="7200"                            # Optional, d
 DEFAULT_SANDBOX_DELETE_AFTER_STOP_SECONDS="2592000"                # Optional, default 2592000 (30 d); 0 disables
 ```
 
-This is useful for pre-installing languages, frameworks, or internal tools that your repos depend on — reducing setup time per agent run. The default snapshot includes the GitHub CLI; agents invoke it as `gh <command>` and rely on the LangSmith proxy for the real credentials.
+This is useful for pre-installing languages, frameworks, or internal tools that your repos depend on — reducing setup time per agent run. Agents invoke the GitHub CLI as `gh <command>` and rely on the LangSmith proxy for the real credentials. The sandbox must provide a compatible CLI; Open SWE currently requires `gh` 2.50.0 or later. To install the pinned version used by Open SWE in a custom image or environment setup script, run `scripts/install_gh.sh`.
 
 `DEFAULT_SANDBOX_SNAPSHOT_ID` is only the deployment default. Admins can override it at runtime — from the **Sandbox** page or via `PUT /dashboard/api/sandbox-settings` — so a rebuilt image can be rolled out without a redeploy. See [INSTALLATION.md](./INSTALLATION.md) and `examples/github-actions/set-base-snapshot.yml` for the CI flow.
 

--- a/scripts/install_gh.sh
+++ b/scripts/install_gh.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GH_VERSION=2.100.0
+
+case "$(uname -m)" in
+  x86_64)
+    arch=amd64
+    sha256=e4d4bb4498e8d007abe545b6568926793ace1b6447da598294a610018cb164be
+    ;;
+  aarch64|arm64)
+    arch=arm64
+    sha256=ea4e7a581a32ccad6cc7923cb1576ac5859ba4b9a16ab22eb8f8a96e78e2e961
+    ;;
+  *)
+    echo "unsupported architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+archive="gh_${GH_VERSION}_linux_${arch}.tar.gz"
+root="gh_${GH_VERSION}_linux_${arch}"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/${archive}" -o "$tmp/$archive"
+echo "$sha256  $tmp/$archive" | sha256sum -c -
+tar -xzf "$tmp/$archive" -C "$tmp"
+install -m 0755 "$tmp/$root/bin/gh" /usr/local/bin/gh
+
+gh --version
+gh api --paginate --slurp --help >/dev/null
+gh pr checks --json name,bucket,state,workflow,link --help >/dev/null


### PR DESCRIPTION
The active managed sandbox can ship a GitHub CLI older than commands required by Open SWE and the bundled baby-sit skill. Add a checksum-verified installer pinned to GitHub CLI 2.100.0 for amd64 and arm64 sandbox images, and document the minimum compatible version and managed-environment installation path.

This repository change makes the fix reproducible; a workspace admin must use the installer while rebuilding and publishing the managed `default` environment for it to affect new runs.

<!-- langsmith-issue {"id":"fbada298-5bd4-4b9e-b7dc-8271ad72c699"} -->

Made by [Open SWE](https://openswe.vercel.app/agents/197f5144-6128-5f39-8430-383498576c46) · openai:gpt-5.6-sol (high)

## References
- Plan: https://openswe.vercel.app/agents/197f5144-6128-5f39-8430-383498576c46/plan