### PR TITLE
feat(desktop): allow personal tracing projects

### DIFF
--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -650,15 +650,10 @@ async def api_delete_my_instructions(
 async def api_get_my_preferences(
     session: dict[str, Any] = _SESSION_DEP,
 ) -> dict[str, Any]:
-    return await get_user_preferences(session["sub"])
-
-
-@router.get("/me/local-tracing")
-async def api_get_my_local_tracing(
-    session: dict[str, Any] = _SESSION_DEP,
-) -> dict[str, str]:
-    preferences = await get_user_preferences(session["sub"])
-    return {"project": preferences["local_tracing_project"] or ENV.LANGSMITH_PROJECT.get()}
+    return {
+        **await get_user_preferences(session["sub"]),
+        "default_local_tracing_project": ENV.LANGSMITH_PROJECT.get(),
+    }
 
 
 @router.put("/me/preferences")
@@ -666,7 +661,10 @@ async def api_put_my_preferences(
     body: UserPreferencesUpdate,
     session: dict[str, Any] = _SESSION_DEP,
 ) -> dict[str, Any]:
-    return await set_user_preferences(session["sub"], body)
+    return {
+        **await set_user_preferences(session["sub"], body),
+        "default_local_tracing_project": ENV.LANGSMITH_PROJECT.get(),
+    }
 
 
 @router.get("/options")

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -657,7 +657,8 @@ async def api_get_my_preferences(
 async def api_get_my_local_tracing(
     session: dict[str, Any] = _SESSION_DEP,
 ) -> dict[str, str]:
-    return {"project": ENV.LANGSMITH_PROJECT.get()}
+    preferences = await get_user_preferences(session["sub"])
+    return {"project": preferences["local_tracing_project"] or ENV.LANGSMITH_PROJECT.get()}
 
 
 @router.put("/me/preferences")

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -653,6 +653,13 @@ async def api_get_my_preferences(
     return await get_user_preferences(session["sub"])
 
 
+@router.get("/me/local-tracing")
+async def api_get_my_local_tracing(
+    session: dict[str, Any] = _SESSION_DEP,
+) -> dict[str, str]:
+    return {"project": ENV.LANGSMITH_PROJECT.get()}
+
+
 @router.put("/me/preferences")
 async def api_put_my_preferences(
     body: UserPreferencesUpdate,

--- a/agent/dashboard/user_preferences.py
+++ b/agent/dashboard/user_preferences.py
@@ -16,11 +16,16 @@ ThreadVisibility = Literal["public", "private"]
 
 class UserPreferencesUpdate(BaseModel):
     default_visibility: ThreadVisibility
+    local_tracing_project: str | None = None
 
 
 def _normalize(record: dict[str, Any] | None) -> dict[str, Any]:
     visibility = (record or {}).get("default_visibility")
-    return {"default_visibility": visibility if visibility in ("public", "private") else "private"}
+    project = (record or {}).get("local_tracing_project")
+    return {
+        "default_visibility": visibility if visibility in ("public", "private") else "private",
+        "local_tracing_project": project if isinstance(project, str) and project.strip() else None,
+    }
 
 
 async def get_user_preferences(login: str) -> dict[str, Any]:
@@ -39,6 +44,9 @@ async def set_user_preferences(login: str, update: UserPreferencesUpdate) -> dic
         **existing,
         "login": login,
         "default_visibility": update.default_visibility,
+        "local_tracing_project": update.local_tracing_project.strip()
+        if update.local_tracing_project
+        else None,
         "created_at": existing.get("created_at") or now_iso(),
         "updated_at": now_iso(),
     }

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -19,9 +19,9 @@ and made available to the local model client through an authenticated loopback b
 tokens are never placed in the local backend environment or inherited by agent shell commands.
 
 Local model calls also honor `LANGSMITH_GATEWAY_*` configuration. On managed macOS installs, the
-app reads `LC_GATEWAY_KEY` and LangSmith tracing credentials from `launchctl` when they are not
-explicitly configured. The local backend traces to the connected cloud deployment's
-`LANGSMITH_PROJECT`. Gateway, tracing, and provider credentials are not inherited by agent shell
+app reads `LC_GATEWAY_KEY` from `launchctl` when no explicit gateway key is configured and enables
+gateway routing for the local backend. The local backend traces to the connected cloud deployment's
+`LANGSMITH_PROJECT` by default. Gateway and provider credentials are not inherited by agent shell
 commands.
 
 The side panel's **Changes** tab diffs the project against a git snapshot taken when the session

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -19,9 +19,10 @@ and made available to the local model client through an authenticated loopback b
 tokens are never placed in the local backend environment or inherited by agent shell commands.
 
 Local model calls also honor `LANGSMITH_GATEWAY_*` configuration. On managed macOS installs, the
-app reads `LC_GATEWAY_KEY` from `launchctl` when no explicit gateway key is configured and enables
-gateway routing for the local backend. Gateway and provider credentials are not inherited by agent
-shell commands.
+app reads `LC_GATEWAY_KEY` and LangSmith tracing credentials from `launchctl` when they are not
+explicitly configured. The local backend traces to the connected cloud deployment's
+`LANGSMITH_PROJECT`. Gateway, tracing, and provider credentials are not inherited by agent shell
+commands.
 
 The side panel's **Changes** tab diffs the project against a git snapshot taken when the session
 started, so it shows what the agent changed and not the working tree's prior state. It also shows

--- a/desktop/src/backend-supervisor.cjs
+++ b/desktop/src/backend-supervisor.cjs
@@ -127,38 +127,27 @@ function modelCredentialStatus(modelId, env, options = {}) {
   };
 }
 
-function resolveManagedEnvironment(
+function resolveGatewayEnvironment(
   env,
   { platform = process.platform, execFileSync = execFileSyncProcess } = {},
 ) {
-  if (platform !== "darwin") return {};
-  const read = (name) => {
-    try {
-      return execFileSync("/bin/launchctl", ["getenv", name], {
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "ignore"],
-        timeout: 1_000,
-      }).trim();
-    } catch {
-      return "";
-    }
-  };
-  const gatewayKey = env.LANGSMITH_GATEWAY_API_KEY
-    ? ""
-    : read("LC_GATEWAY_KEY");
-  const tracingKey = env.LANGSMITH_API_KEY ? "" : read("LANGSMITH_API_KEY");
-  const project = env.LANGSMITH_PROJECT ? "" : read("LANGSMITH_PROJECT");
-  return {
-    ...(gatewayKey ? { LANGSMITH_GATEWAY_API_KEY: gatewayKey } : {}),
-    ...(gatewayKey && env.LANGSMITH_GATEWAY_ENABLED === undefined
-      ? { LANGSMITH_GATEWAY_ENABLED: "true" }
-      : {}),
-    ...(tracingKey ? { LANGSMITH_API_KEY: tracingKey } : {}),
-    ...(tracingKey && env.LANGSMITH_TRACING === undefined
-      ? { LANGSMITH_TRACING: "true" }
-      : {}),
-    ...(project ? { LANGSMITH_PROJECT: project } : {}),
-  };
+  if (env.LANGSMITH_GATEWAY_API_KEY || platform !== "darwin") return {};
+  try {
+    const key = execFileSync("/bin/launchctl", ["getenv", "LC_GATEWAY_KEY"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 1_000,
+    }).trim();
+    if (!key) return {};
+    return {
+      LANGSMITH_GATEWAY_API_KEY: key,
+      ...(env.LANGSMITH_GATEWAY_ENABLED === undefined
+        ? { LANGSMITH_GATEWAY_ENABLED: "true" }
+        : {}),
+    };
+  } catch {
+    return {};
+  }
 }
 
 class BackendSupervisor {
@@ -174,17 +163,17 @@ class BackendSupervisor {
     this.closing = false;
     this.ready = null;
     this.failure = null;
-    this.managedEnv = null;
+    this.gatewayEnv = null;
   }
 
-  managedEnvironment() {
-    if (this.managedEnv) return this.managedEnv;
+  gatewayEnvironment() {
+    if (this.gatewayEnv) return this.gatewayEnv;
     const env = { ...process.env, ...this.options.env };
-    this.managedEnv = resolveManagedEnvironment(
+    this.gatewayEnv = resolveGatewayEnvironment(
       env,
-      this.options.managedEnvironment || this.options.gatewayEnvironment,
+      this.options.gatewayEnvironment,
     );
-    return this.managedEnv;
+    return this.gatewayEnv;
   }
 
   start() {
@@ -213,14 +202,13 @@ class BackendSupervisor {
     if (this.options.isPackaged && !fs.existsSync(target.command)) {
       throw new Error(`Bundled local backend is missing: ${target.command}`);
     }
-    const tracingEnv = (await this.options.tracingEnv?.()) || {};
     const child = this.spawn(target.command, target.args, {
       cwd: target.cwd,
       env: {
         ...process.env,
         ...this.options.env,
-        ...this.managedEnvironment(),
-        ...tracingEnv,
+        ...this.gatewayEnvironment(),
+        ...(await this.options.tracingEnv?.()),
         ...this.options.providerEnv?.(),
         OPEN_SWE_LOCAL_AUTH_TOKEN: this.token,
         OPEN_SWE_LOCAL_PROJECTS_FILE: this.options.projectsFile,
@@ -295,7 +283,7 @@ class BackendSupervisor {
       {
         ...process.env,
         ...this.options.env,
-        ...this.managedEnvironment(),
+        ...this.gatewayEnvironment(),
       },
       { openAiOAuth: this.options.openAiOAuthAvailable?.() === true },
     );

--- a/desktop/src/backend-supervisor.cjs
+++ b/desktop/src/backend-supervisor.cjs
@@ -127,27 +127,38 @@ function modelCredentialStatus(modelId, env, options = {}) {
   };
 }
 
-function resolveGatewayEnvironment(
+function resolveManagedEnvironment(
   env,
   { platform = process.platform, execFileSync = execFileSyncProcess } = {},
 ) {
-  if (env.LANGSMITH_GATEWAY_API_KEY || platform !== "darwin") return {};
-  try {
-    const key = execFileSync("/bin/launchctl", ["getenv", "LC_GATEWAY_KEY"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-      timeout: 1_000,
-    }).trim();
-    if (!key) return {};
-    return {
-      LANGSMITH_GATEWAY_API_KEY: key,
-      ...(env.LANGSMITH_GATEWAY_ENABLED === undefined
-        ? { LANGSMITH_GATEWAY_ENABLED: "true" }
-        : {}),
-    };
-  } catch {
-    return {};
-  }
+  if (platform !== "darwin") return {};
+  const read = (name) => {
+    try {
+      return execFileSync("/bin/launchctl", ["getenv", name], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+        timeout: 1_000,
+      }).trim();
+    } catch {
+      return "";
+    }
+  };
+  const gatewayKey = env.LANGSMITH_GATEWAY_API_KEY
+    ? ""
+    : read("LC_GATEWAY_KEY");
+  const tracingKey = env.LANGSMITH_API_KEY ? "" : read("LANGSMITH_API_KEY");
+  const project = env.LANGSMITH_PROJECT ? "" : read("LANGSMITH_PROJECT");
+  return {
+    ...(gatewayKey ? { LANGSMITH_GATEWAY_API_KEY: gatewayKey } : {}),
+    ...(gatewayKey && env.LANGSMITH_GATEWAY_ENABLED === undefined
+      ? { LANGSMITH_GATEWAY_ENABLED: "true" }
+      : {}),
+    ...(tracingKey ? { LANGSMITH_API_KEY: tracingKey } : {}),
+    ...(tracingKey && env.LANGSMITH_TRACING === undefined
+      ? { LANGSMITH_TRACING: "true" }
+      : {}),
+    ...(project ? { LANGSMITH_PROJECT: project } : {}),
+  };
 }
 
 class BackendSupervisor {
@@ -163,17 +174,17 @@ class BackendSupervisor {
     this.closing = false;
     this.ready = null;
     this.failure = null;
-    this.gatewayEnv = null;
+    this.managedEnv = null;
   }
 
-  gatewayEnvironment() {
-    if (this.gatewayEnv) return this.gatewayEnv;
+  managedEnvironment() {
+    if (this.managedEnv) return this.managedEnv;
     const env = { ...process.env, ...this.options.env };
-    this.gatewayEnv = resolveGatewayEnvironment(
+    this.managedEnv = resolveManagedEnvironment(
       env,
-      this.options.gatewayEnvironment,
+      this.options.managedEnvironment || this.options.gatewayEnvironment,
     );
-    return this.gatewayEnv;
+    return this.managedEnv;
   }
 
   start() {
@@ -202,12 +213,14 @@ class BackendSupervisor {
     if (this.options.isPackaged && !fs.existsSync(target.command)) {
       throw new Error(`Bundled local backend is missing: ${target.command}`);
     }
+    const tracingEnv = (await this.options.tracingEnv?.()) || {};
     const child = this.spawn(target.command, target.args, {
       cwd: target.cwd,
       env: {
         ...process.env,
         ...this.options.env,
-        ...this.gatewayEnvironment(),
+        ...this.managedEnvironment(),
+        ...tracingEnv,
         ...this.options.providerEnv?.(),
         OPEN_SWE_LOCAL_AUTH_TOKEN: this.token,
         OPEN_SWE_LOCAL_PROJECTS_FILE: this.options.projectsFile,
@@ -282,7 +295,7 @@ class BackendSupervisor {
       {
         ...process.env,
         ...this.options.env,
-        ...this.gatewayEnvironment(),
+        ...this.managedEnvironment(),
       },
       { openAiOAuth: this.options.openAiOAuthAvailable?.() === true },
     );

--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -1483,6 +1483,21 @@ if (!hasSingleInstanceLock) {
       stateDir: path.join(app.getPath("userData"), "local-backend"),
       projectsFile: projectsPath(),
       worktreesDir: worktreesPath(),
+      tracingEnv: async () => {
+        if (!backendUrl) return {};
+        try {
+          const response = await backendFetch(
+            new URL("/dashboard/api/me/local-tracing", backendUrl).toString(),
+          );
+          if (!response.ok) return {};
+          const { project } = await response.json();
+          return typeof project === "string" && project
+            ? { LANGSMITH_PROJECT: project }
+            : {};
+        } catch {
+          return {};
+        }
+      },
       providerEnv: () => openAiOAuth?.backendEnv() || {},
       openAiOAuthAvailable: () =>
         openAiOAuth?.status().signedIn === true &&

--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -1488,11 +1488,12 @@ if (!hasSingleInstanceLock) {
         try {
           const response = await backendFetch(
             new URL("/dashboard/api/me/local-tracing", backendUrl).toString(),
+            { signal: AbortSignal.timeout(2_000) },
           );
           if (!response.ok) return {};
           const { project } = await response.json();
           return typeof project === "string" && project
-            ? { LANGSMITH_PROJECT: project }
+            ? { LANGSMITH_PROJECT: project, LANGSMITH_TRACING: "true" }
             : {};
         } catch {
           return {};

--- a/desktop/src/main.cts
+++ b/desktop/src/main.cts
@@ -1487,12 +1487,15 @@ if (!hasSingleInstanceLock) {
         if (!backendUrl) return {};
         try {
           const response = await backendFetch(
-            new URL("/dashboard/api/me/local-tracing", backendUrl).toString(),
+            new URL("/dashboard/api/me/preferences", backendUrl).toString(),
             { signal: AbortSignal.timeout(2_000) },
           );
           if (!response.ok) return {};
-          const { project } = await response.json();
-          return typeof project === "string" && project
+          const preferences = await response.json();
+          const project =
+            preferences.local_tracing_project ||
+            preferences.default_local_tracing_project;
+          return project
             ? { LANGSMITH_PROJECT: project, LANGSMITH_TRACING: "true" }
             : {};
         } catch {

--- a/desktop/test/backend-supervisor.test.cjs
+++ b/desktop/test/backend-supervisor.test.cjs
@@ -90,61 +90,25 @@ test("reports whether the selected provider is configured", () => {
   );
 });
 
-test("caches the managed macOS environment", () => {
-  const probes = [];
+test("caches the managed macOS gateway key", () => {
+  let probes = 0;
   const supervisor = new BackendSupervisor({
     env: {},
-    managedEnvironment: {
+    gatewayEnvironment: {
       platform: "darwin",
-      execFileSync: (_command, [, name]) => {
-        probes.push(name);
-        return {
-          LC_GATEWAY_KEY: "gateway-key\n",
-          LANGSMITH_API_KEY: "tracing-key\n",
-          LANGSMITH_PROJECT: "open-swe\n",
-        }[name];
+      execFileSync: () => {
+        probes += 1;
+        return "managed-key\n";
       },
     },
   });
 
-  assert.deepEqual(supervisor.managedEnvironment(), {
-    LANGSMITH_GATEWAY_API_KEY: "gateway-key",
-    LANGSMITH_GATEWAY_ENABLED: "true",
-    LANGSMITH_API_KEY: "tracing-key",
-    LANGSMITH_TRACING: "true",
-    LANGSMITH_PROJECT: "open-swe",
+  assert.deepEqual(supervisor.credentialStatus("anthropic:test"), {
+    available: true,
+    variable: null,
   });
   supervisor.credentialStatus("openai:test");
-  assert.deepEqual(probes, [
-    "LC_GATEWAY_KEY",
-    "LANGSMITH_API_KEY",
-    "LANGSMITH_PROJECT",
-  ]);
-});
-
-test("applies the configured tracing project when starting", async () => {
-  let spawnedEnv;
-  const child = {
-    stdout: { on() {} },
-    stderr: { on() {} },
-    once() {},
-  };
-  const supervisor = new BackendSupervisor({
-    repoRoot: "/work/open-swe",
-    projectsFile: "/tmp/projects.json",
-    worktreesDir: "/tmp/worktrees",
-    reservePort: async () => 49152,
-    tracingEnv: async () => ({ LANGSMITH_PROJECT: "personal-project" }),
-    spawn: (_command, _args, options) => {
-      spawnedEnv = options.env;
-      return child;
-    },
-    fetch: async () => new Response(null, { status: 200 }),
-  });
-
-  await supervisor.start();
-
-  assert.equal(spawnedEnv.LANGSMITH_PROJECT, "personal-project");
+  assert.equal(probes, 1);
 });
 
 test("creates the local LangGraph thread before stream hydration", async () => {

--- a/desktop/test/backend-supervisor.test.cjs
+++ b/desktop/test/backend-supervisor.test.cjs
@@ -90,25 +90,61 @@ test("reports whether the selected provider is configured", () => {
   );
 });
 
-test("caches the managed macOS gateway key", () => {
-  let probes = 0;
+test("caches the managed macOS environment", () => {
+  const probes = [];
   const supervisor = new BackendSupervisor({
     env: {},
-    gatewayEnvironment: {
+    managedEnvironment: {
       platform: "darwin",
-      execFileSync: () => {
-        probes += 1;
-        return "managed-key\n";
+      execFileSync: (_command, [, name]) => {
+        probes.push(name);
+        return {
+          LC_GATEWAY_KEY: "gateway-key\n",
+          LANGSMITH_API_KEY: "tracing-key\n",
+          LANGSMITH_PROJECT: "open-swe\n",
+        }[name];
       },
     },
   });
 
-  assert.deepEqual(supervisor.credentialStatus("anthropic:test"), {
-    available: true,
-    variable: null,
+  assert.deepEqual(supervisor.managedEnvironment(), {
+    LANGSMITH_GATEWAY_API_KEY: "gateway-key",
+    LANGSMITH_GATEWAY_ENABLED: "true",
+    LANGSMITH_API_KEY: "tracing-key",
+    LANGSMITH_TRACING: "true",
+    LANGSMITH_PROJECT: "open-swe",
   });
   supervisor.credentialStatus("openai:test");
-  assert.equal(probes, 1);
+  assert.deepEqual(probes, [
+    "LC_GATEWAY_KEY",
+    "LANGSMITH_API_KEY",
+    "LANGSMITH_PROJECT",
+  ]);
+});
+
+test("applies the configured tracing project when starting", async () => {
+  let spawnedEnv;
+  const child = {
+    stdout: { on() {} },
+    stderr: { on() {} },
+    once() {},
+  };
+  const supervisor = new BackendSupervisor({
+    repoRoot: "/work/open-swe",
+    projectsFile: "/tmp/projects.json",
+    worktreesDir: "/tmp/worktrees",
+    reservePort: async () => 49152,
+    tracingEnv: async () => ({ LANGSMITH_PROJECT: "personal-project" }),
+    spawn: (_command, _args, options) => {
+      spawnedEnv = options.env;
+      return child;
+    },
+    fetch: async () => new Response(null, { status: 200 }),
+  });
+
+  await supervisor.start();
+
+  assert.equal(spawnedEnv.LANGSMITH_PROJECT, "personal-project");
 });
 
 test("creates the local LangGraph thread before stream hydration", async () => {

--- a/ui/src/features/settings/components/PreferencesSection.tsx
+++ b/ui/src/features/settings/components/PreferencesSection.tsx
@@ -123,7 +123,10 @@ export function PreferencesSection() {
         control={
           <Input
             className="w-56"
-            placeholder="Shared cloud project"
+            placeholder={
+              preferences.data?.default_local_tracing_project ??
+              "Shared cloud project"
+            }
             defaultValue={preferences.data?.local_tracing_project ?? ""}
             disabled={preferences.isLoading || savePreferences.isPending}
             onBlur={(event) =>

--- a/ui/src/features/settings/components/PreferencesSection.tsx
+++ b/ui/src/features/settings/components/PreferencesSection.tsx
@@ -119,7 +119,7 @@ export function PreferencesSection() {
       />
       <SettingsRow
         label="Local tracing project"
-        description="Project used for new local desktop runs. Leave blank to use the shared cloud project."
+        description="Project used for local desktop runs. Leave blank to use the shared cloud project. Restart the desktop app after changing it."
         control={
           <Input
             className="w-56"

--- a/ui/src/features/settings/components/PreferencesSection.tsx
+++ b/ui/src/features/settings/components/PreferencesSection.tsx
@@ -10,6 +10,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import { Input } from "@/components/ui/input"
 import { Switch } from "@/components/ui/switch"
 import {
   notificationsEnabled,
@@ -40,8 +41,7 @@ export function PreferencesSection() {
     queryFn: api.getMyPreferences,
   })
   const savePreferences = useMutation({
-    mutationFn: (default_visibility: ThreadVisibility) =>
-      api.saveMyPreferences({ default_visibility }),
+    mutationFn: api.saveMyPreferences,
     onSuccess: (data) => qc.setQueryData(["myPreferences"], data),
   })
   const supported = notificationsSupported()
@@ -95,7 +95,13 @@ export function PreferencesSection() {
         control={
           <Select
             value={preferences.data?.default_visibility ?? "private"}
-            onValueChange={(v) => v && savePreferences.mutate(v)}
+            onValueChange={(v) =>
+              v &&
+              savePreferences.mutate({
+                ...preferences.data!,
+                default_visibility: v,
+              })
+            }
             disabled={preferences.isLoading || savePreferences.isPending}
           >
             <SelectTrigger className="w-40">
@@ -109,6 +115,24 @@ export function PreferencesSection() {
               ))}
             </SelectContent>
           </Select>
+        }
+      />
+      <SettingsRow
+        label="Local tracing project"
+        description="Project used for new local desktop runs. Leave blank to use the shared cloud project."
+        control={
+          <Input
+            className="w-56"
+            placeholder="Shared cloud project"
+            defaultValue={preferences.data?.local_tracing_project ?? ""}
+            disabled={preferences.isLoading || savePreferences.isPending}
+            onBlur={(event) =>
+              savePreferences.mutate({
+                ...preferences.data!,
+                local_tracing_project: event.target.value.trim() || null,
+              })
+            }
+          />
         }
       />
       <SettingsRow

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -365,6 +365,7 @@ export type ThreadVisibility = "public" | "private"
 export interface UserPreferences {
   default_visibility: ThreadVisibility
   local_tracing_project: string | null
+  default_local_tracing_project: string
 }
 
 export interface Skill {

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -364,6 +364,7 @@ export type ThreadVisibility = "public" | "private"
 
 export interface UserPreferences {
   default_visibility: ThreadVisibility
+  local_tracing_project: string | null
 }
 
 export interface Skill {


### PR DESCRIPTION
### Summary

- trace local desktop runs to the connected deployment’s LangSmith project by default
- let each user override that default with a personal tracing project in dashboard preferences
- reuse the existing user-preferences API for both the personal override and deployment default
- bound the optional cloud-project lookup so it cannot delay local startup indefinitely
- keep tracing credentials out of agent shell environments

### Screenshot

![Local tracing project preference](https://01a09231-4709-7399-bbfc-5a868768493c--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGt4TmpBME5UUXNJbXAwYVNJNklqQXhZVEE1TWpRMUxXWTVZbU10TjJFMVl5MWlaR0k1TFROaU9UWTVNbVUzTVdFMk5DSXNJbk5wWkNJNklqQXhZVEE1TWpNeExUUTNNRGt0TnpNNU9TMWlZbVpqTFRWaE9EWTROelk0TkRrell5SXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMeTV2Y0dWdUxYTjNaUzloY25ScFptRmpkSE12Ykc5allXd3RkSEpoWTJsdVp5MXdjbVZtWlhKbGJtTmxMbkJ1WnlJc0ltTjBJam9pYVcxaFoyVXZjRzVuSWl3aVkyUWlPaUpwYm14cGJtVWlmUS5SVzhUbWpNZnB5dHQ0ZVdpYm5KNEtwLWpzTDRUVzZRa1JfUlVyeV9QZkE0SVNDX2J0Uy1QalIzWnhjWm13RTJsNXJNNzQ5VE9hY0oyTGFlMTA5VVVDUQ)

Made by [Open SWE](https://openswe.vercel.app/agents/45ef0282-cb0e-593a-858d-efe7ea10e8de) · openai:gpt-5.6-sol (medium)