### PR TITLE
fix(ui): use repository selector for global default

### DIFF
--- a/ui/src/routes/admin.tsx
+++ b/ui/src/routes/admin.tsx
@@ -29,6 +29,8 @@ import {
 } from "@/lib/slack-manifest"
 import { dashboardApiBase } from "@/lib/api-base"
 import { MCPConnectionsSection } from "@/features/settings/components/MCPConnectionsSection"
+import { RepoSelector } from "@/features/settings/components/RepoSelector"
+import { useRepos } from "@/lib/profile"
 
 export const Route = createFileRoute("/admin")({ component: AdminPage })
 
@@ -677,13 +679,8 @@ function GlobalDefaultsSection({ models }: { models: Array<ModelOption> }) {
     queryKey: ["teamSettings"],
     queryFn: api.getTeamSettings,
   })
+  const repos = useRepos()
   const [error, setError] = useState<string | null>(null)
-  const [defaultRepoDraft, setDefaultRepoDraft] = useState("")
-
-  useEffect(() => {
-    // oxlint-disable-next-line react/set-state-in-effect
-    setDefaultRepoDraft(settings.data?.default_repo ?? "")
-  }, [settings.data?.default_repo])
 
   const save = useMutation({
     mutationFn: (body: TeamSettings) => api.saveTeamSettings(body),
@@ -822,22 +819,23 @@ function GlobalDefaultsSection({ models }: { models: Array<ModelOption> }) {
         />
         <SettingsRow
           label="Default Repository"
-          description="Global fallback used when a run has no explicit repo and the user has no profile default. Use owner/repo."
+          description="Global fallback used when a run has no explicit repo and the user has no profile default."
           control={
-            <Input
-              className="w-56"
-              placeholder="owner/repo"
-              value={defaultRepoDraft}
-              onChange={(e) => setDefaultRepoDraft(e.target.value)}
-              onBlur={() =>
-                settings.data &&
-                save.mutate({
-                  ...settings.data,
-                  default_repo: defaultRepoDraft.trim() || null,
-                })
-              }
-              disabled={!settings.data || save.isPending}
-            />
+            <div className="w-56">
+              <RepoSelector
+                repos={repos.data?.repositories}
+                selectedRepo={settings.data?.default_repo ?? null}
+                onRepoChange={(repo) =>
+                  settings.data &&
+                  save.mutate({ ...settings.data, default_repo: repo })
+                }
+                placeholder="Pick a repository…"
+                emptySelectionLabel="No default repository"
+                triggerClassName="h-7 w-full max-w-none rounded-md border border-input bg-input/20 px-2 py-1.5 text-xs/relaxed text-foreground transition-colors hover:opacity-100 dark:bg-input/30"
+                dropdownClassName="w-56"
+                disabled={!settings.data || save.isPending}
+              />
+            </div>
           }
         />
         <RolePicker


### PR DESCRIPTION
Reuses the existing searchable repository selector for the workspace-wide default repository setting. The selector is pre-populated from the signed-in admin’s accessible repositories and saves selections immediately.

Screenshot:

![Global default repository selector](https://01a09263-221a-75bf-b540-351a80bcbfea--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGt4TmpJNE16QXNJbXAwYVNJNklqQXhZVEE1TWpaaExUTmpNVEF0TnpSaVlTMWlNR1JqTFROaVpqVm1ZVGRtWm1Vd1lpSXNJbk5wWkNJNklqQXhZVEE1TWpZekxUSXlNV0V0TnpWaVppMWlOVFF3TFRNMU1XRTRNR0pqWW1abFlTSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMeTV2Y0dWdUxYTjNaUzloY25ScFptRmpkSE12WVdSdGFXNHRaR1ZtWVhWc2RDMXlaWEJ2YzJsMGIzSjVMWE5sYkdWamRHOXlMbkJ1WnlJc0ltTjBJam9pYVcxaFoyVXZjRzVuSWl3aVkyUWlPaUpwYm14cGJtVWlMQ0p6Y21NaU9qRTFmUS5ZMF9qVG5Bai04VDNMdjJrMkVfODFkczRXZ1NlM2xzMHBqX25waTdFS2lDQnl0ZzJrZmxvUnJvQXdUN2htcW5Db1dELXpGUkwwVWJLandvRThaWF9BQQ)

Made by [Open SWE](https://openswe.vercel.app/agents/fc8fb6be-350a-58c0-b754-78be86c51c2e) · openai:gpt-5.6-sol (high)
