### PR TITLE
fix: retain content when offload trimming empties summary

### DIFF
--- a/agent/middleware/conversation_offloading.py
+++ b/agent/middleware/conversation_offloading.py
@@ -5,10 +5,12 @@ from contextvars import ContextVar
 from typing import Any, NotRequired
 
 from deepagents.middleware.summarization import (
+    DEEPAGENTS_DEFAULT_SUMMARY_PROMPT,
     SummarizationMiddleware,
     SummarizationState,
     compute_summarization_defaults,
 )
+from langchain.agents.middleware.internal_call_transformer import internal_call_metadata
 from langchain.agents.middleware.types import (
     AgentState,
     ExtendedModelResponse,
@@ -16,7 +18,7 @@ from langchain.agents.middleware.types import (
     ModelResponse,
     hook_config,
 )
-from langchain_core.messages import AnyMessage
+from langchain_core.messages import AnyMessage, get_buffer_string, trim_messages
 from langgraph.config import get_stream_writer
 from langgraph.runtime import Runtime
 
@@ -42,6 +44,7 @@ class ConversationOffloadingMiddleware(SummarizationMiddleware):
             model=summary_model, backend=backend, **compute_summarization_defaults(model)
         )
         self.manual = manual
+        self.trim_tokens_to_summarize = self._lc_helper.trim_tokens_to_summarize
 
     def _status(self, status: str, **details: Any) -> dict[str, Any]:
         payload = {
@@ -64,7 +67,30 @@ class ConversationOffloadingMiddleware(SummarizationMiddleware):
     async def _acreate_summary(self, messages_to_summarize: list[AnyMessage]) -> str:
         self._status("started")
         try:
-            return await super()._acreate_summary(messages_to_summarize)
+            if self.trim_tokens_to_summarize is not None:
+                summary_messages = trim_messages(
+                    messages_to_summarize,
+                    max_tokens=self.trim_tokens_to_summarize,
+                    token_counter=self.token_counter,
+                    strategy="last",
+                    allow_partial=True,
+                    include_system=True,
+                    text_splitter=lambda text: list(text),
+                )
+                if summary_messages:
+                    messages_to_summarize = summary_messages
+            response = await self.model.ainvoke(
+                DEEPAGENTS_DEFAULT_SUMMARY_PROMPT.format(
+                    messages=get_buffer_string(messages_to_summarize, format="xml")
+                ).rstrip(),
+                config={
+                    "metadata": {
+                        "lc_source": "summarization",
+                        **internal_call_metadata(),
+                    }
+                },
+            )
+            return response.text.strip()
         except Exception:
             self._status("failed")
             raise

--- a/tests/middleware/test_conversation_offloading.py
+++ b/tests/middleware/test_conversation_offloading.py
@@ -129,6 +129,37 @@ async def test_automatic_completion_precedes_handler_and_suppresses_tokens(
     ] == "completed"
 
 
+async def test_offload_summarizes_untrimmed_messages_when_trimming_discards_everything(
+    tmp_path,
+):
+    model = FakeListChatModel(responses=["A usable summary."])
+    middleware = ConversationOffloadingMiddleware(
+        model, FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+    )
+    middleware._lc_helper.keep = ("messages", 2)
+    middleware._lc_helper._trigger_clauses = [{"messages": 4}]
+    middleware._lc_helper.trim_tokens_to_summarize = 1
+    graph = create_agent(model=model, middleware=[middleware], checkpointer=InMemorySaver())
+    config = {"configurable": {"thread_id": "fallback"}}
+
+    await graph.ainvoke(
+        {
+            "messages": [
+                HumanMessage(content="old"),
+                AIMessage(content="old reply"),
+                HumanMessage(content="recent"),
+                AIMessage(content="recent reply"),
+            ]
+        },
+        config,
+    )
+
+    state = await graph.aget_state(config)
+    event = state.values["_summarization_event"]
+    assert "A usable summary." in event["summary_message"].content
+    assert state.values["conversation_offloading"]["status"] == "completed"
+
+
 async def test_manual_before_model_runs_after_prepare(tmp_path, monkeypatch):
     prepared = []
 


### PR DESCRIPTION
LangChain's summarization helper returns a successful-looking fallback when newline-based partial trimming discards every oversized message. That caused Open SWE to persist the fallback as a completed offload.

Use character-level partial trimming so oversized messages still contribute bounded context to the summary. If trimming cannot retain a valid message sequence, summarize the original offload partition rather than replacing it with the fallback. The existing recent-message retention and offloaded-history pointer remain unchanged.

Trace inspection was unavailable because the configured LangSmith workspace returned 403; the defect and fix were verified against current source behavior with a regression test.

<!-- langsmith-issue {"id":"9b94fdad-cf98-4aea-bda8-8d6796fa894c"} -->

Made by [Open SWE](https://openswe.vercel.app/agents/ee17ea6b-1a3b-58b6-a2db-5925b86a6011) · openai:gpt-5.6-sol (high)