### PR TITLE
feat(ui): show thread stream reconnects instead of hiding them

### DIFF
--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -47,6 +47,7 @@ import { useSession } from "@/lib/session"
 import { useIsMobile } from "@/lib/useIsMobile"
 import { cn } from "@/lib/utils"
 import { useAgentStream } from "@/features/agents/lib/stream/AgentStreamProvider"
+import { useReconnectStatus } from "@/features/agents/lib/stream/useReconnectStatus"
 
 interface AgentThreadViewProps {
   thread: AgentThread
@@ -226,6 +227,7 @@ export function AgentThreadView({
   const mentionPaths = useMemo(() => editedPaths(baseMessages), [baseMessages])
   const isThinking = stream.isLoading
   const settingUpSandbox = isThinking && baseMessages.length === 0
+  const reconnect = useReconnectStatus("cloud", thread.id)
   // The transcript hydrates from the SDK (`GET …/state` → `stream.messages`).
   // Show a loading state during that one-time fetch instead of the empty state.
   const isHydrating = stream.isThreadLoading && !hasMessages
@@ -347,6 +349,8 @@ export function AgentThreadView({
               scrollControlRef={scrollControlRef}
               isThinking={isThinking}
               isOffloading={stream.isOffloading}
+              reconnectLabel={reconnect.label}
+              onRetryStream={reconnect.retry}
               settingUpSandbox={settingUpSandbox}
               pollWorkflowApprovalsWhileActive={isStreaming}
               contentWidthClass="max-w-3xl"

--- a/ui/src/features/agents/components/messages/Messages.tsx
+++ b/ui/src/features/agents/components/messages/Messages.tsx
@@ -69,6 +69,8 @@ export const Messages = memo(function MessagesComponent({
   isThinking,
   settingUpSandbox,
   isOffloading = false,
+  reconnectLabel = null,
+  onRetryStream,
   project,
   contentWidthClass = "max-w-[42rem]",
   contentPaddingClass = "px-6",
@@ -172,6 +174,7 @@ export const Messages = memo(function MessagesComponent({
             {footer}
             <ThinkingSpinner
               isActive={
+                !!reconnectLabel ||
                 isOffloading ||
                 (!!(isThinking || streamIsLoading || isStreaming) &&
                   !(
@@ -180,10 +183,14 @@ export const Messages = memo(function MessagesComponent({
                     lastAgentIndex === visibleMessages.length - 1
                   ))
               }
-              settingUpSandbox={settingUpSandbox && !isOffloading}
-              label={
-                isOffloading ? "Offloading conversation..." : activityLabel
+              settingUpSandbox={
+                settingUpSandbox && !isOffloading && !reconnectLabel
               }
+              label={
+                reconnectLabel ??
+                (isOffloading ? "Offloading conversation..." : activityLabel)
+              }
+              onRetry={reconnectLabel ? onRetryStream : undefined}
             />
           </div>
         </div>

--- a/ui/src/features/agents/components/messages/ThinkingSpinner.tsx
+++ b/ui/src/features/agents/components/messages/ThinkingSpinner.tsx
@@ -2,10 +2,12 @@ export function ThinkingSpinner({
   isActive,
   settingUpSandbox = false,
   label,
+  onRetry,
 }: {
   isActive: boolean
   settingUpSandbox?: boolean
   label?: string
+  onRetry?: () => void
 }) {
   if (!isActive) return null
 
@@ -21,6 +23,15 @@ export function ThinkingSpinner({
           ? "Agent is setting up the environment…"
           : (label ?? "Working…")}
       </span>
+      {onRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+        >
+          Retry now
+        </button>
+      )}
     </div>
   )
 }

--- a/ui/src/features/agents/components/messages/types.ts
+++ b/ui/src/features/agents/components/messages/types.ts
@@ -34,6 +34,9 @@ export interface MessagesProps extends ApprovalCallbacks {
   isThinking?: boolean
   settingUpSandbox?: boolean
   isOffloading?: boolean
+  /** Takes over the activity line while the event stream is down. */
+  reconnectLabel?: string | null
+  onRetryStream?: () => void
   project?: Project | null
   contentWidthClass?: string
   /** Horizontal padding on centered content (scroll track stays edge-to-edge). */

--- a/ui/src/features/agents/lib/stream/AgentStreamProvider.tsx
+++ b/ui/src/features/agents/lib/stream/AgentStreamProvider.tsx
@@ -1,5 +1,6 @@
 import {
   createContext,
+  useCallback,
   useContext,
   useEffect,
   useLayoutEffect,
@@ -19,18 +20,45 @@ import {
   createLocalGraphClient,
   dashboardFetch,
 } from "@/lib/langgraph-client"
-import { selectStreamFor, useStreamPool } from "./streamPool"
+import {
+  MAX_RECONNECT_ATTEMPTS,
+  RECONNECT_GIVE_UP_GRACE_MS,
+  reconnectDelayMs,
+  selectConnectionFor,
+  selectStreamFor,
+  useStreamPool,
+} from "./streamPool"
 import type { ReactNode } from "react"
 import type {
   AgentStream,
   AgentThreadTransport,
+  StreamConnection,
   StreamPoolEntry,
 } from "./streamPool"
 
-export type { AgentStream, AgentThreadTransport } from "./streamPool"
+export type {
+  AgentStream,
+  AgentThreadTransport,
+  StreamConnection,
+} from "./streamPool"
 
 const AGENT_ASSISTANT_ID = "agent"
 const SWEEP_INTERVAL_MS = 10_000
+
+/**
+ * Reports every event-stream open against an instance so the transport's
+ * otherwise-silent reconnect loop has an observable "we are serving again"
+ * edge; the SDK fires `onReconnect` before each attempt but nothing on success.
+ */
+function connectionSensingFetch(id: string): typeof fetch {
+  return async (input, init) => {
+    const url = input instanceof Request ? input.url : String(input)
+    if (!url.includes("/stream/events")) return dashboardFetch(input, init)
+    const response = await dashboardFetch(input, init)
+    if (response.ok) useStreamPool.getState().streamLive(id)
+    return response
+  }
+}
 
 const AgentStreamContext = createContext<AgentStream | null>(null)
 
@@ -53,12 +81,20 @@ function PooledStream({ entry }: { entry: StreamPoolEntry }) {
   )
   const pool = useStreamPool.getState
   const [isOffloading, setIsOffloading] = useState(false)
+  const sensingFetch = useMemo(
+    () => connectionSensingFetch(entry.id),
+    [entry.id]
+  )
 
   const stream = useStream({
     client,
     assistantId: AGENT_ASSISTANT_ID,
     threadId: entry.threadId,
-    fetch: dashboardFetch,
+    fetch: sensingFetch,
+    maxReconnectAttempts: MAX_RECONNECT_ATTEMPTS,
+    reconnectDelayMs,
+    onReconnect: ({ attempt }) =>
+      pool().streamReconnecting(entry.id, attempt, Date.now()),
     onThreadId: (threadId) => pool().rekey(entry.id, threadId),
     onCreated: () => {
       setIsOffloading(false)
@@ -94,6 +130,17 @@ function PooledStream({ entry }: { entry: StreamPoolEntry }) {
     () => publish(entry.id, { ...stream, isOffloading }),
     [entry.id, publish, stream, isOffloading]
   )
+
+  const { connection } = entry
+  useEffect(() => {
+    if (connection.status !== "reconnecting") return
+    if (connection.attempt < MAX_RECONNECT_ATTEMPTS) return
+    const timer = setTimeout(
+      () => pool().streamLost(entry.id),
+      Math.max(0, connection.retryAt - Date.now()) + RECONNECT_GIVE_UP_GRACE_MS
+    )
+    return () => clearTimeout(timer)
+  }, [connection, entry.id, pool])
 
   return null
 }
@@ -145,7 +192,9 @@ export function AgentStreamProvider({
   return (
     <>
       {entries.map((entry) => (
-        <PooledStream key={entry.id} entry={entry} />
+        // langgraphjs#2817: a dead pump can never be reopened on its own
+        // controller, so recovery is a fresh instance under a fresh key.
+        <PooledStream key={`${entry.id}:${entry.epoch}`} entry={entry} />
       ))}
       {stream && (
         <AgentStreamContext.Provider value={stream}>
@@ -154,4 +203,20 @@ export function AgentStreamProvider({
       )}
     </>
   )
+}
+
+/** Liveness of the bound thread's event stream, with its manual retry. */
+export function useAgentStreamConnection(
+  transport: AgentThreadTransport,
+  threadId: string | null
+): { connection: StreamConnection; retry: () => void } {
+  const connection = useStreamPool((state) =>
+    selectConnectionFor(state, transport, threadId)
+  )
+  const retryStream = useStreamPool((state) => state.retryStream)
+  const retry = useCallback(
+    () => retryStream(transport, threadId),
+    [retryStream, threadId, transport]
+  )
+  return { connection, retry }
 }

--- a/ui/src/features/agents/lib/stream/reconnectLabel.test.ts
+++ b/ui/src/features/agents/lib/stream/reconnectLabel.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+
+import { reconnectLabel } from "./reconnectLabel"
+import { MAX_RECONNECT_ATTEMPTS } from "./streamPool"
+
+const NOW = 1_000_000
+
+describe("reconnectLabel", () => {
+  it("says nothing while the stream is serving", () => {
+    expect(reconnectLabel({ status: "live" }, NOW)).toBeNull()
+  })
+
+  it("counts down to the next attempt", () => {
+    const label = reconnectLabel(
+      { status: "reconnecting", attempt: 2, retryAt: NOW + 4_000 },
+      NOW
+    )
+
+    expect(label).toBe(
+      `Reconnecting… 2/${MAX_RECONNECT_ATTEMPTS} (retrying in 4s)`
+    )
+  })
+
+  it("drops the countdown once the deadline has passed", () => {
+    const label = reconnectLabel(
+      { status: "reconnecting", attempt: 2, retryAt: NOW - 1 },
+      NOW
+    )
+
+    expect(label).toBe(`Reconnecting… 2/${MAX_RECONNECT_ATTEMPTS}`)
+  })
+
+  it("states the outcome once the budget is spent", () => {
+    expect(reconnectLabel({ status: "lost", attempt: 12 }, NOW)).toBe(
+      "Connection lost"
+    )
+  })
+})

--- a/ui/src/features/agents/lib/stream/reconnectLabel.ts
+++ b/ui/src/features/agents/lib/stream/reconnectLabel.ts
@@ -1,0 +1,19 @@
+import { MAX_RECONNECT_ATTEMPTS, type StreamConnection } from "./streamPool"
+
+/**
+ * The activity line's text while the event stream is not serving. Mirrors how
+ * Claude Code and Codex report a retry: attempt count plus a countdown, in the
+ * same slot the normal status occupies rather than an alert of its own.
+ */
+export function reconnectLabel(
+  connection: StreamConnection,
+  now: number
+): string | null {
+  if (connection.status === "live") return null
+  if (connection.status === "lost") return "Connection lost"
+  const seconds = Math.max(0, Math.ceil((connection.retryAt - now) / 1000))
+  const progress = `${connection.attempt}/${MAX_RECONNECT_ATTEMPTS}`
+  return seconds > 0
+    ? `Reconnecting… ${progress} (retrying in ${seconds}s)`
+    : `Reconnecting… ${progress}`
+}

--- a/ui/src/features/agents/lib/stream/streamPool.test.ts
+++ b/ui/src/features/agents/lib/stream/streamPool.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it } from "vitest"
 import {
   IDLE_STREAM_TTL_MS,
   MAX_IDLE_STREAMS,
+  MAX_RECONNECT_ATTEMPTS,
+  reconnectDelayMs,
   useStreamPool,
 } from "./streamPool"
 import type { AgentStream } from "./streamPool"
@@ -134,5 +136,51 @@ describe("streamPool", () => {
     expect(retained).toContain(`thread-${MAX_IDLE_STREAMS}`)
     expect(retained).toContain("current")
     expect(retained).toHaveLength(MAX_IDLE_STREAMS + 1)
+  })
+
+  describe("connection", () => {
+    it("reports each retry with the deadline its delay implies", () => {
+      pool().activate("cloud", "one")
+      const id = activeEntry()!.id
+
+      pool().streamReconnecting(id, 3, NOW)
+
+      expect(activeEntry()!.connection).toEqual({
+        status: "reconnecting",
+        attempt: 3,
+        retryAt: NOW + reconnectDelayMs(3),
+      })
+    })
+
+    it("returns to live once a stream opens again", () => {
+      pool().activate("cloud", "one")
+      const id = activeEntry()!.id
+      pool().streamReconnecting(id, 1, NOW)
+
+      pool().streamLive(id)
+
+      expect(activeEntry()!.connection).toEqual({ status: "live" })
+    })
+
+    it("only gives up on a stream that was already reconnecting", () => {
+      pool().activate("cloud", "one")
+      const id = activeEntry()!.id
+
+      pool().streamLost(id)
+
+      expect(activeEntry()!.connection).toEqual({ status: "live" })
+    })
+
+    it("bumps the epoch on retry so the instance is rebuilt", () => {
+      pool().activate("cloud", "one")
+      pool().streamReconnecting(activeEntry()!.id, MAX_RECONNECT_ATTEMPTS, NOW)
+      pool().streamLost(activeEntry()!.id)
+
+      pool().retryStream("cloud", "one")
+
+      const entry = activeEntry()!
+      expect(entry.epoch).toBe(1)
+      expect(entry.connection.status).toBe("reconnecting")
+    })
   })
 })

--- a/ui/src/features/agents/lib/stream/streamPool.ts
+++ b/ui/src/features/agents/lib/stream/streamPool.ts
@@ -5,6 +5,15 @@ export type AgentStream = UseStreamReturn & { isOffloading?: boolean }
 
 export type AgentThreadTransport = "cloud" | "local"
 
+/**
+ * Liveness of an instance's event stream. `lost` is only ever reached from
+ * `reconnecting`, so a failed run can never be mistaken for a dropped stream.
+ */
+export type StreamConnection =
+  | { status: "live" }
+  | { status: "reconnecting"; attempt: number; retryAt: number }
+  | { status: "lost"; attempt: number }
+
 export interface StreamPoolEntry {
   /** Stable identity for the mounted `useStream` instance. */
   id: string
@@ -14,6 +23,9 @@ export interface StreamPoolEntry {
   /** Created without a thread; its first accepted run is the thread's creation. */
   awaitingCreation: boolean
   lastActiveAt: number
+  connection: StreamConnection
+  /** Bumped to rebuild the SDK controller, which re-hydrates state from scratch. */
+  epoch: number
 }
 
 export interface StreamBinding {
@@ -23,6 +35,29 @@ export interface StreamBinding {
 
 export const IDLE_STREAM_TTL_MS = 60_000
 export const MAX_IDLE_STREAMS = 8
+
+/** 1s doubling to a 5min ceiling spends this budget over roughly 23 minutes. */
+export const MAX_RECONNECT_ATTEMPTS = 12
+
+const RECONNECT_BASE_DELAY_MS = 1_000
+const RECONNECT_MAX_DELAY_MS = 300_000
+
+/**
+ * Grace after the final attempt's delay before the stream is called lost.
+ * langgraphjs#2817: the transport reports nothing when its budget runs out —
+ * `isLoading` stays on and `error` stays unset — so the give-up edge has to be
+ * inferred from the clock rather than observed.
+ */
+export const RECONNECT_GIVE_UP_GRACE_MS = 10_000
+
+export function reconnectDelayMs(attempt: number): number {
+  return Math.min(
+    RECONNECT_BASE_DELAY_MS * 2 ** (attempt - 1),
+    RECONNECT_MAX_DELAY_MS
+  )
+}
+
+const LIVE: StreamConnection = { status: "live" }
 
 export interface StreamPoolState {
   entries: Array<StreamPoolEntry>
@@ -39,6 +74,14 @@ export interface StreamPoolState {
   rekey(id: string, threadId: string): void
   /** The server accepted a run on this instance. */
   runAccepted(id: string): void
+  /** The transport is about to retry; `attempt` is 1-based. */
+  streamReconnecting(id: string, attempt: number, now: number): void
+  /** An event stream opened, so the instance is serving again. */
+  streamLive(id: string): void
+  /** The transport spent its retry budget without ever reconnecting. */
+  streamLost(id: string): void
+  /** Rebuild a thread's instance from scratch, re-hydrating its transcript. */
+  retryStream(transport: AgentThreadTransport, threadId: string | null): void
   consumeCreatedThread(): void
   /** Drop idle instances past the TTL or cap; active and running ones stay. */
   sweep(now: number): void
@@ -92,6 +135,8 @@ export const useStreamPool = create<StreamPoolState>((set, get) => ({
       threadId,
       awaitingCreation: threadId === null,
       lastActiveAt: now,
+      connection: LIVE,
+      epoch: 0,
     }
     set((state) => ({
       activeId: entry.id,
@@ -142,6 +187,70 @@ export const useStreamPool = create<StreamPoolState>((set, get) => ({
     })
   },
 
+  streamReconnecting(id, attempt, now) {
+    set((state) => ({
+      entries: state.entries.map((entry) =>
+        entry.id === id
+          ? {
+              ...entry,
+              connection: {
+                status: "reconnecting",
+                attempt,
+                retryAt: now + reconnectDelayMs(attempt),
+              },
+            }
+          : entry
+      ),
+    }))
+  },
+
+  streamLive(id) {
+    set((state) => {
+      const entry = state.entries.find((candidate) => candidate.id === id)
+      if (!entry || entry.connection.status === "live") return state
+      return {
+        entries: state.entries.map((candidate) =>
+          candidate.id === id ? { ...candidate, connection: LIVE } : candidate
+        ),
+      }
+    })
+  },
+
+  streamLost(id) {
+    set((state) => {
+      const entry = state.entries.find((candidate) => candidate.id === id)
+      if (entry?.connection.status !== "reconnecting") return state
+      const { attempt } = entry.connection
+      return {
+        entries: state.entries.map((candidate) =>
+          candidate.id === id
+            ? { ...candidate, connection: { status: "lost", attempt } }
+            : candidate
+        ),
+      }
+    })
+  },
+
+  retryStream(transport, threadId) {
+    const target = selectEntryFor(get(), transport, threadId)
+    if (!target) return
+    set((state) => ({
+      entries: state.entries.map((entry) =>
+        entry.id === target.id
+          ? {
+              ...entry,
+              epoch: entry.epoch + 1,
+              connection: {
+                status: "reconnecting",
+                attempt: 1,
+                retryAt: Date.now(),
+              },
+            }
+          : entry
+      ),
+    }))
+  },
+
   consumeCreatedThread() {
     set({ createdThreadId: null })
   },
@@ -183,6 +292,24 @@ export function selectStreamFor(
   transport: AgentThreadTransport,
   threadId: string | null
 ): AgentStream | undefined {
+  const entry = selectEntryFor(state, transport, threadId)
+  return entry ? state.handles[entry.id] : undefined
+}
+
+/** The connection of the instance `selectStreamFor` would return. */
+export function selectConnectionFor(
+  state: StreamPoolState,
+  transport: AgentThreadTransport,
+  threadId: string | null
+): StreamConnection {
+  return selectEntryFor(state, transport, threadId)?.connection ?? LIVE
+}
+
+function selectEntryFor(
+  state: StreamPoolState,
+  transport: AgentThreadTransport,
+  threadId: string | null
+): StreamPoolEntry | undefined {
   const retained =
     threadId === null
       ? undefined
@@ -195,6 +322,5 @@ export function selectStreamFor(
     state.binding.threadId === threadId
       ? state.entries.find((entry) => entry.id === state.activeId)
       : undefined
-  const entry = retained ?? bound
-  return entry ? state.handles[entry.id] : undefined
+  return retained ?? bound
 }

--- a/ui/src/features/agents/lib/stream/useReconnectStatus.ts
+++ b/ui/src/features/agents/lib/stream/useReconnectStatus.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react"
+
+import { useAgentStreamConnection } from "./AgentStreamProvider"
+import { reconnectLabel } from "./reconnectLabel"
+import type { AgentThreadTransport, StreamConnection } from "./streamPool"
+
+export interface ReconnectStatus {
+  /** Activity-line text while the stream is down; `null` once it is serving. */
+  label: string | null
+  connection: StreamConnection
+  retry: () => void
+}
+
+/** Drives the reconnect countdown, ticking only while one is pending. */
+export function useReconnectStatus(
+  transport: AgentThreadTransport,
+  threadId: string | null
+): ReconnectStatus {
+  const { connection, retry } = useAgentStreamConnection(transport, threadId)
+  const [now, setNow] = useState(() => Date.now())
+
+  useEffect(() => {
+    if (connection.status !== "reconnecting") return
+    // A countdown has to read the wall clock; the alternative is reading it
+    // during render, which the purity rule rejects for the same reason.
+    // oxlint-disable-next-line react/set-state-in-effect
+    setNow(Date.now())
+    const timer = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(timer)
+  }, [connection])
+
+  return { label: reconnectLabel(connection, now), connection, retry }
+}


### PR DESCRIPTION
A thread transcript's SSE pump retried 5 times over ~20s and then died silently. Per langchain-ai/langgraphjs#2817 the SDK leaves `isLoading` stuck on, `error` unset, and the pump unreopenable on its own controller — so a prod rollout lasting longer than the budget froze the transcript until the user reloaded the page.

This is the third pass at the problem. #2567 raised the budget and remounted on a *status mismatch*; #2644 reverted it because the machinery was invisible and unverifiable. The difference here is that every transition is shown to the user, so the mechanism can be judged from the UI rather than trusted.

### Signals

`onReconnect` marks the reconnecting state. Successful reopens come from the stream `fetch`, because the SDK fires no success callback. Giving up is inferred from the final attempt's deadline plus a grace, because on exhaustion the SDK reports nothing at all.

### Surface

The transcript's existing activity line — the slot that already says "Working…" — takes over with `Reconnecting… 3/12 (retrying in 4s)`, then `Connection lost`, with a `Retry now` link. Same shape as Codex (`Reconnecting... 3/5 (13s)`) and Claude Code (`Retrying in 2 seconds… (attempt 3/10)`). No alert, no banner.

### Budget

12 attempts, 1s doubling to a 5-minute ceiling — about 23 minutes, up from ~20 seconds.

### Recovery

A per-entry `epoch` keys the mounted instance; bumping it builds a fresh controller that re-hydrates the transcript. Required rather than preferred, since `#startRootPump` returns early forever once `#rootPump` is set.

## Test Plan

- [x] none