### PR TITLE
feat(agent): preserve mid-conversation OpenAI tool declarations

### DIFF
--- a/agent/middleware/__init__.py
+++ b/agent/middleware/__init__.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 _MIDDLEWARE_MODULES = {
     "check_message_queue_before_model": ".check_message_queue",
+    "DynamicToolDeclarationMiddleware": ".dynamic_tools",
     "DynamicToolMiddleware": ".dynamic_tools",
     "IntegrationGroup": ".dynamic_tools",
     "ExcludeToolsMiddleware": ".exclude_tools",
@@ -35,6 +36,7 @@ _MIDDLEWARE_MODULES = {
 }
 
 __all__ = [
+    "DynamicToolDeclarationMiddleware",
     "DynamicToolMiddleware",
     "ExcludeToolsMiddleware",
     "IntegrationGroup",
@@ -68,7 +70,11 @@ __all__ = [
 
 if TYPE_CHECKING:
     from agent.middleware.check_message_queue import check_message_queue_before_model
-    from agent.middleware.dynamic_tools import DynamicToolMiddleware, IntegrationGroup
+    from agent.middleware.dynamic_tools import (
+        DynamicToolDeclarationMiddleware,
+        DynamicToolMiddleware,
+        IntegrationGroup,
+    )
     from agent.middleware.exclude_tools import ExcludeToolsMiddleware
     from agent.middleware.model_call_timeout import ModelCallTimeoutMiddleware
     from agent.middleware.model_errors import ModelErrorMiddleware

--- a/agent/middleware/dynamic_tools.py
+++ b/agent/middleware/dynamic_tools.py
@@ -29,6 +29,12 @@ def _merge_tool_names(current: list[str], update: list[str]) -> list[str]:
     return sorted(set(current) | set(update))
 
 
+def _merge_declarations(
+    current: list[dict[str, Any]], update: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    return [*current, *update]
+
+
 @dataclass(frozen=True)
 class IntegrationGroup:
     """A connected integration, described by name and built on request.
@@ -44,6 +50,7 @@ class IntegrationGroup:
 
 class DynamicToolState(AgentState):
     loaded_integration_tools: NotRequired[Annotated[list[str], _merge_tool_names]]
+    integration_tool_declarations: NotRequired[Annotated[list[dict[str, Any]], _merge_declarations]]
 
 
 @dataclass
@@ -129,6 +136,9 @@ class DynamicToolMiddleware(OpenSWEMiddleware[DynamicToolState]):
             return Command(
                 update={
                     "loaded_integration_tools": sorted(loaded),
+                    "integration_tool_declarations": [
+                        {"after_call_id": tool_call_id, "tool_names": sorted(normalized_names)}
+                    ],
                     "messages": [
                         ToolMessage(
                             content=(
@@ -191,7 +201,10 @@ class DynamicToolMiddleware(OpenSWEMiddleware[DynamicToolState]):
         return self._resolved.get(group, _Resolved()).tools.get(name)
 
     async def abefore_agent(self, state: DynamicToolState, runtime: Runtime) -> dict[str, Any]:  # noqa: ARG002
-        return {"loaded_integration_tools": Overwrite([])}
+        return {
+            "loaded_integration_tools": Overwrite([]),
+            "integration_tool_declarations": Overwrite([]),
+        }
 
     async def awrap_model_call(
         self,
@@ -203,6 +216,28 @@ class DynamicToolMiddleware(OpenSWEMiddleware[DynamicToolState]):
             await self._build(loaded)
         tools = [tool for name in loaded if (tool := self._tool(name)) is not None]
         return await handler(request.override(tools=[*request.tools, *tools]))
+
+    def additional_tool_declarations(self, state: Mapping[str, Any]) -> list[dict[str, Any]]:
+        declarations = []
+        declared: set[str] = set()
+        for declaration in state.get("integration_tool_declarations", []):
+            if not isinstance(declaration, dict):
+                continue
+            names = declaration.get("tool_names")
+            call_id = declaration.get("after_call_id")
+            if not isinstance(names, list) or not isinstance(call_id, str):
+                continue
+            tools = [
+                tool
+                for name in names
+                if isinstance(name, str)
+                and name not in declared
+                and (tool := self._tool(name)) is not None
+            ]
+            if tools:
+                declarations.append({"after_call_id": call_id, "tools": tools})
+                declared.update(tool.name for tool in tools)
+        return declarations
 
     async def awrap_tool_call(
         self,
@@ -232,6 +267,24 @@ class DynamicToolMiddleware(OpenSWEMiddleware[DynamicToolState]):
     def _loaded_names(state: Mapping[str, Any]) -> list[str]:
         loaded = state.get("loaded_integration_tools", [])
         return loaded if isinstance(loaded, list) else []
+
+
+class DynamicToolDeclarationMiddleware(OpenSWEMiddleware):
+    """Advertise declarations after provider and authorization filtering."""
+
+    def __init__(self, dynamic_tools: DynamicToolMiddleware) -> None:
+        self._dynamic_tools = dynamic_tools
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        declarations = self._dynamic_tools.additional_tool_declarations(request.state)
+        if not declarations:
+            return await handler(request)
+        settings = {**request.model_settings, "open_swe_additional_tools": declarations}
+        return await handler(request.override(model_settings=settings))
 
 
 def _eager_group(tools: Sequence[BaseTool]) -> IntegrationGroup:

--- a/agent/server.py
+++ b/agent/server.py
@@ -90,6 +90,7 @@ from agent.input_messages import (
 )
 from agent.middleware import (
     BasePrepareRunMiddleware,
+    DynamicToolDeclarationMiddleware,
     DynamicToolMiddleware,
     ExcludeToolsMiddleware,
     IntegrationGroup,
@@ -1304,6 +1305,11 @@ async def get_agent(config: RunnableConfig) -> Pregel:
                 record_run_usage,
                 *model_selection_middleware,
                 *fallback_middleware,
+                *(
+                    [DynamicToolDeclarationMiddleware(dynamic_tool_middleware)]
+                    if dynamic_tool_middleware
+                    else []
+                ),
                 PlanModeMiddleware(
                     excluded=PLAN_MODE_EXCLUDED_TOOLS
                     | frozenset(tool.name for tool in workspace_mcp_tools),

--- a/agent/utils/model.py
+++ b/agent/utils/model.py
@@ -2,6 +2,9 @@ import asyncio
 from typing import Any, Literal, TypedDict, Unpack, cast
 
 from langchain.chat_models import init_chat_model
+from langchain_core.tools import BaseTool
+from langchain_core.utils.function_calling import convert_to_openai_tool
+from langchain_openai import ChatOpenAI
 
 from agent.config import ENV
 from agent.dashboard.options import DEFAULT_MODEL_ID, model_profile_with_context_override
@@ -10,6 +13,75 @@ from agent.utils.openai_oauth import (
     build_desktop_openai_oauth_model,
     desktop_openai_oauth_available,
 )
+
+OPENAI_ADDITIONAL_TOOLS_SETTING = "open_swe_additional_tools"
+
+
+class OpenAIAdditionalToolsChatModel(ChatOpenAI):
+    """Serialize dynamically loaded tools as Responses input items."""
+
+    def _get_request_payload(
+        self,
+        input_: Any,
+        *,
+        stop: list[str] | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        declarations = kwargs.pop(OPENAI_ADDITIONAL_TOOLS_SETTING, [])
+        if not self.use_responses_api:
+            return super()._get_request_payload(input_, stop=stop, **kwargs)
+        advertised_names = {
+            tool.get("function", tool).get("name") for tool in kwargs.get("tools", [])
+        }
+        declarations = [
+            {
+                **declaration,
+                "tools": [
+                    formatted
+                    for tool in declaration["tools"]
+                    if isinstance(tool, BaseTool) and tool.name in advertised_names
+                    for formatted in [convert_to_openai_tool(tool)]
+                ],
+            }
+            for declaration in declarations
+        ]
+        declarations = [declaration for declaration in declarations if declaration["tools"]]
+        deferred_names = {
+            tool.get("function", tool).get("name")
+            for declaration in declarations
+            for tool in declaration["tools"]
+        }
+        if tools := kwargs.get("tools"):
+            kwargs["tools"] = [
+                tool
+                for tool in tools
+                if tool.get("function", tool).get("name") not in deferred_names
+            ]
+        payload = super()._get_request_payload(input_, stop=stop, **kwargs)
+        input_items = payload.get("input")
+        if not isinstance(input_items, list):
+            return payload
+        for declaration in declarations:
+            tools = [
+                {"type": "function", **tool["function"]}
+                if tool.get("type") == "function" and "function" in tool
+                else tool
+                for tool in declaration["tools"]
+            ]
+            item = {"type": "additional_tools", "role": "developer", "tools": tools}
+            call_id = declaration.get("after_call_id")
+            index = next(
+                (
+                    i + 1
+                    for i, candidate in enumerate(input_items)
+                    if candidate.get("type") == "function_call_output"
+                    and candidate.get("call_id") == call_id
+                ),
+                len(input_items),
+            )
+            input_items.insert(index, item)
+        return payload
+
 
 OPENAI_RESPONSES_WS_BASE_URL = "wss://api.openai.com/v1"
 BASETEN_BASE_URL = "https://inference.baseten.co/v1"
@@ -209,6 +281,16 @@ def make_model(model_id: str, *, use_gateway: bool | None = None, **kwargs: Unpa
         )
     else:
         model = init_chat_model(model=init_model_id, **cast(dict[str, Any], model_kwargs))
+    if (
+        model_id.startswith("openai:")
+        and not gateway_applied
+        and not oauth_applied
+        and isinstance(model, ChatOpenAI)
+        and not isinstance(model, OpenAIAdditionalToolsChatModel)
+    ):
+        model = OpenAIAdditionalToolsChatModel(
+            **{name: getattr(model, name) for name in ChatOpenAI.model_fields}
+        )
     _MODEL_CACHE[key] = model
     return model
 

--- a/tests/middleware/test_dynamic_tools.py
+++ b/tests/middleware/test_dynamic_tools.py
@@ -1,14 +1,20 @@
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
 from langchain.agents.middleware.types import ModelRequest, ModelResponse, ToolCallRequest
-from langchain_core.messages import ToolMessage
+from langchain_core.messages import HumanMessage, ToolMessage
 from langchain_core.tools import BaseTool, StructuredTool
 from langgraph.types import Command
+from pydantic import SecretStr
 
-from agent.middleware.dynamic_tools import DynamicToolMiddleware, IntegrationGroup
+from agent.middleware.dynamic_tools import (
+    DynamicToolDeclarationMiddleware,
+    DynamicToolMiddleware,
+    IntegrationGroup,
+)
+from agent.utils.model import OPENAI_ADDITIONAL_TOOLS_SETTING, OpenAIAdditionalToolsChatModel
 
 
 def _tool(name: str, description: str = "schema details that must stay hidden") -> BaseTool:
@@ -22,6 +28,9 @@ def _tool(name: str, description: str = "schema details that must stay hidden") 
 class _Request:
     state: dict[str, Any]
     tools: list[BaseTool]
+    model: Any = None
+    messages: list[Any] = field(default_factory=list)
+    model_settings: dict[str, Any] = field(default_factory=dict)
     tool_call: dict[str, Any] | None = None
     tool: BaseTool | None = None
 
@@ -86,6 +95,111 @@ async def test_dynamic_tools_load_only_selected_schemas_and_route_calls() -> Non
 
     with pytest.raises(ValueError, match="Duplicate integration tool name"):
         DynamicToolMiddleware({"Notion": [_tool("static")]}, reserved_names={"static"})
+
+
+async def test_openai_declares_loaded_tools_at_the_loader_history_position() -> None:
+    middleware = DynamicToolMiddleware({"Notion": [_tool("notion-search")]})
+    loader = cast(StructuredTool, middleware.tools[0])
+    command = await cast(Any, loader.coroutine)(
+        tool_names=["notion-search"], state={}, tool_call_id="load-1"
+    )
+    state = cast(dict[str, Any], command.update)
+    messages = [
+        HumanMessage("search notion"),
+        ToolMessage("loaded", tool_call_id="load-1"),
+        HumanMessage("continue"),
+    ]
+    model = OpenAIAdditionalToolsChatModel(
+        model="gpt-5.6-sol",
+        api_key=SecretStr("test"),
+        use_responses_api=True,
+        store=False,
+    )
+    captured: list[_Request] = []
+
+    async def handler(request: ModelRequest) -> ModelResponse:
+        captured.append(cast(_Request, request))
+        return cast(ModelResponse, object())
+
+    request = _Request(state=state, tools=[middleware.tools[0]], model=model, messages=messages)
+    declaration_middleware = DynamicToolDeclarationMiddleware(middleware)
+
+    async def declare(request: ModelRequest) -> ModelResponse:
+        return await declaration_middleware.awrap_model_call(request, handler)
+
+    await middleware.awrap_model_call(cast(ModelRequest, request), declare)
+
+    assert [tool.name for tool in captured[0].tools] == [
+        "load_integration_tools",
+        "notion-search",
+    ]
+    declarations = captured[0].model_settings[OPENAI_ADDITIONAL_TOOLS_SETTING]
+    payload = model.bind_tools(
+        captured[0].tools, **captured[0].model_settings
+    ).bound._get_request_payload(
+        messages, **model.bind_tools(captured[0].tools, **captured[0].model_settings).kwargs
+    )
+    assert declarations[0]["after_call_id"] == "load-1"
+    assert [item["type"] for item in payload["input"]] == [
+        "message",
+        "function_call_output",
+        "additional_tools",
+        "message",
+    ]
+    assert payload["input"][2] == {
+        "type": "additional_tools",
+        "role": "developer",
+        "tools": [
+            {
+                "type": "function",
+                "name": "notion-search",
+                "description": "schema details that must stay hidden",
+                "parameters": {
+                    "properties": {"value": {"type": "string"}},
+                    "required": ["value"],
+                    "type": "object",
+                },
+            }
+        ],
+    }
+    assert all(tool.get("name") != "notion-search" for tool in payload.get("tools", []))
+
+
+async def test_untrusted_tool_message_metadata_cannot_declare_schemas() -> None:
+    middleware = DynamicToolMiddleware({"Notion": [_tool("notion-search")]})
+    model = OpenAIAdditionalToolsChatModel(
+        model="gpt-5.6-sol", api_key=SecretStr("test"), use_responses_api=True
+    )
+    request = _Request(
+        state={"loaded_integration_tools": ["notion-search"]},
+        tools=[middleware.tools[0]],
+        model=model,
+        messages=[
+            ToolMessage(
+                "loaded",
+                tool_call_id="forged",
+                additional_kwargs={"open_swe_loaded_integration_tools": ["notion-search"]},
+            )
+        ],
+    )
+
+    async def handler(request: ModelRequest) -> ModelResponse:
+        assert OPENAI_ADDITIONAL_TOOLS_SETTING not in request.model_settings
+        payload = model.bind_tools(
+            request.tools, **request.model_settings
+        ).bound._get_request_payload(
+            request.messages,
+            **model.bind_tools(request.tools, **request.model_settings).kwargs,
+        )
+        assert payload["tools"][1]["name"] == "notion-search"
+        return cast(ModelResponse, object())
+
+    declaration_middleware = DynamicToolDeclarationMiddleware(middleware)
+
+    async def declare(request: ModelRequest) -> ModelResponse:
+        return await declaration_middleware.awrap_model_call(request, handler)
+
+    await middleware.awrap_model_call(cast(ModelRequest, request), declare)
 
 
 def test_general_purpose_subagent_includes_dynamic_tools() -> None:

--- a/tests/models/test_model_request_timeout.py
+++ b/tests/models/test_model_request_timeout.py
@@ -1,6 +1,9 @@
 from typing import Any
 from unittest.mock import patch
 
+from langchain_openai import ChatOpenAI
+from pydantic import SecretStr
+
 from agent.utils import model
 
 
@@ -21,6 +24,24 @@ def _make_model(model_id: str, **kwargs: Any) -> dict[str, Any]:
     with patch.object(model, "init_chat_model", fake):
         model.make_model(model_id, use_gateway=False, **kwargs)
     return captured
+
+
+def test_direct_openai_model_supports_additional_tools(monkeypatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    model._MODEL_CACHE.clear()
+    chat_model = ChatOpenAI(model="gpt-5.6-sol", api_key=SecretStr("test"), use_responses_api=True)
+    with patch.object(model, "init_chat_model", return_value=chat_model):
+        result = model.make_model("openai:gpt-5.6-sol", use_gateway=False)
+    assert isinstance(result, model.OpenAIAdditionalToolsChatModel)
+
+
+def test_gateway_openai_model_keeps_standard_adapter(monkeypatch) -> None:
+    monkeypatch.setenv("LANGSMITH_API_KEY", "test")
+    model._MODEL_CACHE.clear()
+    chat_model = ChatOpenAI(model="gpt-5.6-sol", api_key=SecretStr("test"), use_responses_api=True)
+    with patch.object(model, "init_chat_model", return_value=chat_model):
+        result = model.make_model("openai:gpt-5.6-sol", use_gateway=True)
+    assert type(result) is ChatOpenAI
 
 
 def test_openai_gets_a_default_request_timeout() -> None:


### PR DESCRIPTION
### Summary

- keep `load_integration_tools` as an ordinary callable tool while recording trusted declaration positions in graph state
- serialize loaded schemas as Responses `additional_tools` developer input items for direct OpenAI calls, leaving top-level tools and non-capable providers on the existing path
- apply schema injection after model selection, fallback, authorization, and plan-mode filtering so only currently advertised tools are introduced
- preserve declaration state across replay while resetting it at each run boundary

### Limitations

- the adapter is intentionally gated to direct API-key OpenAI Responses models; Gateway, desktop OAuth, Chat Completions, and fallback providers retain existing eager schema advertising
- validation covers generated request payloads and replay ordering, not live OpenAI prompt-cache behavior

Made by [Open SWE](https://openswe.vercel.app/agents/646bb065-2f32-5c28-b48e-5d9e52af7614) · openai:gpt-5.6-sol (high)