### PR TITLE
fix(admin): clarify LangSmith gateway routing

### DIFF
--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -163,6 +163,7 @@ from agent.dashboard.team_settings import (
     get_team_default_model,
     get_team_default_subagent_model,
     get_team_fable_enabled,
+    get_team_gateway_enabled,
     get_team_settings,
     update_team_transcription_model,
     upsert_team_settings,
@@ -282,6 +283,7 @@ from agent.utils.dashboard_links import (
     dashboard_base_url,
     dashboard_is_same_origin,
 )
+from agent.utils.gateway import gateway_configuration_summary
 from agent.utils.thread_ops import langgraph_client, langgraph_url
 from agent.utils.timing import server_timing_header
 
@@ -965,6 +967,17 @@ async def api_get_team_settings(
     session: dict[str, Any] = _SESSION_DEP,
 ) -> dict[str, Any]:
     return await get_team_settings()
+
+
+@router.get("/team-settings/gateway-configuration")
+async def api_get_gateway_configuration(
+    _admin: dict[str, Any] = _ADMIN_DEP,
+) -> dict[str, Any]:
+    settings = await get_team_settings()
+    model_id = settings.get("default_agent_model")
+    if not isinstance(model_id, str):
+        model_id, _ = await get_team_default_model("agent")
+    return gateway_configuration_summary(await get_team_gateway_enabled(), model_id)
 
 
 @router.put("/team-settings/transcription")

--- a/agent/utils/gateway.py
+++ b/agent/utils/gateway.py
@@ -10,6 +10,8 @@ opt-in via ``LANGSMITH_GATEWAY_ENABLED`` (deployment default) or the
 """
 
 import logging
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 from agent.config import ENV
 
@@ -89,6 +91,77 @@ def resolve_gateway_enabled(team_value: bool | None) -> bool:
     if team_value is None:
         return gateway_env_default()
     return team_value
+
+
+def _sanitize_endpoint(value: str) -> str:
+    parsed = urlsplit(value)
+    hostname = parsed.hostname or ""
+    if ":" in hostname and not hostname.startswith("["):
+        hostname = f"[{hostname}]"
+    port = f":{parsed.port}" if parsed.port is not None else ""
+    return urlunsplit((parsed.scheme, f"{hostname}{port}", parsed.path, "", ""))
+
+
+def gateway_configuration_summary(team_value: bool | None, model_id: str) -> dict[str, Any]:
+    """Safe metadata describing the effective endpoint for an administrator."""
+    explicit = ENV.LANGSMITH_GATEWAY_ENABLED.optional()
+    if team_value is not None:
+        enabled = team_value
+        reason = "workspace setting"
+    elif explicit is not None:
+        enabled = _env_bool(explicit)
+        reason = "LANGSMITH_GATEWAY_ENABLED"
+    elif ENV.LANGSMITH_GATEWAY_API_KEY.is_set():
+        enabled = True
+        reason = "LANGSMITH_GATEWAY_API_KEY is set"
+    else:
+        enabled = False
+        reason = "no LangSmith Gateway environment default is set"
+
+    provider = _provider_of(model_id)
+    path = _GATEWAY_PROVIDER_PATHS.get(provider)
+    credential_sources: list[str] = []
+    endpoint_kind = "direct_provider"
+    endpoint: str | None = None
+    if enabled and path and _langsmith_api_key():
+        endpoint_kind = "langsmith_gateway"
+        endpoint = _sanitize_endpoint(f"{gateway_base_url()}{path}")
+        source = ENV.LANGSMITH_GATEWAY_API_KEY.source() or ENV.LANGSMITH_API_KEY.source()
+        if source:
+            credential_sources.append(source)
+    elif provider == "openai":
+        custom_endpoint = ENV.OPENAI_BASE_URL.optional()
+        if custom_endpoint:
+            endpoint_kind = "custom_endpoint"
+            endpoint = _sanitize_endpoint(custom_endpoint)
+        else:
+            endpoint = OPENAI_PROVIDER_ENDPOINT
+        source = ENV.OPENAI_API_KEY.source()
+        if source:
+            credential_sources.append(source)
+    else:
+        credential = {
+            "anthropic": ENV.ANTHROPIC_API_KEY,
+            "baseten": ENV.BASETEN_API_KEY,
+            "fireworks": ENV.FIREWORKS_API_KEY,
+            "google_genai": ENV.GOOGLE_API_KEY,
+        }.get(provider)
+        source = credential.source() if credential else None
+        if source:
+            credential_sources.append(source)
+
+    return {
+        "model_id": model_id,
+        "override_enabled": enabled,
+        "resolution_reason": reason,
+        "endpoint_kind": endpoint_kind,
+        "endpoint": endpoint,
+        "credential_sources": credential_sources,
+        "restart_required": False,
+    }
+
+
+OPENAI_PROVIDER_ENDPOINT = "https://api.openai.com/v1"
 
 
 def _provider_of(model_id: str) -> str:

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -210,7 +210,9 @@ Routing is opt-in and off by default. Enable it either way:
 | `LANGSMITH_GATEWAY_BASE_URL` | `https://gateway.smith.langchain.com` | Override for a regional or self-hosted gateway host. |
 | `LANGSMITH_GATEWAY_OPENAI_USE_RESPONSES` | `true` | Use the OpenAI Responses API through the gateway. Set to `false` only to force Chat Completions for OpenAI models. |
 
-The admin panel (**Admin → LLM Gateway**) exposes a per-workspace toggle stored in team settings; when set it overrides the `LANGSMITH_GATEWAY_ENABLED` env default (a `None`/unset team value inherits the env default).
+The admin panel (**Admin → LangSmith Gateway override**) exposes a per-workspace override stored in team settings. **Inherit** uses `LANGSMITH_GATEWAY_ENABLED` when explicitly set, otherwise enables the override when `LANGSMITH_GATEWAY_API_KEY` is present, and otherwise disables it. `LC_GATEWAY_KEY` does not participate. Workspace changes apply automatically to newly created model clients, usually within 60 seconds; environment changes require a backend restart.
+
+Disabling this override does not guarantee direct provider access. For OpenAI models, `OPENAI_BASE_URL` (or its legacy alias `OPENAI_API_BASE`) still selects a custom OpenAI-compatible endpoint and `OPENAI_API_KEY` supplies its credential. The endpoint and credential must match; Open SWE does not infer that an arbitrary custom URL is LangSmith Gateway or an internal gateway. The admin panel reports the effective endpoint category and safe credential source names without exposing credential values, URL userinfo, query strings, or fragments.
 
 Routing is applied centrally in `make_model` (`agent/utils/model.py`), which resolves the effective on/off and delegates URL/key wiring to `agent/utils/gateway.py`. **OpenAI, Anthropic, Baseten, Fireworks, and Google Gemini** are routed; Google Vertex (service-account auth) and any other provider call the provider directly with a logged warning. Baseten uses `BASETEN_API_KEY` from LangSmith workspace Provider Secrets through Gateway, or the runtime environment for direct calls.
 

--- a/tests/sandbox/test_gateway.py
+++ b/tests/sandbox/test_gateway.py
@@ -496,6 +496,50 @@ def test_make_model_gateway_without_key_falls_back_direct(
     assert "api_key" not in captured
 
 
+def test_gateway_configuration_summary_sanitizes_custom_endpoint(monkeypatch) -> None:
+    monkeypatch.setenv(
+        "OPENAI_API_BASE",
+        "https://user:secret@proxy.example:8443/v1?token=secret#fragment",
+    )
+    monkeypatch.setenv("OPENAI_API_KEY", "never-return-this")
+    monkeypatch.setenv("LC_GATEWAY_KEY", "does-not-enable-langsmith")
+
+    summary = gateway.gateway_configuration_summary(None, "openai:gpt-5.6-sol")
+
+    assert summary == {
+        "model_id": "openai:gpt-5.6-sol",
+        "override_enabled": False,
+        "resolution_reason": "no LangSmith Gateway environment default is set",
+        "endpoint_kind": "custom_endpoint",
+        "endpoint": "https://proxy.example:8443/v1",
+        "credential_sources": ["OPENAI_API_KEY"],
+        "restart_required": False,
+    }
+
+
+def test_gateway_configuration_summary_reports_direct_provider_credential(monkeypatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY_ENABLED", "false")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "never-return-this")
+
+    summary = gateway.gateway_configuration_summary(None, "anthropic:claude-opus-5")
+
+    assert summary["endpoint_kind"] == "direct_provider"
+    assert summary["endpoint"] is None
+    assert summary["credential_sources"] == ["ANTHROPIC_API_KEY"]
+
+
+def test_gateway_configuration_summary_reports_inherited_gateway(monkeypatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "never-return-this")
+
+    summary = gateway.gateway_configuration_summary(None, "anthropic:claude-opus-5")
+
+    assert summary["override_enabled"] is True
+    assert summary["resolution_reason"] == "LANGSMITH_GATEWAY_API_KEY is set"
+    assert summary["endpoint_kind"] == "langsmith_gateway"
+    assert summary["endpoint"] == "https://gateway.smith.langchain.com/anthropic"
+    assert summary["credential_sources"] == ["LANGSMITH_GATEWAY_API_KEY"]
+
+
 def test_gateway_default_follows_the_dedicated_key(monkeypatch) -> None:
     from agent.utils import gateway
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -158,6 +158,16 @@ export interface ProfileUpdate {
   review_draft_prs?: boolean | null
 }
 
+export interface GatewayConfiguration {
+  model_id: string
+  override_enabled: boolean
+  resolution_reason: string
+  endpoint_kind: "direct_provider" | "custom_endpoint" | "langsmith_gateway"
+  endpoint: string | null
+  credential_sources: string[]
+  restart_required: boolean
+}
+
 export interface TeamSettings {
   review_draft_prs: boolean
   pr_summaries: boolean
@@ -787,6 +797,8 @@ export const api = {
   listEnvironmentOptions: () =>
     request<EnvironmentOptionList>("/environments/options"),
   getTeamSettings: () => request<TeamSettings>("/team-settings"),
+  getGatewayConfiguration: () =>
+    request<GatewayConfiguration>("/team-settings/gateway-configuration"),
   saveTeamSettings: (body: TeamSettings) =>
     request<TeamSettings>("/team-settings", {
       method: "PUT",

--- a/ui/src/routes/-admin.test.tsx
+++ b/ui/src/routes/-admin.test.tsx
@@ -1,9 +1,11 @@
 /** @vitest-environment jsdom */
 
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { SlackIntegrationSection } from "./admin"
+import { LLMGatewaySection, SlackIntegrationSection } from "./admin"
+import { api } from "@/lib/api"
 
 const STORAGE_KEY = "open-swe.admin.slack-code-channels-enabled"
 const storage = new Map<string, string>()
@@ -12,6 +14,44 @@ const localStorage = {
   getItem: (key: string) => storage.get(key) ?? null,
   setItem: (key: string, value: string) => storage.set(key, value),
 }
+
+describe("LLMGatewaySection", () => {
+  it("shows the resolved custom endpoint without exposing credentials", async () => {
+    vi.spyOn(api, "getTeamSettings").mockResolvedValue({
+      review_draft_prs: false,
+      pr_summaries: true,
+      review_trace_links: true,
+      gateway_enabled: null,
+    })
+    vi.spyOn(api, "getGatewayConfiguration").mockResolvedValue({
+      model_id: "openai:gpt-5.6-sol",
+      override_enabled: false,
+      resolution_reason: "LANGSMITH_GATEWAY_ENABLED",
+      endpoint_kind: "custom_endpoint",
+      endpoint: "https://proxy.example/v1",
+      credential_sources: ["OPENAI_API_KEY"],
+      restart_required: false,
+    })
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    render(
+      <QueryClientProvider client={client}>
+        <LLMGatewaySection />
+      </QueryClientProvider>
+    )
+
+    expect(
+      await screen.findByText(/Inherit currently resolves to disabled/)
+    ).toBeTruthy()
+    expect(
+      screen.getByText(/Custom endpoint — https:\/\/proxy.example\/v1/)
+    ).toBeTruthy()
+    expect(screen.getByText(/Credential source: OPENAI_API_KEY/)).toBeTruthy()
+    expect(screen.getByText("Environment precedence and examples")).toBeTruthy()
+  })
+})
 
 describe("SlackIntegrationSection", () => {
   const writeText = vi

--- a/ui/src/routes/admin.tsx
+++ b/ui/src/routes/admin.tsx
@@ -482,11 +482,15 @@ function gatewayModeValue(mode: GatewayMode): boolean | null {
   return null
 }
 
-function LLMGatewaySection() {
+export function LLMGatewaySection() {
   const qc = useQueryClient()
   const settings = useQuery({
     queryKey: ["teamSettings"],
     queryFn: api.getTeamSettings,
+  })
+  const configuration = useQuery({
+    queryKey: ["gatewayConfiguration"],
+    queryFn: api.getGatewayConfiguration,
   })
   const [error, setError] = useState<string | null>(null)
 
@@ -494,6 +498,7 @@ function LLMGatewaySection() {
     mutationFn: (body: TeamSettings) => api.saveTeamSettings(body),
     onSuccess: (saved) => {
       qc.setQueryData(["teamSettings"], saved)
+      void qc.invalidateQueries({ queryKey: ["gatewayConfiguration"] })
       setError(null)
     },
     onError: (e: Error) => setError(e.message),
@@ -503,13 +508,17 @@ function LLMGatewaySection() {
 
   return (
     <SettingsSection
-      title="LLM Gateway"
-      description="Route agent and reviewer LLM calls through the LangSmith LLM Gateway. It authenticates with the workspace LangSmith API key and resolves provider keys from Provider Secrets, so no provider keys are needed at runtime. Requires the gateway (private beta) enabled for your organization."
+      title="LangSmith Gateway override"
+      description="Overrides supported model calls with the LangSmith Gateway endpoint and credential. Turning it off does not disable custom provider endpoints."
     >
       <div className="divide-y divide-border">
         <SettingsRow
-          label="Route through the gateway"
-          description="Inherit uses the LANGSMITH_GATEWAY_ENABLED deployment default. OpenAI, Anthropic, Fireworks, and Google Gemini are routed; other providers call the provider directly."
+          label="LangSmith Gateway override"
+          description={
+            configuration.data
+              ? `Inherit currently resolves to ${configuration.data.override_enabled ? "enabled" : "disabled"} because ${configuration.data.resolution_reason}. Changes apply automatically to new model clients, usually within 60 seconds; environment changes require a backend restart.`
+              : "Loading the effective deployment configuration…"
+          }
           control={
             <Select
               value={mode}
@@ -535,7 +544,47 @@ function LLMGatewaySection() {
             </Select>
           }
         />
+        {configuration.data && (
+          <div className="space-y-1 px-4 py-3 text-xs text-muted-foreground">
+            <p>
+              <span className="font-medium text-foreground">
+                Effective endpoint:
+              </span>{" "}
+              {configuration.data.endpoint_kind === "langsmith_gateway"
+                ? "LangSmith Gateway"
+                : configuration.data.endpoint_kind === "custom_endpoint"
+                  ? "Custom endpoint"
+                  : "Direct provider access"}
+              {configuration.data.endpoint
+                ? ` — ${configuration.data.endpoint}`
+                : ""}
+            </p>
+            <p>
+              Credential source:{" "}
+              {configuration.data.credential_sources.join(", ") ||
+                "none detected"}
+              . Endpoint and credential must belong to the same service.
+            </p>
+          </div>
+        )}
       </div>
+      <details className="px-4 py-3 text-xs text-muted-foreground">
+        <summary className="cursor-pointer select-none">
+          Environment precedence and examples
+        </summary>
+        <div className="mt-2 space-y-2 leading-relaxed">
+          <p>
+            Inherit uses LANGSMITH_GATEWAY_ENABLED when explicitly set;
+            otherwise LANGSMITH_GATEWAY_API_KEY enables the override; otherwise
+            it is disabled. LC_GATEWAY_KEY does not affect this decision.
+          </p>
+          <p>
+            Disabled can still use OPENAI_BASE_URL (or OPENAI_API_BASE) with
+            OPENAI_API_KEY. A company proxy URL remains a custom endpoint; Open
+            SWE does not assume it is a LangSmith or internal gateway.
+          </p>
+        </div>
+      </details>
       {error && <p className="px-4 pb-3 text-xs text-destructive">{error}</p>}
     </SettingsSection>
   )


### PR DESCRIPTION
## Before / after

| Before | After |
| --- | --- |
| Admin called the setting **LLM Gateway**. **Disabled** appeared to turn off all gateway-style routing, even when OpenAI used a custom base URL. The **Inherit** explanation could also report the active workspace override instead of the deployment default it would inherit. | Admin calls it **LangSmith Gateway override**. **Disabled** clearly leaves custom provider endpoints alone, and **Inherit** reports the deployment default independently of the workspace override. |

## What changed

- Shows whether the selected agent model uses direct provider access, a custom endpoint, or LangSmith Gateway.
- Names the credential environment variable without exposing its value.
- Sanitizes endpoint metadata by removing user info, query strings, and fragments.
- Documents precedence and when workspace or environment changes take effect.
- Leaves routing and authentication behavior unchanged: `LC_GATEWAY_KEY` does not enable the override, and arbitrary custom endpoints are not identified as internal gateways.

## Updated UI

![Updated LangSmith Gateway override settings](https://01a0a177-8842-7d8c-9095-de8d20b9815b--dl.smithbox.dev/ZXlKaGJHY2lPaUpGWkVSVFFTSXNJbXRwWkNJNklrVmpWRFZxTVd3MmNIQXhlVFZJU3pCQ2VtSjBhMjFTTlc1SmJuTklVVTFqYWpKVVNVUk5kMmgzVURRaUxDSjBlWEFpT2lKS1YxUWlmUS5leUpoZFdRaU9sc2ljMkZ1WkdKdmVDMWtiM2R1Ykc5aFpDSmRMQ0pwWVhRaU9qRTNPRGswTVRZME5EWXNJbXAwYVNJNklqQXhZVEJoTVRnNExURTVaREF0TjJNMll5MDRPV1ptTFdWaE4yTXlOV00yTURNNU1pSXNJbk5wWkNJNklqQXhZVEJoTVRjM0xUZzROREl0TjJRNFl5MDVNRGsxTFdSbE9HUXlNR0k1T0RFMVlpSXNJblJwWkNJNkltVmlZbUZtTW1WaUxUYzJPV0l0TkRVd05TMWhZMkV5TFdReE1XUmxNVEF6TnpKaE5DSXNJbkJoZEdnaU9pSXZkMjl5YTNOd1lXTmxMMjl3Wlc0dGMzZGxMeTV2Y0dWdUxYTjNaUzloY25ScFptRmpkSE12WjJGMFpYZGhlUzF6WlhSMGFXNW5jeTV3Ym1jaUxDSmpkQ0k2SW1sdFlXZGxMM0J1WnlJc0ltTmtJam9pYVc1c2FXNWxJaXdpYzNKaklqb3hOWDAuOUh4Z1U5bWRQdWtKZWprNnlkcmFaM2pjRlhiRDMzcFg5TmcyUVFoN1NMMzZacm5zQ3B6MEhDQzExMXNTRkFmbml2SnNlUy1lVjFBRlFBS2puUGU3Qmc)

Made by [Open SWE](https://openswe.vercel.app/agents/bbbc896f-4904-504e-9de1-b6459df937e0) · openai:gpt-5.6-sol (medium)