### PR TITLE
fix: discover desktop updates without restarting

### DIFF
--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -12,6 +12,7 @@ const {
   nativeTheme,
   net,
   protocol,
+  powerMonitor,
   safeStorage,
   session,
   shell,
@@ -124,6 +125,28 @@ function setUpdateState(
   }
 }
 
+let lastUpdateCheck = 0;
+let updateCheck: ReturnType<typeof autoUpdater.checkForUpdates> | null = null;
+
+function checkForUpdates() {
+  lastUpdateCheck = Date.now();
+  updateCheck ??= autoUpdater.checkForUpdates().finally(() => {
+    updateCheck = null;
+  });
+  return updateCheck;
+}
+
+function checkForUpdatesInBackground() {
+  if (
+    updateState.status !== "idle" ||
+    Date.now() - lastUpdateCheck < 60 * 60 * 1000
+  )
+    return;
+  void checkForUpdates().catch((error) =>
+    console.warn("Could not check for desktop updates", error),
+  );
+}
+
 function configureAutoUpdater() {
   if (!app.isPackaged) return;
   autoUpdater.autoDownload = true;
@@ -137,18 +160,21 @@ function configureAutoUpdater() {
   );
   autoUpdater.on("error", (error) => {
     console.warn("Desktop update failed", error);
-    setUpdateState("idle", undefined);
+    if (updateState.status === "downloading") setUpdateState("idle");
   });
-  void autoUpdater
-    .checkForUpdates()
-    .catch((error) =>
-      console.warn("Could not check for desktop updates", error),
-    );
+  checkForUpdatesInBackground();
+  const timer = setInterval(checkForUpdatesInBackground, 4 * 60 * 60 * 1000);
+  timer.unref();
+  powerMonitor.on("resume", checkForUpdatesInBackground);
+  app.on("activate", checkForUpdatesInBackground);
+  app.on("browser-window-focus", checkForUpdatesInBackground);
 }
 
 async function checkForDesktopUpdates() {
   try {
-    const result = await autoUpdater.checkForUpdates();
+    if (updateState.status === "ready" || updateState.status === "installing")
+      return;
+    const result = await checkForUpdates();
     if (result?.isUpdateAvailable) {
       await dialog.showMessageBox({
         type: "info",

--- a/ui/src/features/agents/components/AgentsSidebar.tsx
+++ b/ui/src/features/agents/components/AgentsSidebar.tsx
@@ -902,14 +902,15 @@ export function AgentsSidebar({
         {(updateState.status === "ready" || updateInstalling) && (
           <button
             type="button"
-            title={updateInstalling ? "Installing update…" : "Update"}
-            aria-label={updateInstalling ? "Installing update" : "Update"}
+            title={
+              updateInstalling ? "Installing update…" : "Restart to update"
+            }
+            aria-label={
+              updateInstalling ? "Installing update" : "Restart to update"
+            }
             disabled={updateInstalling}
             onClick={() => void installUpdate()}
-            className={cn(
-              "group flex size-8 shrink-0 items-center justify-center rounded-full bg-primary text-xs font-medium text-primary-foreground hover:w-auto hover:bg-primary/90 hover:px-3 disabled:opacity-60",
-              updateInstalling && "w-auto gap-2 px-3"
-            )}
+            className="flex h-8 shrink-0 items-center justify-center gap-2 rounded-full bg-primary px-3 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-60"
           >
             {updateInstalling ? (
               <>
@@ -918,8 +919,8 @@ export function AgentsSidebar({
               </>
             ) : (
               <>
-                <DownloadSimpleIcon className="size-4 group-hover:hidden" />
-                <span className="hidden group-hover:inline">Update</span>
+                <DownloadSimpleIcon className="size-4" />
+                <span>Restart to update</span>
               </>
             )}
           </button>


### PR DESCRIPTION
Check for desktop updates every four hours and on wake/activation/focus, throttled to once an hour. Share in-flight checks and retain downloaded updates on errors. Make “Restart to update” visible without hovering; installation remains user-controlled.

### Screenshot
Alice signed in, with a simulated downloaded update:

![Restart to update](https://01a0919f-488c-79b0-9911-940bec25416d--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGt4TlRBMk9EQXNJbXAwYVNJNklqQXhZVEE1TVdJd0xXUTBOakl0TjJNeE5DMWlOVEF3TFRJM1lqazFORGsxTVdSaU15SXNJbk5wWkNJNklqQXhZVEE1TVRsbUxUUTRPR010TnpsaU1DMDVPVEV4TFRrME1HSmxZekkxTkRFMlpDSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkRzF3TDJSbGMydDBiM0F0Y21WemRHRnlkQzExY0dSaGRHVXVjRzVuSWl3aVkzUWlPaUpwYldGblpTOXdibWNpTENKalpDSTZJbWx1YkdsdVpTSjkuY3lBV0hGd3dCMmVnRFlNZUFReTV1TXhjS3lEd2ZwMnNZZmx1LWdmRTRuZGhleV9GdnZVM19EOGlYNHdLc3NWNU16YlBKdFpXakFqYXoxbUtsQmxQRGc)

Made by [Open SWE](https://openswe.vercel.app/agents/01a0919f-434e-7734-9f27-e5647d2c0161) · fireworks:accounts/fireworks/models/glm-5p3-flash (max)