### PR TITLE
fix: say "Feedback submitted" after Slack thread feedback

### DIFF
--- a/agent/slack/thread_feedback.py
+++ b/agent/slack/thread_feedback.py
@@ -304,7 +304,7 @@ async def _acknowledge(record: ThreadFeedback, *, response_url: str) -> None:
                     posted = await post_slack_ephemeral_message(
                         current.channel_id,
                         current.user_id,
-                        "✅ Feedback completed. Thanks!",
+                        "✅ Feedback submitted. Thanks!",
                         thread_ts=current.thread_ts if current.thread_ts != "0" else None,
                     )
                     if not posted:

--- a/tests/slack/test_slack_thread_feedback.py
+++ b/tests/slack/test_slack_thread_feedback.py
@@ -358,7 +358,7 @@ async def test_prompt_cleanup_failure_preserves_saved_feedback_and_confirmation(
         feedback.post_slack_ephemeral_message.assert_not_awaited()
     else:
         feedback.post_slack_ephemeral_message.assert_awaited_once_with(
-            "C1", "U1", "✅ Feedback completed. Thanks!", thread_ts="1.0"
+            "C1", "U1", "✅ Feedback submitted. Thanks!", thread_ts="1.0"
         )
 
 


### PR DESCRIPTION
The ephemeral Slack acknowledgment after submitting thread feedback said "✅ Feedback completed. Thanks!" — this changes it to "✅ Feedback submitted. Thanks!" and updates the corresponding test assertion.

Changed files:
- `agent/slack/thread_feedback.py`
- `tests/slack/test_slack_thread_feedback.py`

Made by [Open SWE](https://openswe.vercel.app/agents/40c5441e-19cd-51ca-ac5a-dc8cd5623b0f) · openai:gpt-5.6-sol (high)