### PR TITLE
fix: position sent messages for streaming responses

### DIFF
--- a/ui/src/features/agents/components/AgentThreadView.tsx
+++ b/ui/src/features/agents/components/AgentThreadView.tsx
@@ -134,7 +134,6 @@ export function AgentThreadView({
   )
   const submitMessage = useCallback(
     async (content: string, images: Array<ImageChunk>) => {
-      scrollControlRef.current?.scrollToBottom()
       if (planFeedbackPending) await rejectPlan(thread.id, false)
       await sendMessage.mutateAsync({
         content,
@@ -143,6 +142,9 @@ export function AgentThreadView({
         effort: activeSelection?.effort ?? null,
         plan_mode: activePlanMode,
       })
+      requestAnimationFrame(() =>
+        scrollControlRef.current?.scrollToLatestUserMessage()
+      )
       setPlanFeedbackPending(false)
     },
     [

--- a/ui/src/features/agents/components/messages/Messages.tsx
+++ b/ui/src/features/agents/components/messages/Messages.tsx
@@ -81,8 +81,13 @@ export const Messages = memo(function MessagesComponent({
   onAutoApprove,
   onOpenFile,
 }: MessagesProps) {
-  const { scrollRef, contentRef, showScrollToBottom, scrollToBottom } =
-    useTranscriptScroll({ scrollKey, messages, isStreaming })
+  const {
+    scrollRef,
+    contentRef,
+    showScrollToBottom,
+    scrollToBottom,
+    scrollToLatestUserMessage,
+  } = useTranscriptScroll({ scrollKey, messages, isStreaming })
 
   const visibleMessages = useMemo(
     () => messages.filter((message) => !message.hidden),
@@ -96,11 +101,11 @@ export const Messages = memo(function MessagesComponent({
 
   useEffect(() => {
     if (!scrollControlRef) return
-    scrollControlRef.current = { scrollToBottom }
+    scrollControlRef.current = { scrollToBottom, scrollToLatestUserMessage }
     return () => {
       scrollControlRef.current = null
     }
-  }, [scrollToBottom, scrollControlRef])
+  }, [scrollToBottom, scrollToLatestUserMessage, scrollControlRef])
 
   useEffect(() => {
     onShowScrollToBottomChange?.(showScrollToBottom)
@@ -129,7 +134,9 @@ export const Messages = memo(function MessagesComponent({
           <div
             ref={contentRef}
             className={`w-full ${contentWidthClass} mx-auto min-w-0 ${contentPaddingClass}`}
-            style={bottomInset > 0 ? { paddingBottom: bottomInset } : undefined}
+            style={{
+              paddingBottom: `calc(${bottomInset}px + ${isStreaming ? "50vh" : "0px"})`,
+            }}
           >
             {visibleMessages.length === 0 && emptyState}
             {visibleMessages.map((message, index) => {

--- a/ui/src/features/agents/components/messages/types.ts
+++ b/ui/src/features/agents/components/messages/types.ts
@@ -14,6 +14,7 @@ export interface ApprovalCallbacks {
 
 export type MessagesScrollControl = {
   scrollToBottom: () => void
+  scrollToLatestUserMessage: () => void
 }
 
 export interface MessagesProps extends ApprovalCallbacks {

--- a/ui/src/features/agents/components/messages/useTranscriptScroll.ts
+++ b/ui/src/features/agents/components/messages/useTranscriptScroll.ts
@@ -209,7 +209,7 @@ export function useTranscriptScroll({
     const el = scrollRef.current
     const message = Array.from(
       contentRef.current?.querySelectorAll<HTMLElement>(
-        '[data-testid="user-message"]'
+        '[data-testid="user-message"], [data-testid="queued-message"]'
       ) ?? []
     ).at(-1)
     if (!el || !message) return

--- a/ui/src/features/agents/components/messages/useTranscriptScroll.ts
+++ b/ui/src/features/agents/components/messages/useTranscriptScroll.ts
@@ -205,5 +205,29 @@ export function useTranscriptScroll({
     return () => observer.disconnect()
   }, [applyPendingRestore, scheduleJumpToBottom])
 
-  return { scrollRef, contentRef, showScrollToBottom, scrollToBottom }
+  const scrollToLatestUserMessage = useCallback(() => {
+    const el = scrollRef.current
+    const message = Array.from(
+      contentRef.current?.querySelectorAll<HTMLElement>(
+        '[data-testid="user-message"]'
+      ) ?? []
+    ).at(-1)
+    if (!el || !message) return
+    state.current.followTail = false
+    state.current.pendingRestoreTop = null
+    cancelScheduledJump()
+    el.scrollTop = Math.min(
+      message.offsetTop - el.clientHeight / 2,
+      maxScrollTop(el)
+    )
+    settle(el, el.scrollTop)
+  }, [cancelScheduledJump, settle])
+
+  return {
+    scrollRef,
+    contentRef,
+    showScrollToBottom,
+    scrollToBottom,
+    scrollToLatestUserMessage,
+  }
 }


### PR DESCRIPTION
Positions a newly sent follow-up halfway up the transcript and reserves space below while the response streams.

Screenshot: [sent message positioning](https://01a09284-cec1-7469-b3c6-1155c4045af0--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGt4TmpVeE5UY3NJbXAwYVNJNklqQXhZVEE1TWpoa0xXSmxNVGt0TnpReFpTMWlZelUyTFRCaE9EWTBOakl3T1RReE9DSXNJbk5wWkNJNklqQXhZVEE1TWpnMExXTmxZekV0TnpRMk9TMWlNMk0yTFRFeE5UVmpOREEwTldGbU1DSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkRzF3TDNOamNtOXNiQzF6Wlc1MExXMWxjM05oWjJVdWNHNW5JaXdpWTNRaU9pSnBiV0ZuWlM5d2JtY2lMQ0pqWkNJNkltbHViR2x1WlNJc0luTnlZeUk2TVRWOS50cElRbV9lZEJJUkcxZEFOTzgyNHhneTNKSWJXUWdjaERuNExqNUM1ZjE4dHRQLXA0SC1La2FlZHViRXR2RDhhN3BGdTlSTFZ1Z0J3QW5oTXp0WHlBQQ)

Made by [Open SWE](https://openswe.vercel.app/agents/01a09284-cb32-7552-a295-1adbc0ceb216) · fireworks:accounts/fireworks/models/glm-5p3-flash (max)