### PR TITLE
fix(e2e): expose installation repositories

### DIFF
--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -37,7 +37,11 @@ from e2e_env import (  # noqa: E402
     BOT_USER_ID,
     DEMO_CHANNEL,
     HUMAN_USER,
+    OWNER,
+    REPO,
     REPO_ROOT,
+    SECOND_OWNER,
+    SECOND_REPO,
     TEST_USERS,
 )
 from fastapi import HTTPException, Request  # noqa: E402
@@ -618,6 +622,15 @@ def _gh_pr_json(pr: dict[str, Any]) -> dict[str, Any]:
         "changed_files": len(pr["files"]),
         "created_at": pr["created_at"],
     }
+
+
+@app.get("/fake-gh/installation/repositories")
+async def gh_list_installation_repositories() -> JSONResponse:
+    repositories = [
+        {"full_name": f"{OWNER}/{REPO}"},
+        {"full_name": f"{SECOND_OWNER}/{SECOND_REPO}"},
+    ]
+    return JSONResponse({"total_count": len(repositories), "repositories": repositories})
 
 
 @app.get("/fake-gh/repos/{owner}/{repo}")


### PR DESCRIPTION
[PR #2647](https://github.com/langchain-ai/open-swe/pull/2647) added a `GET /installation/repositories` access check in [`open_pull_request.py`](https://github.com/langchain-ai/open-swe/blob/main/agent/tools/open_pull_request.py). The fake GitHub API in [`tests/e2e/harness.py`](https://github.com/langchain-ai/open-swe/blob/main/tests/e2e/harness.py) lacked that endpoint, causing 18 failures in [browser E2E run 34618768597](https://github.com/langchain-ai/open-swe/actions/runs/34618768597) and blocking [PR #2584](https://github.com/langchain-ai/open-swe/pull/2584).

Add a GitHub-compatible fake response listing both fixture repositories, `fakeorg/demo` and `anotherorg/companion`. Production access checks remain unchanged.

Made by [Open SWE](https://openswe.vercel.app/agents/a52305d0-002e-59e1-9353-ef757352a971) · openai:gpt-5.6-sol (high)