### PR TITLE
feat: accept pasted ngrok URLs in make tunnel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,14 @@ web:
 	pnpm run dev
 
 # Public URL for GitHub and Slack webhooks while developing (docs/DEVELOPMENT.md, step 3).
-# ngrok's free plan includes one static domain: NGROK_DOMAIN=<name>.ngrok-free.dev. The policy
-# file exposes only /webhooks/*; langgraph dev has no auth, so the rest of the API stays local.
+# ngrok's free plan includes one static domain: NGROK_DOMAIN=<name>.ngrok-free.dev. A pasted
+# https:// URL with a trailing slash also works. The policy file exposes only /webhooks/*;
+# langgraph dev has no auth, so the rest of the API stays local.
 # Another tunnel is fine only if it enforces the same /webhooks/* allowlist (or a filtering proxy does).
 tunnel:
 	@test -n "$(NGROK_DOMAIN)" || { echo 'Set NGROK_DOMAIN=<your-domain>.ngrok-free.dev (claim it under Domains at https://dashboard.ngrok.com)' >&2; exit 1; }
-	ngrok http 2024 --url https://$(NGROK_DOMAIN) --traffic-policy-file examples/ngrok/webhooks-only.yml
+	$(eval DOMAIN := $(shell DOMAIN="$(NGROK_DOMAIN)"; DOMAIN="$${DOMAIN#https://}"; DOMAIN="$${DOMAIN#http://}"; echo "$${DOMAIN%/}"))
+	ngrok http 2024 --url https://$(DOMAIN) --traffic-policy-file examples/ngrok/webhooks-only.yml
 
 # Build the dashboard into ui/.output/public; `make dev` then serves it at /.
 # With a LangGraph http.mount_prefix, pass DASHBOARD_BASE_PATH=<prefix>/ so the

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -42,7 +42,7 @@ GitHub and Slack need a public HTTPS hostname that stays the same across restart
    make tunnel NGROK_DOMAIN=<name>.ngrok-free.dev   # or export NGROK_DOMAIN once in your shell
    ```
 
-   `NGROK_DOMAIN` takes only the hostname. If you copy the URL from the ngrok dashboard, strip the leading `https://` and any trailing slash: `https://example.ngrok-free.dev/` becomes `example.ngrok-free.dev`. The GitHub App's **Webhook URL** keeps its full form, though: `https://example.ngrok-free.dev/webhooks/github`.
+   `NGROK_DOMAIN` accepts the bare hostname or a full URL — a pasted `https://example.ngrok-free.dev/` is normalized to the hostname. The GitHub App's **Webhook URL** still needs its full form, though: `https://example.ngrok-free.dev/webhooks/github`.
 
 `make tunnel` runs `ngrok http 2024` on that domain with [`examples/ngrok/webhooks-only.yml`](../examples/ngrok/webhooks-only.yml) as its traffic policy, so only `/webhooks/*` is reachable from the internet. That restriction is not optional. Under `langgraph dev` the LangGraph API itself (`/threads`, `/runs`, `/assistants`, `/store`, …) has no authentication at all: the dashboard API checks its session cookie and the webhook endpoints check their signatures, but anyone who can reach port 2024 can read and create threads and runs. A tunnel that forwards the whole port publishes exactly that. Everything except the webhooks stays on `http://localhost:2024`, where you keep opening the dashboard. Check the policy once the backend is up (step 6): `curl https://<name>.ngrok-free.dev/webhooks/slack` answers `{"status":"ok", …}` from the backend, while `/ok` gets ngrok's own 404.
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -42,6 +42,8 @@ GitHub and Slack need a public HTTPS hostname that stays the same across restart
    make tunnel NGROK_DOMAIN=<name>.ngrok-free.dev   # or export NGROK_DOMAIN once in your shell
    ```
 
+   `NGROK_DOMAIN` takes only the hostname. If you copy the URL from the ngrok dashboard, strip the leading `https://` and any trailing slash: `https://example.ngrok-free.dev/` becomes `example.ngrok-free.dev`. The GitHub App's **Webhook URL** keeps its full form, though: `https://example.ngrok-free.dev/webhooks/github`.
+
 `make tunnel` runs `ngrok http 2024` on that domain with [`examples/ngrok/webhooks-only.yml`](../examples/ngrok/webhooks-only.yml) as its traffic policy, so only `/webhooks/*` is reachable from the internet. That restriction is not optional. Under `langgraph dev` the LangGraph API itself (`/threads`, `/runs`, `/assistants`, `/store`, …) has no authentication at all: the dashboard API checks its session cookie and the webhook endpoints check their signatures, but anyone who can reach port 2024 can read and create threads and runs. A tunnel that forwards the whole port publishes exactly that. Everything except the webhooks stays on `http://localhost:2024`, where you keep opening the dashboard. Check the policy once the backend is up (step 6): `curl https://<name>.ngrok-free.dev/webhooks/slack` answers `{"status":"ok", …}` from the backend, while `/ok` gets ngrok's own 404.
 
 Use ngrok with this policy. A different tunnel is only an option if it can restrict the public paths to `/webhooks/*` the same way; one that forwards the whole port is not.


### PR DESCRIPTION
Instead of requiring the user to strip the protocol from a URL copied out of the ngrok dashboard, `make tunnel` now normalizes `NGROK_DOMAIN` itself: a leading `https://` or `http://` and any trailing slash are stripped before it is passed to `ngrok --url` (verified with a scratch Makefile for bare hostname, `https://…/`, and `http://…/` inputs). The doc note in `docs/DEVELOPMENT.md` was updated to match, and still clarifies that the GitHub App's Webhook URL keeps `https://` and the `/webhooks/github` path.

Made by [Open SWE](https://openswe.vercel.app/agents/41a316fc-f133-5381-b3d5-53b2232a6085) · openai:gpt-5.6-sol (high)