### PR TITLE
docs: clarify credentials when using an LLM gateway

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -61,7 +61,7 @@ LANGSMITH_API_KEY=""            # LangSmith → Settings → API Keys; also used
 LANGSMITH_TRACING="true"        # trace runs to LangSmith
 LANGSMITH_PROJECT=""            # optional project for traces and "View trace" links; default "default"
 
-ANTHROPIC_API_KEY=""            # any provider key, or LANGSMITH_GATEWAY_API_KEY for the LLM Gateway; see the installation guide
+ANTHROPIC_API_KEY=""            # any provider key; not needed if you use the LLM Gateway — set LANGSMITH_GATEWAY_API_KEY instead (see the installation guide)
 
 GITHUB_APP_ID=""                # step 2
 GITHUB_APP_CLIENT_ID=""
@@ -80,7 +80,7 @@ DASHBOARD_JWT_SECRET=""         # openssl rand -hex 32     (signs the session co
 CONFIGURED_ADMINS=""            # your GitHub login or email; admins see the Admin pages
 ```
 
-`LANGGRAPH_URL` defaults to `http://localhost:2024`, and `DASHBOARD_BASE_URL` / `DASHBOARD_API_BASE_URL` default to it, so none of the three is needed locally. Provider keys, the LLM Gateway, and how the running model is chosen are in [Model providers and API keys](INSTALLATION.md#4-model-providers-and-api-keys). Linear, if you use it, comes from the [Linear](INSTALLATION.md#linear) section of the installation guide, with your ngrok domain as the URL.
+`LANGGRAPH_URL` defaults to `http://localhost:2024`, and `DASHBOARD_BASE_URL` / `DASHBOARD_API_BASE_URL` default to it, so none of the three is needed locally. You only need one model credential: either a provider key, or — if you route model calls through the [LangSmith LLM Gateway](INSTALLATION.md#4-model-providers-and-api-keys) — just `LANGSMITH_GATEWAY_API_KEY` and no provider keys at all. How the running model is chosen is covered in the same section. Linear, if you use it, comes from the [Linear](INSTALLATION.md#linear) section of the installation guide, with your ngrok domain as the URL.
 
 ## 6. Run
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -88,7 +88,7 @@ Give each deployment its own GitHub App, or at least a distinct mention handle (
 
 ## 4. Model providers and API keys
 
-Open SWE calls models through [LangChain](https://python.langchain.com/) chat models named `provider:model`, so any provider you give a key for is available. Set at least one:
+Open SWE calls models through [LangChain](https://python.langchain.com/) chat models named `provider:model`, so any provider you give a key for is available. Set at least one — with the gateway (below), no provider key is needed at all:
 
 | Provider | Variable | Notes |
 |---|---|---|


### PR DESCRIPTION
The setup docs implied you always need a model provider key. Clarify that deployments using an LLM gateway only need the gateway credential, using LangSmith Gateway as an example.

Docs-only change; no code behavior touched.

Made by [Open SWE](https://openswe.vercel.app/agents/d2038371-e266-5630-b969-b72b2035f665) · openai:gpt-5.6-sol (medium)