### PR TITLE
feat: configure sandbox auth proxies per environment

### DIFF
--- a/agent/dashboard/environment_auth.py
+++ b/agent/dashboard/environment_auth.py
@@ -1,0 +1,222 @@
+"""Environment-owned authentication rules for the sandbox HTTP proxy."""
+
+import ipaddress
+import re
+from typing import Any, Literal
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    SecretStr,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
+
+from agent.encryption import decrypt_token, encrypt_token
+from agent.store import TypedStore
+
+ENVIRONMENT_AUTH_NAMESPACE = ["environment_auth"]
+MAX_AUTH_RULES = 20
+MAX_AUTH_REQUEST_BYTES = 200_000
+
+_DNS_LABEL_RE = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?")
+_HEADER_RE = re.compile(r"[!#$%&'*+.^_`|~0-9A-Za-z-]{1,128}")
+_BLOCKED_HEADERS = frozenset(
+    {
+        "connection",
+        "content-length",
+        "host",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+    }
+)
+
+
+class EnvironmentAuthRequestError(ValueError):
+    """A validation error whose message is safe to return to the dashboard."""
+
+
+def _validate_host(value: str) -> str:
+    host = value.strip().lower()
+    if not host or len(host) > 253 or host.endswith("."):
+        raise ValueError("Invalid DNS host")
+    try:
+        ipaddress.ip_address(host)
+    except ValueError:
+        pass
+    else:
+        raise ValueError("IP addresses are not allowed")
+    if any(not _DNS_LABEL_RE.fullmatch(label) for label in host.split(".")):
+        raise ValueError("Invalid DNS host")
+    if host == "github.com" or host.endswith(".github.com"):
+        raise ValueError("GitHub destinations use managed authentication")
+    return host
+
+
+def _validate_header(value: str) -> str:
+    if not _HEADER_RE.fullmatch(value) or value.lower() in _BLOCKED_HEADERS:
+        raise ValueError("Invalid authentication header")
+    return value
+
+
+class EnvironmentAuthRule(BaseModel):
+    model_config = ConfigDict(extra="forbid", hide_input_in_errors=True, frozen=True)
+
+    id: str = Field(pattern=r"^[a-z][a-z0-9-]{0,31}$")
+    host: str = Field(max_length=253)
+    header: str = Field(default="Authorization", max_length=128)
+    scheme: Literal["bearer", "api_key"]
+
+    _host = field_validator("host")(_validate_host)
+    _header = field_validator("header")(_validate_header)
+
+
+class EnvironmentAuthRuleUpdate(EnvironmentAuthRule):
+    credential: SecretStr | None = Field(default=None, min_length=1, max_length=8192, repr=False)
+
+    @field_validator("credential")
+    @classmethod
+    def _credential(cls, value: SecretStr | None) -> SecretStr | None:
+        if value is not None and any(
+            ord(char) < 33 or ord(char) > 126 for char in value.get_secret_value()
+        ):
+            raise ValueError("Credentials must contain only visible ASCII characters")
+        return value
+
+
+class EnvironmentAuthUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid", hide_input_in_errors=True)
+
+    rules: list[EnvironmentAuthRuleUpdate] = Field(max_length=MAX_AUTH_RULES)
+
+    @model_validator(mode="after")
+    def _unique_rules(self) -> EnvironmentAuthUpdate:
+        ids: set[str] = set()
+        destinations: set[tuple[str, str]] = set()
+        for rule in self.rules:
+            destination = (rule.host, rule.header.lower())
+            if rule.id in ids or destination in destinations:
+                raise ValueError("Rule IDs and host/header destinations must be unique")
+            ids.add(rule.id)
+            destinations.add(destination)
+        return self
+
+
+class _EnvironmentAuthRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid", hide_input_in_errors=True)
+
+    rules: list[EnvironmentAuthRule] = Field(max_length=MAX_AUTH_RULES)
+    encrypted_credentials: dict[str, str]
+
+    @model_validator(mode="after")
+    def _credentials_match_rules(self) -> _EnvironmentAuthRecord:
+        ids = [rule.id for rule in self.rules]
+        destinations = [(rule.host, rule.header.lower()) for rule in self.rules]
+        if (
+            len(ids) != len(set(ids))
+            or len(destinations) != len(set(destinations))
+            or set(ids) != set(self.encrypted_credentials)
+            or any(not value for value in self.encrypted_credentials.values())
+        ):
+            raise ValueError("Unreadable environment authentication record")
+        return self
+
+
+_store = TypedStore(ENVIRONMENT_AUTH_NAMESPACE, _EnvironmentAuthRecord)
+
+
+def parse_environment_auth_update(raw_body: bytes) -> EnvironmentAuthUpdate:
+    """Parse a request body without allowing Pydantic to echo credential input."""
+    if len(raw_body) > MAX_AUTH_REQUEST_BYTES:
+        raise EnvironmentAuthRequestError("Environment auth proxy settings are too large")
+    try:
+        return EnvironmentAuthUpdate.model_validate_json(raw_body)
+    except ValidationError:
+        raise EnvironmentAuthRequestError("Invalid environment auth proxy settings") from None
+
+
+def _public(record: _EnvironmentAuthRecord | None) -> dict[str, Any]:
+    if record is None:
+        return {"rules": []}
+    return {
+        "rules": [
+            {
+                **rule.model_dump(mode="json"),
+                "has_credential": rule.id in record.encrypted_credentials,
+            }
+            for rule in record.rules
+        ]
+    }
+
+
+def _decrypt_credential(encrypted: str) -> str:
+    credential = decrypt_token(encrypted)
+    if not credential:
+        raise ValueError("Environment authentication credential could not be decrypted")
+    return credential
+
+
+async def get_environment_auth(slug: str) -> dict[str, Any]:
+    """Return one environment's non-sensitive rule definitions."""
+    return _public(await _store.get(slug))
+
+
+async def save_environment_auth(slug: str, update: EnvironmentAuthUpdate) -> dict[str, Any]:
+    """Atomically replace definitions and encrypted credentials for an environment."""
+    previous = await _store.get(slug)
+    previous_credentials = previous.encrypted_credentials if previous else {}
+    encrypted_credentials: dict[str, str] = {}
+    rules: list[EnvironmentAuthRule] = []
+    for draft in update.rules:
+        credential = draft.credential
+        if credential is not None:
+            encrypted = encrypt_token(credential.get_secret_value())
+        else:
+            encrypted = previous_credentials.get(draft.id, "")
+            if encrypted:
+                _decrypt_credential(encrypted)
+        if not encrypted:
+            raise EnvironmentAuthRequestError("Every new auth proxy rule requires a credential")
+        rules.append(EnvironmentAuthRule.model_validate(draft.model_dump(exclude={"credential"})))
+        encrypted_credentials[draft.id] = encrypted
+
+    record = _EnvironmentAuthRecord(
+        rules=rules,
+        encrypted_credentials=encrypted_credentials,
+    )
+    await _store.put(slug, record)
+    return _public(record)
+
+
+async def resolve_environment_auth_rules(slug: str) -> list[dict[str, Any]]:
+    """Resolve an environment's encrypted values into provider proxy rules."""
+    record = await _store.get(slug)
+    if record is None:
+        return []
+
+    by_host: dict[str, dict[str, Any]] = {}
+    for rule in record.rules:
+        provider_rule = by_host.setdefault(
+            rule.host,
+            {
+                "name": f"environment-auth-{rule.id}",
+                "match_hosts": [rule.host],
+                "headers": [],
+            },
+        )
+        credential = _decrypt_credential(record.encrypted_credentials[rule.id])
+        value = f"Bearer {credential}" if rule.scheme == "bearer" else credential
+        provider_rule["headers"].append({"name": rule.header, "type": "opaque", "value": value})
+    return list(by_host.values())
+
+
+async def delete_environment_auth(slug: str) -> None:
+    """Delete all environment-owned authentication definitions and credentials."""
+    await _store.delete(slug)

--- a/agent/dashboard/environment_refresh.py
+++ b/agent/dashboard/environment_refresh.py
@@ -163,6 +163,7 @@ async def _create_builder_sandbox(record: Environment, snapshot_id: str | None) 
         raise RuntimeError("GitHub App installation token is unavailable")
     return await create_langsmith_sandbox(
         github_token=token,
+        environment_slug=record.slug,
         snapshot_id=snapshot_id,
         create_params={
             **record.sandbox_create_params(),

--- a/agent/dashboard/environments.py
+++ b/agent/dashboard/environments.py
@@ -645,6 +645,9 @@ class EnvironmentStore(TypedStore[Environment]):
         record = await self.get(slug)
         if record is None:
             return False
+        from agent.dashboard.environment_auth import delete_environment_auth
+
+        await delete_environment_auth(slug)
         await self.delete(slug)
         from agent.dashboard.environment_refresh import remove_refresh_cron
 
@@ -823,36 +826,43 @@ def _stamp_captured(
 ENVIRONMENTS = EnvironmentStore()
 
 
-async def resolve_default_environment() -> Environment | None:
+async def resolve_default_environment(*, fail_on_error: bool = False) -> Environment | None:
     """Return the environment named ``default``, or ``None``.
 
     Fail-soft on purpose: this runs while a sandbox is being created, and a
     store failure must fall back to the base snapshot with no environment
-    prompt rather than fail the run.
+    prompt rather than fail the run. Runtime paths that also resolve environment
+    credentials opt into strict failure handling.
     """
     try:
         return await ENVIRONMENTS.get(DEFAULT_ENVIRONMENT_SLUG)
     except Exception:
+        if fail_on_error:
+            raise
         logger.warning("default environment resolution failed", exc_info=True)
         return None
 
 
-async def resolve_environment(slug: str | None) -> Environment | None:
+async def resolve_environment(
+    slug: str | None, *, fail_on_error: bool = False
+) -> Environment | None:
     """Return the environment a run uses: the one it selected, else ``default``.
 
-    Never raises, and a selection that no longer exists falls back to ``default``
-    rather than failing the run.
+    By default, a selection that no longer exists or cannot be read falls back
+    to ``default``. Runtime paths that resolve credentials request strict errors.
     """
     if not slug or slug == DEFAULT_ENVIRONMENT_SLUG:
-        return await resolve_default_environment()
+        return await resolve_default_environment(fail_on_error=fail_on_error)
     try:
         record = await ENVIRONMENTS.get(slug)
     except Exception:
+        if fail_on_error:
+            raise
         logger.warning("environment resolution failed for %s", slug, exc_info=True)
         record = None
     if record is None:
         logger.info("Environment %s is not configured; falling back to the default", slug)
-        return await resolve_default_environment()
+        return await resolve_default_environment(fail_on_error=fail_on_error)
     return record
 
 

--- a/agent/dashboard/routes.py
+++ b/agent/dashboard/routes.py
@@ -39,6 +39,12 @@ from agent.dashboard.enabled_repos import (
     list_enabled_review_repos,
     set_review_repo_enabled,
 )
+from agent.dashboard.environment_auth import (
+    EnvironmentAuthRequestError,
+    get_environment_auth,
+    parse_environment_auth_update,
+    save_environment_auth,
+)
 from agent.dashboard.environment_refresh import (
     ensure_refresh_cron,
     is_refresh_in_flight,
@@ -1178,6 +1184,33 @@ async def api_get_environment(
     if not record:
         raise HTTPException(404, "environment not found")
     return record
+
+
+@router.get("/environments/{slug}/auth-proxy")
+async def api_get_environment_auth_proxy(
+    slug: str,
+    _admin: dict[str, Any] = _ADMIN_DEP,
+) -> dict[str, Any]:
+    normalized = _normalized_slug(slug)
+    if await ENVIRONMENTS.get(normalized) is None:
+        raise HTTPException(404, "environment not found")
+    return await get_environment_auth(normalized)
+
+
+@router.put("/environments/{slug}/auth-proxy")
+async def api_set_environment_auth_proxy(
+    slug: str,
+    request: Request,
+    _admin: dict[str, Any] = _ADMIN_DEP,
+) -> dict[str, Any]:
+    normalized = _normalized_slug(slug)
+    if await ENVIRONMENTS.get(normalized) is None:
+        raise HTTPException(404, "environment not found")
+    try:
+        update = parse_environment_auth_update(await request.body())
+        return await save_environment_auth(normalized, update)
+    except EnvironmentAuthRequestError as exc:
+        raise HTTPException(422, str(exc)) from None
 
 
 @router.put("/environments/{slug}")

--- a/agent/github/proxy.py
+++ b/agent/github/proxy.py
@@ -33,6 +33,7 @@ _PROXY_TOKEN_EXPIRY: dict[
     str, tuple[datetime | None, datetime, tuple[str, ...] | None, PermissionKey]
 ] = {}
 _PROXY_BASE_CONFIGS: dict[str, dict[str, Any]] = {}
+_PROXY_ENVIRONMENT_SLUGS: dict[str, str] = {}
 ProxyTokenRecord = tuple[datetime | None, datetime, tuple[str, ...] | None, PermissionKey]
 
 
@@ -68,6 +69,7 @@ def record_proxy_token_expiry(
     repositories: Sequence[str] | None = None,
     permissions: PermissionMap | None = None,
     base_proxy_config: dict[str, Any] | None = None,
+    environment_slug: str | None = None,
 ) -> None:
     """Record when ``thread_id``'s proxy token expires and the repo scope it was minted with.
 
@@ -87,6 +89,14 @@ def record_proxy_token_expiry(
         _PROXY_BASE_CONFIGS[thread_id] = dict(base_proxy_config)
     else:
         _PROXY_BASE_CONFIGS.pop(thread_id, None)
+    if environment_slug is not None:
+        _PROXY_ENVIRONMENT_SLUGS[thread_id] = environment_slug
+    else:
+        _PROXY_ENVIRONMENT_SLUGS.pop(thread_id, None)
+
+
+def get_recorded_proxy_environment(thread_id: str | None) -> str | None:
+    return _PROXY_ENVIRONMENT_SLUGS.get(thread_id) if thread_id else None
 
 
 def get_recorded_proxy_base_config(thread_id: str | None) -> dict[str, Any] | None:
@@ -100,6 +110,7 @@ def clear_proxy_token_expiry(thread_id: str | None) -> None:
     if thread_id:
         _PROXY_TOKEN_EXPIRY.pop(thread_id, None)
         _PROXY_BASE_CONFIGS.pop(thread_id, None)
+        _PROXY_ENVIRONMENT_SLUGS.pop(thread_id, None)
 
 
 def _unpack_proxy_token_record(record: tuple[Any, ...]) -> ProxyTokenRecord:
@@ -156,20 +167,20 @@ async def refresh_proxy_token(
 
     current_backend = unwrap_sandbox_backend(sandbox_backend)
     base_proxy_config = _PROXY_BASE_CONFIGS.get(thread_id)
+    environment_slug = get_recorded_proxy_environment(thread_id)
+    configure_kwargs: dict[str, Any] = {}
     if base_proxy_config is not None:
-        await configure_github_proxy(
-            current_backend.id,
-            token,
-            base_proxy_config=base_proxy_config,
-        )
-    else:
-        await configure_github_proxy(current_backend.id, token)
+        configure_kwargs["base_proxy_config"] = base_proxy_config
+    if environment_slug is not None:
+        configure_kwargs["environment_slug"] = environment_slug
+    await configure_github_proxy(current_backend.id, token, **configure_kwargs)
     record_proxy_token_expiry(
         thread_id,
         expires_at,
         repositories=effective_repositories,
         permissions=dict(permission_key) if permission_key else None,
         base_proxy_config=base_proxy_config,
+        environment_slug=environment_slug,
     )
     logger.info("Refreshed GitHub proxy token for thread %s", thread_id)
     return True

--- a/agent/sandboxes/lifecycle.py
+++ b/agent/sandboxes/lifecycle.py
@@ -25,7 +25,11 @@ from agent.dashboard.environments import (
 )
 from agent.dashboard.sandbox_settings import get_admin_base_snapshot_id
 from agent.github.app import get_github_app_installation_token_with_expiry
-from agent.github.proxy import get_recorded_proxy_base_config, record_proxy_token_expiry
+from agent.github.proxy import (
+    get_recorded_proxy_base_config,
+    get_recorded_proxy_environment,
+    record_proxy_token_expiry,
+)
 from agent.sandboxes.providers.langsmith import (
     configure_github_proxy,
     create_langsmith_sandbox_from_params,
@@ -50,6 +54,7 @@ logger = logging.getLogger(__name__)
 client = get_client()
 
 _SANDBOX_PROXY_CONFIG_METADATA_KEY = "sandbox_base_proxy_config"
+_SANDBOX_ENVIRONMENT_METADATA_KEY = "sandbox_environment_slug"
 
 
 async def _resolve_proxy_token(
@@ -73,7 +78,9 @@ class SandboxCreateConfig:
 
     @classmethod
     async def resolve(cls, environment_slug: str | None = None) -> SandboxCreateConfig:
-        environment = await resolve_environment(environment_slug)
+        environment = await resolve_environment(
+            environment_slug, fail_on_error=ENV.SANDBOX_TYPE.get() == "langsmith"
+        )
         if environment is None:
             return cls(snapshot_id=await get_admin_base_snapshot_id())
         return cls(
@@ -165,11 +172,13 @@ async def _create_sandbox_with_proxy(
                 logger.error(msg)
                 raise ValueError(msg)
             proxy_config = config.proxy_config
+            resolved_slug = config.environment.slug if config.environment is not None else None
             async with aphase(thread_id, "sandbox.proxy_configure"):
                 await _configure_proxy(
                     sandbox_backend.id,
                     token,
                     proxy_config,
+                    environment_slug=resolved_slug,
                 )
             record_proxy_token_expiry(
                 thread_id,
@@ -177,6 +186,7 @@ async def _create_sandbox_with_proxy(
                 repositories=github_proxy_repositories,
                 permissions=permissions,
                 base_proxy_config=proxy_config,
+                environment_slug=resolved_slug,
             )
 
     # This run gets fresh checkouts now; the background capture makes the *next*
@@ -205,10 +215,14 @@ async def _configure_proxy(
     sandbox_id: str,
     token: str,
     base_proxy_config: dict[str, Any] | None,
+    *,
+    environment_slug: str | None = None,
 ) -> None:
     kwargs: dict[str, Any] = {}
     if base_proxy_config is not None:
         kwargs["base_proxy_config"] = base_proxy_config
+    if environment_slug is not None:
+        kwargs["environment_slug"] = environment_slug
     await configure_github_proxy(sandbox_id, token, **kwargs)
 
 
@@ -219,6 +233,7 @@ async def _refresh_github_proxy(
     thread_id: str | None = None,
     github_proxy_repositories: Sequence[str] | None = None,
     base_proxy_config: dict[str, Any] | None = None,
+    environment_slug: str | None = None,
 ) -> None:
     """Refresh managed proxy credentials for reused LangSmith sandboxes."""
     if ENV.SANDBOX_TYPE.get() != "langsmith":
@@ -235,6 +250,7 @@ async def _refresh_github_proxy(
             current_backend.id,
             token,
             base_proxy_config,
+            environment_slug=environment_slug,
         )
     record_proxy_token_expiry(
         thread_id,
@@ -242,6 +258,7 @@ async def _refresh_github_proxy(
         repositories=github_proxy_repositories,
         permissions=permissions,
         base_proxy_config=base_proxy_config,
+        environment_slug=environment_slug,
     )
 
 
@@ -251,6 +268,7 @@ async def _refresh_github_proxy_or_fail(
     github_proxy_token: str | None = None,
     github_proxy_repositories: Sequence[str] | None = None,
     base_proxy_config: dict[str, Any] | None = None,
+    environment_slug: str | None = None,
 ) -> SandboxBackendProtocol:
     """Refresh proxy credentials; a sandbox we can't reconfigure is unreachable."""
     try:
@@ -260,6 +278,7 @@ async def _refresh_github_proxy_or_fail(
             thread_id=thread_id,
             github_proxy_repositories=github_proxy_repositories,
             base_proxy_config=base_proxy_config,
+            environment_slug=environment_slug,
         )
     except Exception as exc:
         logger.warning(
@@ -314,6 +333,7 @@ async def _connect_existing_sandbox(
     github_proxy_token: str | None = None,
     github_proxy_repositories: Sequence[str] | None = None,
     base_proxy_config: dict[str, Any] | None = None,
+    environment_slug: str | None = None,
 ) -> SandboxBackendProtocol:
     """Reuse the sandbox already bound to ``thread_id``, or fail unreachable.
 
@@ -341,6 +361,7 @@ async def _connect_existing_sandbox(
             github_proxy_token,
             github_proxy_repositories,
             base_proxy_config,
+            environment_slug,
         )
     return refreshed
 
@@ -398,6 +419,15 @@ async def ensure_sandbox_for_thread(
         else get_recorded_proxy_base_config(thread_id)
     )
     created_proxy_config: dict[str, Any] | None = None
+    recorded_environment = sandbox_metadata.get(_SANDBOX_ENVIRONMENT_METADATA_KEY)
+    resolved_slug = (
+        environment_slug
+        or (recorded_environment if isinstance(recorded_environment, str) else None)
+        or get_recorded_proxy_environment(thread_id)
+    )
+    if ENV.SANDBOX_TYPE.get() == "langsmith" and sandbox_id is not None and resolved_slug is None:
+        environment = await resolve_environment(None, fail_on_error=True)
+        resolved_slug = environment.slug if environment is not None else None
 
     if sandbox_backend is None and sandbox_id is None:
         logger.info("Creating new sandbox for thread %s", thread_id)
@@ -408,6 +438,7 @@ async def ensure_sandbox_for_thread(
             environment_slug=environment_slug,
         )
         created_proxy_config = get_recorded_proxy_base_config(thread_id)
+        resolved_slug = get_recorded_proxy_environment(thread_id)
         logger.info("Sandbox created: %s", sandbox_backend.id)
     else:
         try:
@@ -418,6 +449,7 @@ async def ensure_sandbox_for_thread(
                 github_proxy_token=github_proxy_token,
                 github_proxy_repositories=github_proxy_repositories,
                 base_proxy_config=base_proxy_config,
+                environment_slug=resolved_slug,
             )
         except (SandboxGoneError, SandboxUnreachableError) as exc:
             gone = isinstance(exc, SandboxGoneError)
@@ -437,6 +469,7 @@ async def ensure_sandbox_for_thread(
                     environment_slug=environment_slug,
                 )
                 created_proxy_config = get_recorded_proxy_base_config(thread_id)
+                resolved_slug = get_recorded_proxy_environment(thread_id)
             except Exception as create_exc:
                 # Keep the failure typed so callers still recognize "this run has no
                 # sandbox" and can notify the user.
@@ -454,10 +487,12 @@ async def ensure_sandbox_for_thread(
     # Bind the thread only once the sandbox is created and initialized: a run
     # that dies earlier leaves no id to reconnect to, so the next run creates
     # rather than adopting a half-built box.
-    if sandbox_id != sandbox_backend.id:
+    if sandbox_id != sandbox_backend.id or resolved_slug != recorded_environment:
         sandbox_metadata: dict[str, Any] = {"sandbox_id": sandbox_backend.id}
         if created_proxy_config is not None:
             sandbox_metadata[_SANDBOX_PROXY_CONFIG_METADATA_KEY] = created_proxy_config
+        if resolved_slug is not None or recorded_environment is not None:
+            sandbox_metadata[_SANDBOX_ENVIRONMENT_METADATA_KEY] = resolved_slug
         async with aphase(thread_id, "sandbox.bind_thread"):
             await client.threads.update(thread_id=thread_id, metadata=sandbox_metadata)
 
@@ -482,6 +517,15 @@ async def reset_sandbox_for_thread(
     if not old_sandbox_id:
         raise ValueError(f"Thread {thread_id} has no sandbox to reset")
 
+    metadata = await get_sandbox_metadata(thread_id)
+    recorded_environment = metadata.get(_SANDBOX_ENVIRONMENT_METADATA_KEY)
+    environment_slug = (
+        recorded_environment if isinstance(recorded_environment, str) else None
+    ) or get_recorded_proxy_environment(thread_id)
+    if environment_slug is None:
+        environment = await resolve_environment(None, fail_on_error=True)
+        environment_slug = environment.slug if environment is not None else None
+
     new_sandbox = await create_langsmith_sandbox_from_params(create_params)
     if new_sandbox.id == old_sandbox_id:
         raise RuntimeError("Sandbox provider did not create a distinct sandbox")
@@ -494,12 +538,15 @@ async def reset_sandbox_for_thread(
         new_sandbox.id,
         token,
         proxy_config,
+        environment_slug=environment_slug,
     )
     await configure_git_identity(new_sandbox)
     sandbox_metadata: dict[str, Any] = {
         "sandbox_id": new_sandbox.id,
         _SANDBOX_PROXY_CONFIG_METADATA_KEY: proxy_config,
     }
+    if environment_slug is not None:
+        sandbox_metadata[_SANDBOX_ENVIRONMENT_METADATA_KEY] = environment_slug
     await client.threads.update(thread_id=thread_id, metadata=sandbox_metadata)
     set_sandbox_backend(thread_id, new_sandbox)
     record_proxy_token_expiry(
@@ -507,6 +554,7 @@ async def reset_sandbox_for_thread(
         expires_at,
         permissions=permissions,
         base_proxy_config=proxy_config,
+        environment_slug=environment_slug,
     )
     logger.info(
         "Reset thread %s from sandbox %s to sandbox %s",
@@ -537,7 +585,10 @@ async def recreate_sandbox_for_thread(
         raise RuntimeError("Sandbox provider did not create a distinct sandbox")
 
     await configure_git_identity(new_sandbox)
-    sandbox_metadata: dict[str, Any] = {"sandbox_id": new_sandbox.id}
+    sandbox_metadata: dict[str, Any] = {
+        "sandbox_id": new_sandbox.id,
+        _SANDBOX_ENVIRONMENT_METADATA_KEY: get_recorded_proxy_environment(thread_id),
+    }
     base_proxy_config = get_recorded_proxy_base_config(thread_id)
     if base_proxy_config is not None:
         sandbox_metadata[_SANDBOX_PROXY_CONFIG_METADATA_KEY] = base_proxy_config

--- a/agent/sandboxes/providers/langsmith.py
+++ b/agent/sandboxes/providers/langsmith.py
@@ -6,6 +6,7 @@ import json
 import logging
 import shlex
 from abc import ABC, abstractmethod
+from fnmatch import fnmatchcase
 from typing import Any
 
 import httpx2
@@ -20,6 +21,7 @@ from langsmith.sandbox import (
 )
 
 from agent.config import ENV
+from agent.dashboard.environment_auth import resolve_environment_auth_rules
 from agent.sandboxes.providers.registry import SandboxGoneError
 from agent.sandboxes.retry import retry_transient_sandbox_errors
 
@@ -383,11 +385,29 @@ async def _start_sandbox_best_effort(sandbox_name: str) -> None:
         await client.aclose()
 
 
+def _proxy_rule_matches_host(rule: dict[str, Any], host: str) -> bool:
+    if rule.get("enabled") is False:
+        return False
+    # Provider auth precedes header rules and has implicit destination matching.
+    rule_type = rule.get("type")
+    rule_type = rule_type.strip().lower() if isinstance(rule_type, str) else ""
+    if rule_type == "gcp":
+        return host == "googleapis.com" or host.endswith(".googleapis.com")
+    if rule_type == "aws":
+        return host.endswith(".amazonaws.com")
+    return any(
+        fnmatchcase(host, pattern.lower())
+        for pattern in (rule.get("match_hosts") or [])
+        if isinstance(pattern, str)
+    )
+
+
 async def configure_github_proxy(
     sandbox_name: str,
     github_token: str,
     *,
     base_proxy_config: dict[str, Any] | None = None,
+    environment_slug: str | None = None,
 ) -> None:
     """Configure sandbox proxy to inject managed credentials for outbound traffic.
 
@@ -399,9 +419,12 @@ async def configure_github_proxy(
         sandbox_name: The sandbox name/ID returned by the LangSmith API.
         github_token: GitHub token to inject as Authorization header.
         base_proxy_config: Additional persisted proxy settings to preserve.
+        environment_slug: Environment whose current credentials should be injected.
     """
     api_key = _get_langsmith_api_key()
     if not api_key:
+        if environment_slug is not None:
+            raise RuntimeError("Cannot configure environment auth proxy without a sandbox API key")
         logger.warning("No LangSmith API key found, skipping GitHub proxy configuration")
         return
     langsmith_endpoint = _get_sandbox_endpoint()
@@ -414,25 +437,62 @@ async def configure_github_proxy(
         for rule in (custom_rules if isinstance(custom_rules, list) else [])
         if not isinstance(rule, dict) or rule.get("name") != "open-swe-langsmith"
     ]
-    proxy_config["rules"] = [
+    rules = [
         *preserved_rules,
         *_github_proxy_rules(github_token),
         *_stagehand_proxy_rules(),
     ]
+    environment_rules = (
+        await resolve_environment_auth_rules(environment_slug) if environment_slug else []
+    )
+    # Callback configuration has no enabled/type fields; ignore unknown fields
+    # here just as the provider does when decoding a callback.
+    callbacks = [
+        {"match_hosts": callback.get("match_hosts", [])}
+        for callback in (proxy_config.get("callbacks") or [])
+        if isinstance(callback, dict)
+    ]
+    for environment_rule in environment_rules:
+        for existing in [*rules, *callbacks]:
+            if not isinstance(existing, dict) or existing.get("enabled") is False:
+                continue
+            # Header rules also preempt authorization callbacks on matching hosts.
+            if existing.get("name") == environment_rule["name"] or any(
+                _proxy_rule_matches_host(existing, host) for host in environment_rule["match_hosts"]
+            ):
+                raise ValueError(
+                    "Environment auth proxy rule conflicts with an existing proxy rule"
+                )
+    proxy_config["rules"] = [*rules, *environment_rules]
     payload = {"proxy_config": proxy_config}
     async with httpx2.AsyncClient(timeout=PROXY_CONFIG_TIMEOUT_SECONDS) as client:
+        needs_start = False
         try:
             await _patch_proxy_config(client, url, payload, api_key, sandbox_name)
         except httpx2.HTTPStatusError as exc:
             if exc.response.status_code != PROXY_CONFIG_NOT_READY_STATUS:
+                if environment_slug is not None:
+                    raise RuntimeError("Failed to configure environment auth proxy") from None
                 raise
+            needs_start = True
+        except Exception:
+            if environment_slug is not None:
+                raise RuntimeError("Failed to configure environment auth proxy") from None
+            raise
+        # Leave the exception handler before retrying: startup errors must not
+        # inherit a proxy response that may have echoed an opaque header value.
+        if needs_start:
             logger.warning(
-                "Proxy config rejected for sandbox %s; starting it and retrying: %s",
-                sandbox_name,
-                exc,
+                "Proxy config rejected; starting sandbox before retry",
+                extra={"sandbox_id": sandbox_name},
             )
-            await _start_sandbox_best_effort(sandbox_name)
-            await _patch_proxy_config(client, url, payload, api_key, sandbox_name)
+            try:
+                await _start_sandbox_best_effort(sandbox_name)
+                await _patch_proxy_config(client, url, payload, api_key, sandbox_name)
+            except Exception:
+                if environment_slug is not None:
+                    raise RuntimeError("Failed to configure environment auth proxy") from None
+                raise
     logger.info("Configured GitHub proxy for sandbox %s", sandbox_name)
 
 
@@ -531,6 +591,7 @@ async def create_langsmith_sandbox(
     vcpus: int | None = None,
     fs_capacity_bytes: int | None = None,
     create_params: dict[str, Any] | None = None,
+    environment_slug: str | None = None,
 ) -> SandboxBackendProtocol:
     """Create or connect to a LangSmith sandbox without automatic cleanup.
 
@@ -549,6 +610,7 @@ async def create_langsmith_sandbox(
         vcpus: Optional virtual CPU count override for a newly-created sandbox.
         fs_capacity_bytes: Optional filesystem capacity override for a newly-created sandbox.
         create_params: Optional additional fields merged into the sandbox create body.
+        environment_slug: Environment auth applied before setup scripts run.
 
     Returns:
         SandboxBackendProtocol instance
@@ -587,14 +649,12 @@ async def create_langsmith_sandbox(
 
     if sandbox_id is None and github_token:
         proxy_config = get_sandbox_proxy_config(create_params)
+        configure_kwargs: dict[str, Any] = {}
         if proxy_config is not None:
-            await configure_github_proxy(
-                backend.id,
-                github_token,
-                base_proxy_config=proxy_config,
-            )
-        else:
-            await configure_github_proxy(backend.id, github_token)
+            configure_kwargs["base_proxy_config"] = proxy_config
+        if environment_slug is not None:
+            configure_kwargs["environment_slug"] = environment_slug
+        await configure_github_proxy(backend.id, github_token, **configure_kwargs)
 
     return backend
 

--- a/docs/ENVIRONMENT_AUTH.md
+++ b/docs/ENVIRONMENT_AUTH.md
@@ -1,0 +1,48 @@
+# Environment auth proxy
+
+Workspace admins can configure credentials directly on an environment in
+**Settings → Environments → Authentication proxy**. Each entry specifies an exact DNS
+hostname, an HTTP header, an authentication method, and a credential.
+
+- **Bearer token** injects `Bearer <credential>` into the selected header,
+  normally `Authorization`.
+- **API key** injects the credential directly, for example into `X-API-Key`.
+
+Use a hostname such as `api.staging.example.com`, without a scheme, path, port,
+or wildcard. Multiple headers for the same hostname are supported. Destinations
+already matched by a managed GitHub/Stagehand rule, an AWS/GCP authentication
+rule, a custom proxy routing rule, or an authorization callback cannot also
+have environment auth: overlapping rules could bypass the intended
+authentication. With an AWS authentication rule, environment auth excludes
+all `*.amazonaws.com` hosts.
+
+Credentials are encrypted using the existing `TOKEN_ENCRYPTION_KEY` setup and
+stored separately from the environment definition. The editor shows only
+whether a credential is configured. Leaving an existing credential input blank
+keeps it; entering a new value rotates it; removing an entry removes its stored
+credential. Credentials belong to the environment, so anyone allowed to run in
+that environment can make authenticated requests to its configured hosts.
+
+Open SWE resolves credentials on the server and supplies them as opaque proxy
+headers. It does not write them to the sandbox filesystem, environment
+variables, snapshots, prompts, or thread metadata. Clients that require a local
+API-key variable can use a non-sensitive placeholder; the proxy supplies the
+real header on outbound requests. Do not put credentials in setup scripts,
+prompts, additional create parameters, or chat messages.
+
+Rules apply to new sandboxes and environment snapshot builders before scripts
+run. Existing sandboxes receive current rules and rotated credentials at the
+next agent run or scheduled GitHub proxy-token refresh. Saving settings does
+not immediately change a running or idle sandbox. Removing an environment
+also removes its stored auth rules; its existing sandboxes lose those injected
+headers on their next proxy refresh.
+
+This feature currently uses the LangSmith sandbox provider. A credential lookup
+or decryption failure prevents proxy configuration and fails sandbox preparation,
+rather than starting an agent with incomplete authentication.
+
+The admin API is `GET` / `PUT /dashboard/api/environments/{slug}/auth-proxy` (under the
+deployment's dashboard mount). `PUT` replaces the complete rule list. Keep each
+rule's stable `id` and omit `credential` to retain the saved value. Responses
+contain `has_credential` instead of credential values. An empty list clears all
+rules. Ordinary environment definitions and agent tools never return credentials.

--- a/tests/dashboard/test_environment_auth.py
+++ b/tests/dashboard/test_environment_auth.py
@@ -1,0 +1,515 @@
+import json
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from pydantic import ValidationError
+
+from agent.dashboard import environment_auth, environments, routes
+from agent.dashboard.environments import ENVIRONMENTS, EnvironmentCreate
+from agent.encryption import decrypt_token
+
+
+@pytest.fixture(autouse=True)
+def encryption(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("TOKEN_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+
+async def _create_environment() -> None:
+    await ENVIRONMENTS.create(EnvironmentCreate(name="Staging"), "admin")
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(routes.router)
+    app.dependency_overrides[routes._admin_session] = lambda: {"sub": "admin"}
+    return app
+
+
+async def test_auth_proxy_roundtrip_encrypts_masks_and_resolves(fake_store) -> None:
+    await _create_environment()
+    body = {
+        "rules": [
+            {
+                "id": "anthropic",
+                "host": "api.anthropic.com",
+                "header": "x-api-key",
+                "scheme": "api_key",
+                "credential": "synthetic-anthropic-secret",
+            },
+            {
+                "id": "openai",
+                "host": "API.OPENAI.COM",
+                "scheme": "bearer",
+                "credential": "synthetic-openai-secret",
+            },
+        ]
+    }
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=_app()), base_url="http://test"
+    ) as client:
+        response = await client.put("/dashboard/api/environments/staging/auth-proxy", json=body)
+        fetched = await client.get("/dashboard/api/environments/staging/auth-proxy")
+
+    expected = {
+        "rules": [
+            {
+                "id": "anthropic",
+                "host": "api.anthropic.com",
+                "header": "x-api-key",
+                "scheme": "api_key",
+                "has_credential": True,
+            },
+            {
+                "id": "openai",
+                "host": "api.openai.com",
+                "header": "Authorization",
+                "scheme": "bearer",
+                "has_credential": True,
+            },
+        ]
+    }
+    assert response.status_code == 200
+    assert response.json() == expected
+    assert fetched.json() == expected
+    assert "synthetic" not in response.text
+    assert "synthetic" not in fetched.text
+
+    stored = fake_store.values(environment_auth.ENVIRONMENT_AUTH_NAMESPACE)["staging"]
+    assert "synthetic" not in json.dumps(stored)
+    assert {
+        rule_id: decrypt_token(value) for rule_id, value in stored["encrypted_credentials"].items()
+    } == {
+        "anthropic": "synthetic-anthropic-secret",
+        "openai": "synthetic-openai-secret",
+    }
+    assert "auth" not in json.dumps(fake_store.values(["environments"])["staging"])
+    assert await environment_auth.resolve_environment_auth_rules("staging") == [
+        {
+            "name": "environment-auth-anthropic",
+            "match_hosts": ["api.anthropic.com"],
+            "headers": [
+                {"name": "x-api-key", "type": "opaque", "value": "synthetic-anthropic-secret"}
+            ],
+        },
+        {
+            "name": "environment-auth-openai",
+            "match_hosts": ["api.openai.com"],
+            "headers": [
+                {
+                    "name": "Authorization",
+                    "type": "opaque",
+                    "value": "Bearer synthetic-openai-secret",
+                }
+            ],
+        },
+    ]
+
+
+async def test_full_replacement_retains_rotates_and_deletes_credentials(fake_store) -> None:
+    await _create_environment()
+    await environment_auth.save_environment_auth(
+        "staging",
+        environment_auth.EnvironmentAuthUpdate.model_validate(
+            {
+                "rules": [
+                    {
+                        "id": "keep",
+                        "host": "keep.example.com",
+                        "scheme": "api_key",
+                        "credential": "synthetic-keep",
+                    },
+                    {
+                        "id": "remove",
+                        "host": "remove.example.com",
+                        "scheme": "bearer",
+                        "credential": "synthetic-remove",
+                    },
+                ]
+            }
+        ),
+    )
+
+    retained = await environment_auth.save_environment_auth(
+        "staging",
+        environment_auth.EnvironmentAuthUpdate.model_validate(
+            {"rules": [{"id": "keep", "host": "moved.example.com", "scheme": "bearer"}]}
+        ),
+    )
+    assert retained["rules"][0]["has_credential"] is True
+    stored = fake_store.values(environment_auth.ENVIRONMENT_AUTH_NAMESPACE)["staging"]
+    assert set(stored["encrypted_credentials"]) == {"keep"}
+    assert decrypt_token(stored["encrypted_credentials"]["keep"]) == "synthetic-keep"
+
+    await environment_auth.save_environment_auth(
+        "staging",
+        environment_auth.EnvironmentAuthUpdate.model_validate(
+            {
+                "rules": [
+                    {
+                        "id": "keep",
+                        "host": "moved.example.com",
+                        "scheme": "bearer",
+                        "credential": "synthetic-rotated",
+                    }
+                ]
+            }
+        ),
+    )
+    stored = fake_store.values(environment_auth.ENVIRONMENT_AUTH_NAMESPACE)["staging"]
+    assert decrypt_token(stored["encrypted_credentials"]["keep"]) == "synthetic-rotated"
+
+    await environment_auth.save_environment_auth(
+        "staging", environment_auth.EnvironmentAuthUpdate(rules=[])
+    )
+    stored = fake_store.values(environment_auth.ENVIRONMENT_AUTH_NAMESPACE)["staging"]
+    assert stored == {"rules": [], "encrypted_credentials": {}}
+
+
+async def test_resolver_aggregates_multiple_headers_for_the_same_host(fake_store) -> None:
+    await environment_auth.save_environment_auth(
+        "staging",
+        environment_auth.EnvironmentAuthUpdate.model_validate(
+            {
+                "rules": [
+                    {
+                        "id": "client-id",
+                        "host": "api.example.com",
+                        "header": "x-client-id",
+                        "scheme": "api_key",
+                        "credential": "synthetic-client",
+                    },
+                    {
+                        "id": "api-key",
+                        "host": "api.example.com",
+                        "header": "x-api-key",
+                        "scheme": "api_key",
+                        "credential": "synthetic-key",
+                    },
+                ]
+            }
+        ),
+    )
+
+    assert await environment_auth.resolve_environment_auth_rules("staging") == [
+        {
+            "name": "environment-auth-client-id",
+            "match_hosts": ["api.example.com"],
+            "headers": [
+                {"name": "x-client-id", "type": "opaque", "value": "synthetic-client"},
+                {"name": "x-api-key", "type": "opaque", "value": "synthetic-key"},
+            ],
+        }
+    ]
+
+
+async def test_new_rule_requires_a_credential_without_echoing_request(fake_store) -> None:
+    await _create_environment()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=_app()), base_url="http://test"
+    ) as client:
+        response = await client.put(
+            "/dashboard/api/environments/staging/auth-proxy",
+            json={
+                "rules": [
+                    {
+                        "id": "new-rule",
+                        "host": "secret-marker.example.com",
+                        "scheme": "api_key",
+                    }
+                ]
+            },
+        )
+    assert response.status_code == 422
+    assert "credential" in response.json()["detail"].lower()
+    assert "secret-marker" not in response.text
+    assert fake_store.values(environment_auth.ENVIRONMENT_AUTH_NAMESPACE) == {}
+
+
+@pytest.mark.parametrize(
+    "rule",
+    [
+        {"id": "rule", "host": "https://api.example.com", "scheme": "bearer"},
+        {"id": "rule", "host": "127.0.0.1", "scheme": "bearer"},
+        {"id": "rule", "host": "*.example.com", "scheme": "bearer"},
+        {"id": "rule", "host": "api.example.com:443", "scheme": "bearer"},
+        {"id": "rule", "host": "github.com", "scheme": "bearer"},
+        {"id": "rule", "host": "api.github.com", "scheme": "bearer"},
+        {"id": "rule", "host": "example..com", "scheme": "bearer"},
+        {"id": "INVALID ID", "host": "api.example.com", "scheme": "bearer"},
+        {"id": "rule", "host": "api.example.com", "header": "Host", "scheme": "bearer"},
+        {
+            "id": "rule",
+            "host": "api.example.com",
+            "header": "content-length",
+            "scheme": "bearer",
+        },
+        {
+            "id": "rule",
+            "host": "api.example.com",
+            "header": "transfer-encoding",
+            "scheme": "bearer",
+        },
+        {
+            "id": "rule",
+            "host": "api.example.com",
+            "header": "bad header",
+            "scheme": "bearer",
+        },
+        {
+            "id": "rule",
+            "host": "api.example.com",
+            "scheme": "bearer",
+            "credential": "synthetic\ncredential",
+        },
+        {
+            "id": "rule",
+            "host": "api.example.com",
+            "scheme": "bearer",
+            "credential": "   ",
+        },
+        {
+            "id": "rule",
+            "host": "api.example.com",
+            "scheme": "bearer",
+            "credential": "synthetic\x00credential",
+        },
+        {
+            "id": "rule",
+            "host": "api.example.com",
+            "scheme": "bearer",
+            "credential": "synthetic-\N{SNOWMAN}",
+        },
+    ],
+)
+async def test_invalid_rules_are_rejected_without_echoing_values(fake_store, rule) -> None:
+    await _create_environment()
+    rule.setdefault("credential", "synthetic-credential")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=_app()), base_url="http://test"
+    ) as client:
+        response = await client.put(
+            "/dashboard/api/environments/staging/auth-proxy", json={"rules": [rule]}
+        )
+    assert response.status_code == 422
+    assert "synthetic" not in response.text
+    assert "api.example.com" not in response.text
+    assert fake_store.values(environment_auth.ENVIRONMENT_AUTH_NAMESPACE) == {}
+
+
+@pytest.mark.parametrize(
+    "rules",
+    [
+        [
+            {
+                "id": "duplicate",
+                "host": "one.example.com",
+                "scheme": "bearer",
+                "credential": "synthetic-one",
+            },
+            {
+                "id": "duplicate",
+                "host": "two.example.com",
+                "scheme": "api_key",
+                "credential": "synthetic-two",
+            },
+        ],
+        [
+            {
+                "id": "one",
+                "host": "SAME.EXAMPLE.COM",
+                "header": "X-API-Key",
+                "scheme": "api_key",
+                "credential": "synthetic-one",
+            },
+            {
+                "id": "two",
+                "host": "same.example.com",
+                "header": "x-api-key",
+                "scheme": "api_key",
+                "credential": "synthetic-two",
+            },
+        ],
+    ],
+)
+async def test_duplicate_ids_and_destinations_are_rejected(fake_store, rules) -> None:
+    await _create_environment()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=_app()), base_url="http://test"
+    ) as client:
+        response = await client.put(
+            "/dashboard/api/environments/staging/auth-proxy", json={"rules": rules}
+        )
+    assert response.status_code == 422
+    assert "synthetic" not in response.text
+    assert fake_store.values(environment_auth.ENVIRONMENT_AUTH_NAMESPACE) == {}
+
+
+async def test_rule_count_and_credential_size_are_bounded(fake_store) -> None:
+    await _create_environment()
+    app = _app()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        too_many = await client.put(
+            "/dashboard/api/environments/staging/auth-proxy",
+            json={
+                "rules": [
+                    {
+                        "id": f"rule-{index}",
+                        "host": f"api-{index}.example.com",
+                        "scheme": "api_key",
+                        "credential": "synthetic",
+                    }
+                    for index in range(21)
+                ]
+            },
+        )
+        too_large = await client.put(
+            "/dashboard/api/environments/staging/auth-proxy",
+            json={
+                "rules": [
+                    {
+                        "id": "rule",
+                        "host": "api.example.com",
+                        "scheme": "api_key",
+                        "credential": "s" * 8193,
+                    }
+                ]
+            },
+        )
+    assert too_many.status_code == 422
+    assert too_large.status_code == 422
+    assert "ssss" not in too_large.text
+    assert fake_store.values(environment_auth.ENVIRONMENT_AUTH_NAMESPACE) == {}
+
+
+async def test_routes_require_an_admin_and_an_existing_environment(fake_store, monkeypatch) -> None:
+    await _create_environment()
+    monkeypatch.setenv("CONFIGURED_ADMINS", "admin@example.com")
+    session = {"sub": "member", "email": "member@example.com"}
+    app = FastAPI()
+    app.include_router(routes.router)
+    app.dependency_overrides[routes.require_session] = lambda: session
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        assert (
+            await client.get("/dashboard/api/environments/staging/auth-proxy")
+        ).status_code == 403
+        assert (
+            await client.put("/dashboard/api/environments/staging/auth-proxy", json={"rules": []})
+        ).status_code == 403
+        session = {"sub": "admin", "email": "admin@example.com"}
+        assert (
+            await client.get("/dashboard/api/environments/missing/auth-proxy")
+        ).status_code == 404
+        assert (
+            await client.put("/dashboard/api/environments/missing/auth-proxy", json={"rules": []})
+        ).status_code == 404
+
+
+async def test_malformed_request_errors_are_sanitized(fake_store) -> None:
+    await _create_environment()
+    app = _app()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        wrong_type = await client.put(
+            "/dashboard/api/environments/staging/auth-proxy",
+            json={"rules": [{"credential": {"synthetic-secret": "synthetic-secret"}}]},
+        )
+        extra_field = await client.put(
+            "/dashboard/api/environments/staging/auth-proxy",
+            json={"rules": [], "synthetic-secret": "synthetic-secret"},
+        )
+        invalid_json = await client.put(
+            "/dashboard/api/environments/staging/auth-proxy",
+            content=b'{"rules": ["synthetic-secret"',
+            headers={"Content-Type": "application/json"},
+        )
+    for response in (wrong_type, extra_field, invalid_json):
+        assert response.status_code == 422
+        assert "synthetic-secret" not in response.text
+    assert fake_store.values(environment_auth.ENVIRONMENT_AUTH_NAMESPACE) == {}
+
+
+async def test_missing_corrupt_and_undecryptable_records_fail_closed(fake_store) -> None:
+    assert await environment_auth.resolve_environment_auth_rules("missing") == []
+
+    fake_store.seed(
+        environment_auth.ENVIRONMENT_AUTH_NAMESPACE,
+        "corrupt",
+        {"rules": "synthetic-secret", "encrypted_credentials": {}},
+    )
+    with pytest.raises(ValidationError):
+        await environment_auth.resolve_environment_auth_rules("corrupt")
+
+    fake_store.seed(
+        environment_auth.ENVIRONMENT_AUTH_NAMESPACE,
+        "undecryptable",
+        {
+            "rules": [
+                {
+                    "id": "rule",
+                    "host": "api.example.com",
+                    "header": "Authorization",
+                    "scheme": "bearer",
+                }
+            ],
+            "encrypted_credentials": {"rule": "synthetic-invalid-ciphertext"},
+        },
+    )
+    with pytest.raises(ValueError, match="could not be decrypted"):
+        await environment_auth.resolve_environment_auth_rules("undecryptable")
+
+
+async def test_removing_environment_deletes_auth_before_the_environment_record(
+    fake_store, monkeypatch
+) -> None:
+    await _create_environment()
+    await environment_auth.save_environment_auth(
+        "staging",
+        environment_auth.EnvironmentAuthUpdate.model_validate(
+            {
+                "rules": [
+                    {
+                        "id": "rule",
+                        "host": "api.example.com",
+                        "scheme": "api_key",
+                        "credential": "synthetic-secret",
+                    }
+                ]
+            }
+        ),
+    )
+    monkeypatch.setattr("agent.dashboard.environments._delete_snapshot", AsyncMock())
+    monkeypatch.setattr("agent.dashboard.environment_refresh.remove_refresh_cron", AsyncMock())
+
+    assert await ENVIRONMENTS.remove("staging") is True
+    assert fake_store.values(environment_auth.ENVIRONMENT_AUTH_NAMESPACE) == {}
+    assert fake_store.values(["environments"]) == {}
+
+
+async def test_auth_cleanup_failure_preserves_the_environment(fake_store, monkeypatch) -> None:
+    await _create_environment()
+    cleanup = AsyncMock(side_effect=RuntimeError("store unavailable"))
+    monkeypatch.setattr(environment_auth, "delete_environment_auth", cleanup)
+
+    with pytest.raises(RuntimeError, match="store unavailable"):
+        await ENVIRONMENTS.remove("staging")
+    assert "staging" in fake_store.values(["environments"])
+
+
+async def test_strict_environment_resolution_propagates_store_failures(monkeypatch) -> None:
+    get = AsyncMock(side_effect=RuntimeError("store unavailable"))
+    monkeypatch.setattr(ENVIRONMENTS, "get", get)
+
+    assert await environments.resolve_default_environment() is None
+    assert await environments.resolve_environment("staging") is None
+    with pytest.raises(RuntimeError, match="store unavailable"):
+        await environments.resolve_default_environment(fail_on_error=True)
+    with pytest.raises(RuntimeError, match="store unavailable"):
+        await environments.resolve_environment("staging", fail_on_error=True)

--- a/tests/sandbox/test_environment_auth_proxy.py
+++ b/tests/sandbox/test_environment_auth_proxy.py
@@ -1,0 +1,366 @@
+"""Environment credentials reach only the proxy, and refresh with its auth."""
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx2
+import pytest
+from cryptography.fernet import Fernet
+
+from agent.dashboard.environment_auth import EnvironmentAuthUpdate, save_environment_auth
+from agent.dashboard.environments import ENVIRONMENTS, Environment, EnvironmentCreate
+from agent.github import proxy
+from agent.sandboxes import lifecycle
+from agent.sandboxes.providers import langsmith
+from agent.sandboxes.state import SandboxBackendProxy
+from tests.conftest import FakeStore
+
+
+def auth_rule(value: str = "test-credential") -> dict[str, Any]:
+    return {
+        "name": "environment-auth-staging",
+        "match_hosts": ["api.staging.example.com"],
+        "headers": [{"name": "Authorization", "type": "opaque", "value": f"Bearer {value}"}],
+    }
+
+
+@pytest.fixture
+def proxy_http(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    monkeypatch.setenv("LANGSMITH_API_KEY", "test-control-key")
+    monkeypatch.delenv("STAGEHAND_MODEL_API_KEY", raising=False)
+    client = MagicMock()
+    client.patch = AsyncMock(
+        return_value=httpx2.Response(200, request=httpx2.Request("PATCH", "https://example.com"))
+    )
+    factory = MagicMock()
+    factory.return_value.__aenter__ = AsyncMock(return_value=client)
+    factory.return_value.__aexit__ = AsyncMock(return_value=False)
+    monkeypatch.setattr(langsmith.httpx2, "AsyncClient", factory)
+    return client.patch
+
+
+async def test_proxy_resolves_rotation_and_removal_without_persisting_values(
+    monkeypatch: pytest.MonkeyPatch, proxy_http: AsyncMock
+) -> None:
+    resolve = AsyncMock(side_effect=[[auth_rule()], [auth_rule("rotated")], []])
+    monkeypatch.setattr(langsmith, "resolve_environment_auth_rules", resolve, raising=False)
+    base = {"rules": [{"name": "public", "match_hosts": ["public.example.com"]}], "callbacks": None}
+    for _ in range(3):
+        await langsmith.configure_github_proxy(
+            "sandbox", "test-github", base_proxy_config=base, environment_slug="staging"
+        )
+
+    first, rotated, removed = [
+        call.kwargs["json"]["proxy_config"] for call in proxy_http.await_args_list
+    ]
+    assert first["rules"][0] == base["rules"][0]
+    assert auth_rule() in first["rules"]
+    assert auth_rule("rotated") in rotated["rules"]
+    assert all(rule["name"] != "environment-auth-staging" for rule in removed["rules"])
+    assert "test-credential" not in str(base)
+    assert "environment_slug" not in first
+    assert all(call.args == ("staging",) for call in resolve.await_args_list)
+
+
+@pytest.mark.parametrize(
+    "conflict",
+    [
+        {"name": "custom", "match_hosts": ["*.example.com"]},
+        {"name": "custom", "match_hosts": ["api.staging.example.com"]},
+        {"name": "environment-auth-staging", "match_hosts": ["unrelated.example.com"]},
+    ],
+)
+async def test_conflicting_proxy_rules_fail_before_patching(
+    monkeypatch: pytest.MonkeyPatch, proxy_http: AsyncMock, conflict: dict[str, Any]
+) -> None:
+    monkeypatch.setattr(
+        langsmith,
+        "resolve_environment_auth_rules",
+        AsyncMock(return_value=[auth_rule()]),
+        raising=False,
+    )
+    with pytest.raises(ValueError, match="conflict"):
+        await langsmith.configure_github_proxy(
+            "sandbox", "github", base_proxy_config={"rules": [conflict]}, environment_slug="staging"
+        )
+    proxy_http.assert_not_awaited()
+
+
+async def test_managed_proxy_host_conflict_is_rejected(
+    monkeypatch: pytest.MonkeyPatch, proxy_http: AsyncMock
+) -> None:
+    rule = auth_rule()
+    rule["match_hosts"] = ["api.anthropic.com"]
+    monkeypatch.setenv("STAGEHAND_MODEL", "anthropic/claude-sonnet-4-5")
+    monkeypatch.setenv("STAGEHAND_MODEL_API_KEY", "test-stagehand")
+    monkeypatch.setattr(
+        langsmith, "resolve_environment_auth_rules", AsyncMock(return_value=[rule]), raising=False
+    )
+    with pytest.raises(ValueError, match="conflict"):
+        await langsmith.configure_github_proxy("sandbox", "github", environment_slug="staging")
+    proxy_http.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "host, config",
+    [
+        (
+            "api.staging.example.com",
+            {"callbacks": [{"match_hosts": ["*.example.com"], "url": "https://auth.example.net"}]},
+        ),
+        ("storage.googleapis.com", {"rules": [{"name": "google-auth", "type": "gcp"}]}),
+        ("storage.googleapis.com", {"rules": [{"name": "google-auth", "type": " GCP "}]}),
+        (
+            "api.staging.example.com",
+            {
+                "callbacks": [
+                    {
+                        "match_hosts": ["*.example.com"],
+                        "url": "https://auth.example.net",
+                        "enabled": False,
+                    }
+                ]
+            },
+        ),
+        ("s3.us-west-2.amazonaws.com", {"rules": [{"name": "aws-auth", "type": "aws"}]}),
+    ],
+)
+async def test_provider_and_callback_auth_cannot_be_shadowed(
+    monkeypatch: pytest.MonkeyPatch, proxy_http: AsyncMock, host: str, config: dict[str, Any]
+) -> None:
+    rule = auth_rule()
+    rule["match_hosts"] = [host]
+    monkeypatch.setattr(langsmith, "resolve_environment_auth_rules", AsyncMock(return_value=[rule]))
+    with pytest.raises(ValueError, match="conflict"):
+        await langsmith.configure_github_proxy(
+            "sandbox", "github", base_proxy_config=config, environment_slug="staging"
+        )
+    proxy_http.assert_not_awaited()
+
+
+async def test_disabled_rules_do_not_conflict_with_environment_auth(
+    monkeypatch: pytest.MonkeyPatch, proxy_http: AsyncMock
+) -> None:
+    monkeypatch.setattr(
+        langsmith, "resolve_environment_auth_rules", AsyncMock(return_value=[auth_rule()])
+    )
+    await langsmith.configure_github_proxy(
+        "sandbox",
+        "github",
+        base_proxy_config={
+            "rules": [{"name": "disabled", "match_hosts": ["*.example.com"], "enabled": False}]
+        },
+        environment_slug="staging",
+    )
+    assert auth_rule() in proxy_http.await_args.kwargs["json"]["proxy_config"]["rules"]
+
+
+async def test_credential_lookup_failure_does_not_patch_proxy(
+    monkeypatch: pytest.MonkeyPatch, proxy_http: AsyncMock
+) -> None:
+    monkeypatch.setattr(
+        langsmith,
+        "resolve_environment_auth_rules",
+        AsyncMock(side_effect=RuntimeError("credential unavailable")),
+        raising=False,
+    )
+    with pytest.raises(RuntimeError, match="credential unavailable"):
+        await langsmith.configure_github_proxy("sandbox", "github", environment_slug="staging")
+    proxy_http.assert_not_awaited()
+
+
+async def test_proxy_errors_do_not_expose_echoed_environment_credentials(
+    monkeypatch: pytest.MonkeyPatch, proxy_http: AsyncMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr(
+        langsmith,
+        "resolve_environment_auth_rules",
+        AsyncMock(return_value=[auth_rule()]),
+        raising=False,
+    )
+    proxy_http.return_value = httpx2.Response(
+        400,
+        text="invalid credential test-credential",
+        request=httpx2.Request("PATCH", "https://example.com"),
+    )
+    with pytest.raises(RuntimeError, match="configure environment auth proxy") as error:
+        await langsmith.configure_github_proxy("sandbox", "github", environment_slug="staging")
+    assert "test-credential" not in str(error.value)
+    assert "test-credential" not in caplog.text
+    assert error.value.__suppress_context__
+
+
+async def test_reused_sandbox_binds_environment_and_refreshes_without_replacing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SANDBOX_TYPE", "langsmith")
+    sandbox = MagicMock(id="existing", aexecute=AsyncMock())
+    base = {"rules": [{"name": "public", "match_hosts": ["public.example.com"]}]}
+    with (
+        patch.dict(
+            lifecycle.SANDBOX_BACKENDS,
+            {"thread": SandboxBackendProxy(sandbox, thread_id="thread")},
+            clear=True,
+        ),
+        patch.object(lifecycle, "get_sandbox_id_from_metadata", AsyncMock(return_value="existing")),
+        patch.object(
+            lifecycle,
+            "get_sandbox_metadata",
+            AsyncMock(return_value={"sandbox_base_proxy_config": base}),
+        ),
+        patch.object(
+            lifecycle,
+            "get_github_app_installation_token_with_expiry",
+            AsyncMock(return_value=("github", None)),
+        ),
+        patch.object(lifecycle, "configure_github_proxy", AsyncMock()) as configure,
+        patch.object(lifecycle.client.threads, "update", AsyncMock()) as update,
+        patch.object(lifecycle, "_create_sandbox_with_proxy", AsyncMock()) as create,
+    ):
+        await lifecycle.ensure_sandbox_for_thread("thread", environment_slug="staging")
+    configure.assert_awaited_once_with(
+        "existing", "github", base_proxy_config=base, environment_slug="staging"
+    )
+    create.assert_not_awaited()
+    assert update.await_args.kwargs["metadata"]["sandbox_environment_slug"] == "staging"
+    assert "credential" not in str(update.await_args.kwargs)
+    proxy.clear_proxy_token_expiry("thread")
+
+
+async def test_mid_run_token_refresh_preserves_environment_reference(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SANDBOX_TYPE", "langsmith")
+    backend = MagicMock(id="sandbox")
+    proxy.record_proxy_token_expiry("thread", datetime.now(UTC), environment_slug="staging")
+    with (
+        patch.dict(proxy.SANDBOX_BACKENDS, {"thread": backend}, clear=True),
+        patch.object(
+            proxy,
+            "get_github_app_installation_token_with_expiry",
+            AsyncMock(return_value=("github", None)),
+        ),
+        patch.object(langsmith, "configure_github_proxy", AsyncMock()) as configure,
+    ):
+        assert await proxy.refresh_proxy_token("thread")
+    configure.assert_awaited_once_with("sandbox", "github", environment_slug="staging")
+    assert proxy.get_recorded_proxy_environment("thread") == "staging"
+    proxy.clear_proxy_token_expiry("thread")
+    assert proxy.get_recorded_proxy_environment("thread") is None
+
+
+async def test_snapshot_builder_uses_environment_auth() -> None:
+    from agent.dashboard.environment_refresh import _create_builder_sandbox
+
+    with (
+        patch(
+            "agent.github.app.get_github_app_installation_token", AsyncMock(return_value="github")
+        ),
+        patch.object(langsmith, "create_langsmith_sandbox", AsyncMock()) as create,
+    ):
+        await _create_builder_sandbox(Environment(slug="staging"), "snapshot")
+    assert create.await_args.kwargs["environment_slug"] == "staging"
+    assert "credential" not in str(create.await_args.kwargs["create_params"])
+
+
+async def test_reset_preserves_environment_auth_after_process_restart(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SANDBOX_TYPE", "langsmith")
+    old = MagicMock(id="old-sandbox")
+    new = MagicMock(id="new-sandbox", aexecute=AsyncMock())
+    with (
+        patch.dict(lifecycle.SANDBOX_BACKENDS, {}, clear=True),
+        patch.object(lifecycle, "get_sandbox_id_from_metadata", AsyncMock(return_value=old.id)),
+        patch.object(
+            lifecycle,
+            "get_sandbox_metadata",
+            AsyncMock(return_value={"sandbox_environment_slug": "staging"}),
+        ),
+        patch.object(
+            lifecycle, "create_langsmith_sandbox_from_params", AsyncMock(return_value=new)
+        ),
+        patch.object(
+            lifecycle, "_resolve_proxy_token", AsyncMock(return_value=("github", None, None))
+        ),
+        patch.object(lifecycle, "configure_github_proxy", AsyncMock()) as configure,
+        patch.object(lifecycle.client.threads, "update", AsyncMock()) as update,
+    ):
+        assert await lifecycle.reset_sandbox_for_thread("reset-thread", {}) == (old.id, new.id)
+    configure.assert_awaited_once_with("new-sandbox", "github", environment_slug="staging")
+    assert update.await_args.kwargs["metadata"]["sandbox_environment_slug"] == "staging"
+    assert proxy.get_recorded_proxy_environment("reset-thread") == "staging"
+    proxy.clear_proxy_token_expiry("reset-thread")
+
+
+@pytest.mark.parametrize("resolved_slug", ["staging", None])
+async def test_recreation_replaces_or_clears_the_persisted_environment(
+    resolved_slug: str | None,
+) -> None:
+    with (
+        patch.dict(lifecycle.SANDBOX_BACKENDS, {}, clear=True),
+        patch.object(lifecycle, "get_sandbox_id_from_metadata", AsyncMock(return_value="old")),
+        patch.object(
+            lifecycle,
+            "_create_sandbox_with_proxy",
+            AsyncMock(return_value=MagicMock(id="new", aexecute=AsyncMock())),
+        ),
+        patch.object(lifecycle, "get_recorded_proxy_environment", return_value=resolved_slug),
+        patch.object(lifecycle.client.threads, "update", AsyncMock()) as update,
+    ):
+        await lifecycle.recreate_sandbox_for_thread("recreated-thread")
+    assert "sandbox_environment_slug" in update.await_args.kwargs["metadata"]
+    assert update.await_args.kwargs["metadata"]["sandbox_environment_slug"] == resolved_slug
+
+
+async def test_new_sandbox_injects_stored_credentials_and_persists_only_environment_slug(
+    monkeypatch: pytest.MonkeyPatch, fake_store: FakeStore, proxy_http: AsyncMock
+) -> None:
+    monkeypatch.setenv("SANDBOX_TYPE", "langsmith")
+    monkeypatch.setenv("TOKEN_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.delenv("SANDBOX_CREATE_EXTRA_JSON", raising=False)
+    await ENVIRONMENTS.create(EnvironmentCreate(name="staging"), "admin")
+    await save_environment_auth(
+        "staging",
+        EnvironmentAuthUpdate.model_validate(
+            {
+                "rules": [
+                    {
+                        "id": "api",
+                        "host": "api.staging.example.com",
+                        "header": "X-API-Key",
+                        "scheme": "api_key",
+                        "credential": "test-staging-credential",
+                    }
+                ]
+            }
+        ),
+    )
+    sandbox = MagicMock(id="new-sandbox", aexecute=AsyncMock())
+    with (
+        patch.dict(lifecycle.SANDBOX_BACKENDS, {}, clear=True),
+        patch.object(lifecycle, "get_sandbox_id_from_metadata", AsyncMock(return_value=None)),
+        patch.object(lifecycle, "create_sandbox", AsyncMock(return_value=sandbox)) as create,
+        patch.object(
+            lifecycle,
+            "get_github_app_installation_token_with_expiry",
+            AsyncMock(return_value=("test-github", None)),
+        ),
+        patch.object(lifecycle.client.threads, "update", AsyncMock()) as update,
+    ):
+        await lifecycle.ensure_sandbox_for_thread("new-thread", environment_slug="staging")
+    rule = proxy_http.await_args.kwargs["json"]["proxy_config"]["rules"][-1]
+    assert rule == {
+        "name": "environment-auth-api",
+        "match_hosts": ["api.staging.example.com"],
+        "headers": [{"name": "X-API-Key", "type": "opaque", "value": "test-staging-credential"}],
+    }
+    assert update.await_args.kwargs["metadata"] == {
+        "sandbox_id": "new-sandbox",
+        "sandbox_environment_slug": "staging",
+    }
+    assert "test-staging-credential" not in str(create.await_args)
+    assert "test-staging-credential" not in str(fake_store.items)
+    assert proxy.get_recorded_proxy_environment("new-thread") == "staging"
+    proxy.clear_proxy_token_expiry("new-thread")

--- a/tests/sandbox/test_proxy_auth.py
+++ b/tests/sandbox/test_proxy_auth.py
@@ -21,6 +21,8 @@ from agent.sandboxes.providers.langsmith import (
 )
 from agent.sandboxes.state import SandboxBackendProxy
 
+pytestmark = pytest.mark.usefixtures("fake_store")
+
 
 def _mock_async_client(mock_client_cls: MagicMock, inner: MagicMock) -> None:
     """Wire an ``httpx2.AsyncClient`` mock class to yield ``inner`` from its
@@ -510,6 +512,7 @@ class TestCreateSandboxWithProxy:
             "sandbox-123",
             "ghs_install",
             base_proxy_config=environment.create_params["proxy_config"],
+            environment_slug="env",
         )
 
     @pytest.mark.asyncio

--- a/tests/sandbox/test_reviewer_sandbox_recovery.py
+++ b/tests/sandbox/test_reviewer_sandbox_recovery.py
@@ -17,6 +17,8 @@ from agent.sandboxes.lifecycle import SANDBOX_BACKENDS, ensure_sandbox_for_threa
 from agent.sandboxes.providers.registry import SandboxGoneError
 from agent.sandboxes.state import SandboxUnreachableError, set_sandbox_backend
 
+pytestmark = pytest.mark.usefixtures("fake_store")
+
 
 @pytest.mark.asyncio
 async def test_replaces_unreachable_sandbox_when_replacement_allowed() -> None:

--- a/tests/sandbox/test_sandbox_recreation.py
+++ b/tests/sandbox/test_sandbox_recreation.py
@@ -49,7 +49,7 @@ async def test_recreate_sandbox_hands_off_after_metadata_persists() -> None:
     configure.assert_awaited_once_with(new_sandbox)
     update.assert_awaited_once_with(
         thread_id=thread_id,
-        metadata={"sandbox_id": "sandbox-new"},
+        metadata={"sandbox_id": "sandbox-new", "sandbox_environment_slug": None},
     )
     assert SANDBOX_BACKENDS[thread_id] is proxy
     assert proxy.current is new_sandbox

--- a/tests/sandbox/test_sandbox_reset.py
+++ b/tests/sandbox/test_sandbox_reset.py
@@ -6,6 +6,8 @@ import pytest
 from agent.sandboxes.lifecycle import reset_sandbox_for_thread
 from agent.sandboxes.state import SANDBOX_BACKENDS, set_sandbox_backend
 
+pytestmark = pytest.mark.usefixtures("fake_store")
+
 
 @pytest.mark.asyncio
 async def test_reset_sandbox_hands_off_after_metadata_persists() -> None:
@@ -65,6 +67,7 @@ async def test_reset_sandbox_hands_off_after_metadata_persists() -> None:
         "expiry",
         permissions=None,
         base_proxy_config={"rules": []},
+        environment_slug=None,
     )
     configure.assert_awaited_once_with(new_sandbox)
     update.assert_awaited_once_with(

--- a/tests/sandbox/test_sandbox_settings.py
+++ b/tests/sandbox/test_sandbox_settings.py
@@ -11,6 +11,8 @@ from agent.dashboard.sandbox_settings import (
     upsert_sandbox_settings,
 )
 
+pytestmark = pytest.mark.usefixtures("fake_store")
+
 
 def _store(item: object) -> MagicMock:
     client = MagicMock()

--- a/tests/sandbox/test_stale_sandbox_creating.py
+++ b/tests/sandbox/test_stale_sandbox_creating.py
@@ -11,6 +11,8 @@ import pytest
 from agent.sandboxes.lifecycle import SANDBOX_BACKENDS, ensure_sandbox_for_thread
 from agent.sandboxes.state import get_or_create_sandbox_backend_proxy
 
+pytestmark = pytest.mark.usefixtures("fake_store")
+
 
 @pytest.mark.asyncio
 async def test_ensure_sandbox_creates_new_when_no_metadata() -> None:
@@ -60,6 +62,7 @@ async def test_ensure_sandbox_reconnects_to_metadata_sandbox() -> None:
         _github_proxy_token=None,
         _github_proxy_repositories=None,
         _base_proxy_config=None,
+        _environment_slug=None,
     ):
         return sandbox_backend
 
@@ -108,6 +111,7 @@ async def test_ensure_sandbox_resolves_unresolved_backend_proxy() -> None:
         _github_proxy_token=None,
         _github_proxy_repositories=None,
         _base_proxy_config=None,
+        _environment_slug=None,
     ):
         return sandbox_backend
 

--- a/ui/src/features/settings/components/EnvironmentAuthProxy.test.tsx
+++ b/ui/src/features/settings/components/EnvironmentAuthProxy.test.tsx
@@ -1,0 +1,259 @@
+/** @vitest-environment jsdom */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import type {
+  EnvironmentAuthProxyRules,
+  EnvironmentAuthProxyRulesUpdate,
+} from "@/lib/api"
+import { EnvironmentAuthProxy } from "./EnvironmentAuthProxy"
+
+const clients: Array<QueryClient> = []
+
+afterEach(() => {
+  cleanup()
+  for (const client of clients) client.clear()
+  clients.length = 0
+  vi.restoreAllMocks()
+})
+
+function renderEditor() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+  clients.push(client)
+  render(
+    <QueryClientProvider client={client}>
+      <EnvironmentAuthProxy
+        environmentSlug="default"
+        environmentName="Default"
+      />
+    </QueryClientProvider>
+  )
+  return client
+}
+
+function response(body: unknown, init?: ResponseInit) {
+  return new Response(JSON.stringify(body), {
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  })
+}
+
+describe("EnvironmentAuthProxy", () => {
+  it("loads masked credential status and omits retained credentials from saves", async () => {
+    const writes: EnvironmentAuthProxyRulesUpdate[] = []
+    const urls: string[] = []
+    let saved: EnvironmentAuthProxyRules = {
+      rules: [
+        {
+          id: "github-api",
+          host: "api.github.com",
+          header: "Authorization",
+          scheme: "bearer",
+          has_credential: true,
+        },
+      ],
+    }
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      urls.push(String(input))
+      if (init?.method !== "PUT") return response(saved)
+      const update = JSON.parse(
+        String(init.body)
+      ) as EnvironmentAuthProxyRulesUpdate
+      writes.push(update)
+      saved = {
+        rules: update.rules.map(({ credential: _credential, ...rule }) => ({
+          ...rule,
+          has_credential: true,
+        })),
+      }
+      return response(saved)
+    })
+
+    const client = renderEditor()
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Configure authentication proxy for Default",
+      })
+    )
+
+    expect(await screen.findByText("Credential configured")).toBeTruthy()
+    expect(urls[0]).toContain("/dashboard/api/environments/default/auth-proxy")
+    expect(
+      (screen.getByLabelText("Credential for rule 1") as HTMLInputElement).value
+    ).toBe("")
+    fireEvent.click(screen.getByRole("button", { name: "Save rules" }))
+    await waitFor(() => expect(writes).toHaveLength(1))
+    expect(writes[0]).toEqual({
+      rules: [
+        {
+          id: "github-api",
+          host: "api.github.com",
+          header: "Authorization",
+          scheme: "bearer",
+        },
+      ],
+    })
+
+    const credential = screen.getByLabelText("Credential for rule 1")
+    fireEvent.change(credential, { target: { value: "rotated-secret" } })
+    fireEvent.click(screen.getByRole("button", { name: "Save rules" }))
+    await waitFor(() => expect(writes).toHaveLength(2))
+    expect(writes[1]?.rules[0]?.credential).toBe("rotated-secret")
+    await waitFor(() => expect((credential as HTMLInputElement).value).toBe(""))
+    expect(
+      JSON.stringify(
+        client
+          .getMutationCache()
+          .getAll()
+          .map((mutation) => mutation.state.variables)
+      )
+    ).not.toContain("rotated-secret")
+  })
+
+  it("creates and deletes rules through full-list saves", async () => {
+    const writes: EnvironmentAuthProxyRulesUpdate[] = []
+    let saved: EnvironmentAuthProxyRules = { rules: [] }
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+      if (init?.method !== "PUT") return response(saved)
+      const update = JSON.parse(
+        String(init.body)
+      ) as EnvironmentAuthProxyRulesUpdate
+      writes.push(update)
+      saved = {
+        rules: update.rules.map(({ credential: _credential, ...rule }) => ({
+          ...rule,
+          has_credential: true,
+        })),
+      }
+      return response(saved)
+    })
+
+    renderEditor()
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Configure authentication proxy for Default",
+      })
+    )
+    expect(
+      await screen.findByText("No authentication rules configured.")
+    ).toBeTruthy()
+    fireEvent.click(screen.getByRole("button", { name: "Add rule" }))
+    expect(screen.queryByLabelText("Rule ID 1")).toBeNull()
+    fireEvent.change(screen.getByLabelText("Host for rule 1"), {
+      target: { value: "api.datadoghq.com" },
+    })
+    fireEvent.change(
+      screen.getByLabelText("Authentication method for rule 1"),
+      {
+        target: { value: "api_key" },
+      }
+    )
+    expect(
+      (screen.getByLabelText("Header for rule 1") as HTMLInputElement).value
+    ).toBe("X-API-Key")
+    fireEvent.change(screen.getByLabelText("Credential for rule 1"), {
+      target: { value: "new-secret" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Save rules" }))
+    await waitFor(() => expect(writes).toHaveLength(1))
+    expect(writes[0]?.rules[0]).toMatchObject({
+      host: "api.datadoghq.com",
+      header: "X-API-Key",
+      scheme: "api_key",
+      credential: "new-secret",
+    })
+    expect(writes[0]?.rules[0]?.id).toMatch(/^rule-[a-f0-9]{27}$/)
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove rule 1" }))
+    expect(screen.getByText("No authentication rules configured.")).toBeTruthy()
+    fireEvent.click(screen.getByRole("button", { name: "Save rules" }))
+    await waitFor(() => expect(writes).toHaveLength(2))
+    expect(writes[1]).toEqual({ rules: [] })
+  })
+
+  it("keeps a credential draft editable after a failed save", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) =>
+      init?.method === "PUT"
+        ? response({ detail: "Settings unavailable" }, { status: 503 })
+        : response({ rules: [] })
+    )
+
+    renderEditor()
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Configure authentication proxy for Default",
+      })
+    )
+    await screen.findByText("No authentication rules configured.")
+    fireEvent.click(screen.getByRole("button", { name: "Add rule" }))
+    fireEvent.change(screen.getByLabelText("Host for rule 1"), {
+      target: { value: "api.incident.io" },
+    })
+    const credential = screen.getByLabelText("Credential for rule 1")
+    fireEvent.change(credential, { target: { value: "recoverable-secret" } })
+    fireEvent.click(screen.getByRole("button", { name: "Save rules" }))
+
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "Settings unavailable"
+    )
+    expect((credential as HTMLInputElement).value).toBe("recoverable-secret")
+    expect(
+      (screen.getByLabelText("Host for rule 1") as HTMLInputElement).value
+    ).toBe("api.incident.io")
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Close authentication proxy for Default",
+      })
+    )
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Configure authentication proxy for Default",
+      })
+    )
+    await screen.findByText("No authentication rules configured.")
+    expect(screen.queryByDisplayValue("recoverable-secret")).toBeNull()
+  })
+
+  it("rejects destinations that are not exact DNS hostnames", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(response({ rules: [] }))
+
+    renderEditor()
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Configure authentication proxy for Default",
+      })
+    )
+    await screen.findByText("No authentication rules configured.")
+    fireEvent.click(screen.getByRole("button", { name: "Add rule" }))
+    fireEvent.change(screen.getByLabelText("Host for rule 1"), {
+      target: { value: "https://api.example.com:443" },
+    })
+    fireEvent.change(screen.getByLabelText("Credential for rule 1"), {
+      target: { value: "secret" },
+    })
+    fireEvent.click(screen.getByRole("button", { name: "Save rules" }))
+
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "Enter an exact DNS hostname"
+    )
+    expect(
+      fetchMock.mock.calls.filter(([, init]) => init?.method === "PUT")
+    ).toHaveLength(0)
+  })
+})

--- a/ui/src/features/settings/components/EnvironmentAuthProxy.tsx
+++ b/ui/src/features/settings/components/EnvironmentAuthProxy.tsx
@@ -1,0 +1,382 @@
+import { useId, useState } from "react"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import {
+  api,
+  type EnvironmentAuthProxyRule,
+  type EnvironmentAuthProxyRuleUpdate,
+  type EnvironmentAuthProxyRules,
+  type EnvironmentAuthProxyScheme,
+} from "@/lib/api"
+
+const MAX_RULES = 20
+const RULE_ID_RE = /^[a-z][a-z0-9-]{0,31}$/
+const HEADER_RE = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/
+
+type DraftRule = EnvironmentAuthProxyRule & {
+  key: string
+  credential: string
+}
+
+function exactDnsHostname(host: string): boolean {
+  if (!host || host.length > 253 || host.includes(":")) return false
+  if (/^\d+(?:\.\d+){3}$/.test(host)) return false
+  return host
+    .split(".")
+    .every(
+      (label) =>
+        label.length > 0 &&
+        label.length <= 63 &&
+        /^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/.test(label)
+    )
+}
+
+function toDraft(rule: EnvironmentAuthProxyRule): DraftRule {
+  return {
+    ...rule,
+    key: `saved:${rule.id}`,
+    credential: "",
+  }
+}
+
+function newRuleId(): string {
+  return `rule-${globalThis.crypto.randomUUID().replaceAll("-", "").slice(0, 27)}`
+}
+
+function buildUpdate(rules: DraftRule[]): EnvironmentAuthProxyRuleUpdate[] {
+  const seen = new Set<string>()
+  return rules.map((rule) => {
+    const id = rule.id.trim()
+    const host = rule.host.trim()
+    const header = rule.header.trim()
+    if (!RULE_ID_RE.test(id)) {
+      throw new Error(
+        "Rule IDs must use lowercase letters and numbers separated by hyphens."
+      )
+    }
+    if (seen.has(id)) throw new Error("Rule IDs must be unique.")
+    seen.add(id)
+    if (!exactDnsHostname(host)) {
+      throw new Error(
+        "Enter an exact DNS hostname without a URL, port, wildcard, or IP address."
+      )
+    }
+    if (!HEADER_RE.test(header)) {
+      throw new Error("Enter a valid HTTP header name.")
+    }
+    if (!rule.has_credential && !rule.credential.trim()) {
+      throw new Error(`Enter a credential for ${id}.`)
+    }
+    return {
+      id,
+      host,
+      header,
+      scheme: rule.scheme,
+      ...(rule.credential ? { credential: rule.credential } : {}),
+    }
+  })
+}
+
+export function EnvironmentAuthProxy({
+  environmentSlug,
+  environmentName,
+}: {
+  environmentSlug: string
+  environmentName: string
+}) {
+  const queryClient = useQueryClient()
+  const panelId = useId()
+  const [open, setOpen] = useState(false)
+  const [rules, setRules] = useState<DraftRule[] | null>(null)
+  const [validationError, setValidationError] = useState<string | null>(null)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+  const queryKey = ["environment-auth-proxy", environmentSlug] as const
+  const authProxy = useQuery({
+    queryKey,
+    queryFn: () => api.getEnvironmentAuthProxy(environmentSlug),
+    enabled: open,
+  })
+  const currentRules = rules ?? authProxy.data?.rules.map(toDraft) ?? []
+
+  const close = () => {
+    setOpen(false)
+    setRules(null)
+    setValidationError(null)
+    setSaveError(null)
+    setSaved(false)
+  }
+
+  const updateRule = (key: string, update: Partial<DraftRule>) => {
+    setRules(
+      currentRules.map((rule) =>
+        rule.key === key ? { ...rule, ...update } : rule
+      )
+    )
+    setValidationError(null)
+    setSaveError(null)
+    setSaved(false)
+  }
+
+  const changeScheme = (
+    rule: DraftRule,
+    scheme: EnvironmentAuthProxyScheme
+  ) => {
+    const previousDefault =
+      rule.scheme === "bearer" ? "Authorization" : "X-API-Key"
+    const nextDefault = scheme === "bearer" ? "Authorization" : "X-API-Key"
+    updateRule(rule.key, {
+      scheme,
+      header: rule.header === previousDefault ? nextDefault : rule.header,
+    })
+  }
+
+  const submit = async () => {
+    setValidationError(null)
+    setSaveError(null)
+    setSaved(false)
+    let body: { rules: EnvironmentAuthProxyRuleUpdate[] }
+    try {
+      body = { rules: buildUpdate(currentRules) }
+    } catch (error) {
+      setValidationError(
+        error instanceof Error ? error.message : "Unable to validate rules."
+      )
+      return
+    }
+    setSaving(true)
+    try {
+      const result = await api.saveEnvironmentAuthProxy(environmentSlug, body)
+      queryClient.setQueryData<EnvironmentAuthProxyRules>(queryKey, result)
+      setRules(result.rules.map(toDraft))
+      setSaved(true)
+      setSaving(false)
+    } catch (error) {
+      setSaveError(
+        error instanceof Error ? error.message : "Unable to save rules."
+      )
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="border-t border-border/70 pt-2">
+      <Button
+        type="button"
+        size="sm"
+        variant="ghost"
+        aria-controls={panelId}
+        aria-expanded={open}
+        aria-label={
+          open
+            ? `Close authentication proxy for ${environmentName}`
+            : `Configure authentication proxy for ${environmentName}`
+        }
+        onClick={() => (open ? close() : setOpen(true))}
+      >
+        {open ? "Close authentication proxy" : "Authentication proxy"}
+      </Button>
+      {open && (
+        <div id={panelId} className="mt-3 space-y-3">
+          {authProxy.isLoading ? (
+            <p className="text-xs text-muted-foreground">
+              Loading authentication rules…
+            </p>
+          ) : authProxy.isError ? (
+            <div className="space-y-2">
+              <p role="alert" className="text-xs text-destructive">
+                {authProxy.error.message ||
+                  "Could not load authentication rules."}
+              </p>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => void authProxy.refetch()}
+              >
+                Retry
+              </Button>
+            </div>
+          ) : (
+            <form
+              className="space-y-3"
+              onSubmit={(event) => {
+                event.preventDefault()
+                void submit()
+              }}
+            >
+              <p className="text-xs/relaxed text-muted-foreground">
+                Add up to 20 rules for exact DNS hostnames. Credentials stay
+                masked after saving and apply on the next proxy refresh.
+              </p>
+              {(validationError || saveError) && (
+                <p role="alert" className="text-xs text-destructive">
+                  {validationError ?? saveError}
+                </p>
+              )}
+              {saved && (
+                <p role="status" className="text-xs text-muted-foreground">
+                  Authentication rules saved.
+                </p>
+              )}
+              {currentRules.length === 0 ? (
+                <p className="rounded-md border border-dashed border-border px-3 py-4 text-center text-xs text-muted-foreground">
+                  No authentication rules configured.
+                </p>
+              ) : (
+                <div className="space-y-3">
+                  {currentRules.map((rule, index) => {
+                    const label = `rule ${index + 1}`
+                    return (
+                      <fieldset
+                        key={rule.key}
+                        disabled={saving}
+                        className="space-y-3 rounded-md border border-border p-3"
+                      >
+                        <div className="flex items-center justify-between gap-3">
+                          <span className="text-xs font-medium text-foreground">
+                            {rule.host || `Rule ${index + 1}`}
+                          </span>
+                          <Button
+                            type="button"
+                            size="xs"
+                            variant="destructive"
+                            aria-label={`Remove ${label}`}
+                            onClick={() => {
+                              setRules(
+                                currentRules.filter(
+                                  (item) => item.key !== rule.key
+                                )
+                              )
+                              setValidationError(null)
+                              setSaveError(null)
+                              setSaved(false)
+                            }}
+                          >
+                            Remove
+                          </Button>
+                        </div>
+                        <div className="grid gap-3 sm:grid-cols-2">
+                          <label className="block text-xs">
+                            Host
+                            <Input
+                              aria-label={`Host for ${label}`}
+                              required
+                              value={rule.host}
+                              placeholder="api.example.com"
+                              autoCapitalize="none"
+                              onChange={(event) =>
+                                updateRule(rule.key, {
+                                  host: event.target.value,
+                                })
+                              }
+                            />
+                          </label>
+                          <label className="block text-xs">
+                            Authentication method
+                            <select
+                              aria-label={`Authentication method for ${label}`}
+                              className="mt-1 block h-7 w-full rounded-md border border-input bg-background px-2 text-xs"
+                              value={rule.scheme}
+                              onChange={(event) =>
+                                changeScheme(
+                                  rule,
+                                  event.target
+                                    .value as EnvironmentAuthProxyScheme
+                                )
+                              }
+                            >
+                              <option value="bearer">Bearer token</option>
+                              <option value="api_key">API key</option>
+                            </select>
+                          </label>
+                          <label className="block text-xs">
+                            Header
+                            <Input
+                              aria-label={`Header for ${label}`}
+                              required
+                              value={rule.header}
+                              onChange={(event) =>
+                                updateRule(rule.key, {
+                                  header: event.target.value,
+                                })
+                              }
+                            />
+                          </label>
+                        </div>
+                        <label className="block text-xs">
+                          Credential
+                          <Input
+                            aria-label={`Credential for ${label}`}
+                            required={!rule.has_credential}
+                            type="password"
+                            autoComplete="new-password"
+                            value={rule.credential}
+                            placeholder={
+                              rule.has_credential
+                                ? "Leave blank to keep current credential"
+                                : "Enter credential"
+                            }
+                            onChange={(event) =>
+                              updateRule(rule.key, {
+                                credential: event.target.value,
+                              })
+                            }
+                          />
+                          <span className="text-[11px] text-muted-foreground">
+                            {rule.has_credential ? (
+                              <>
+                                <span aria-hidden="true">•••••••• · </span>
+                                <span>Credential configured</span>
+                              </>
+                            ) : (
+                              "Credential required"
+                            )}
+                          </span>
+                        </label>
+                      </fieldset>
+                    )
+                  })}
+                </div>
+              )}
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  disabled={saving || currentRules.length >= MAX_RULES}
+                  onClick={() => {
+                    const id = newRuleId()
+                    setRules([
+                      ...currentRules,
+                      {
+                        key: `new:${id}`,
+                        id,
+                        host: "",
+                        header: "Authorization",
+                        scheme: "bearer",
+                        has_credential: false,
+                        credential: "",
+                      },
+                    ])
+                    setValidationError(null)
+                    setSaveError(null)
+                    setSaved(false)
+                  }}
+                >
+                  Add rule
+                </Button>
+                <Button type="submit" size="sm" disabled={saving}>
+                  {saving ? "Saving…" : "Save rules"}
+                </Button>
+              </div>
+            </form>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/src/features/settings/components/EnvironmentsSection.test.tsx
+++ b/ui/src/features/settings/components/EnvironmentsSection.test.tsx
@@ -29,7 +29,7 @@ function renderSection(isAdmin: boolean) {
 }
 
 describe("EnvironmentsSection", () => {
-  it("shows refresh outcomes without edit controls", async () => {
+  it("shows refresh outcomes and admin authentication controls", async () => {
     vi.spyOn(api, "listEnvironmentOptions").mockResolvedValue({
       default_slug: "default",
       environments: [
@@ -63,7 +63,17 @@ describe("EnvironmentsSection", () => {
     expect(screen.getByText(/Refresh failed/)).toBeTruthy()
     expect(screen.getByText("setup script exited 1")).toBeTruthy()
     expect(screen.getByText("Refresh log")).toBeTruthy()
-    expect(view.container.querySelector("button, input, textarea")).toBeNull()
+    expect(
+      screen.getByRole("button", {
+        name: "Configure authentication proxy for Default",
+      })
+    ).toBeTruthy()
+    expect(
+      screen.getByRole("button", {
+        name: "Configure authentication proxy for Preview",
+      })
+    ).toBeTruthy()
+    expect(view.container.querySelector("input, textarea")).toBeNull()
   })
 
   it("never renders a refresh log for non-admins, even if one arrives", async () => {
@@ -89,6 +99,9 @@ describe("EnvironmentsSection", () => {
     expect(await screen.findByText(/Rebuilt 1 hour ago/)).toBeTruthy()
     expect(screen.queryByText("Refresh log")).toBeNull()
     expect(screen.queryByText(/hunter2/)).toBeNull()
+    expect(
+      screen.queryByRole("button", { name: /authentication proxy/i })
+    ).toBeNull()
   })
 
   it("says so when an environment has never been refreshed", async () => {

--- a/ui/src/features/settings/components/EnvironmentsSection.tsx
+++ b/ui/src/features/settings/components/EnvironmentsSection.tsx
@@ -9,6 +9,7 @@ import {
   type EnvironmentRefreshStep,
 } from "@/lib/api"
 import { formatRelativeTime } from "@/lib/utils"
+import { EnvironmentAuthProxy } from "./EnvironmentAuthProxy"
 
 const REFRESH_LABEL: Record<EnvironmentRefreshStatus, string> = {
   never: "Never refreshed",
@@ -124,6 +125,12 @@ function EnvironmentRow({
             {log}
           </pre>
         </details>
+      )}
+      {isAdmin && (
+        <EnvironmentAuthProxy
+          environmentSlug={environment.slug}
+          environmentName={environment.name}
+        />
       )}
     </div>
   )

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -434,6 +434,32 @@ export interface EnvironmentOptionList {
   default_slug: string
 }
 
+export type EnvironmentAuthProxyScheme = "bearer" | "api_key"
+
+export interface EnvironmentAuthProxyRule {
+  id: string
+  host: string
+  header: string
+  scheme: EnvironmentAuthProxyScheme
+  has_credential: boolean
+}
+
+export interface EnvironmentAuthProxyRuleUpdate {
+  id: string
+  host: string
+  header: string
+  scheme: EnvironmentAuthProxyScheme
+  credential?: string
+}
+
+export interface EnvironmentAuthProxyRules {
+  rules: Array<EnvironmentAuthProxyRule>
+}
+
+export interface EnvironmentAuthProxyRulesUpdate {
+  rules: Array<EnvironmentAuthProxyRuleUpdate>
+}
+
 export type FindingSeverity = "low" | "medium" | "high" | "critical"
 export type FindingConfidence = "low" | "medium" | "high"
 export type FindingStatus = "open" | "resolved" | "dismissed"
@@ -786,6 +812,19 @@ export const api = {
     }),
   listEnvironmentOptions: () =>
     request<EnvironmentOptionList>("/environments/options"),
+  getEnvironmentAuthProxy: (slug: string) =>
+    request<EnvironmentAuthProxyRules>(
+      `/environments/${encodeURIComponent(slug)}/auth-proxy`,
+      { cache: "no-store" }
+    ),
+  saveEnvironmentAuthProxy: (
+    slug: string,
+    body: EnvironmentAuthProxyRulesUpdate
+  ) =>
+    request<EnvironmentAuthProxyRules>(
+      `/environments/${encodeURIComponent(slug)}/auth-proxy`,
+      { method: "PUT", body: JSON.stringify(body) }
+    ),
   getTeamSettings: () => request<TeamSettings>("/team-settings"),
   saveTeamSettings: (body: TeamSettings) =>
     request<TeamSettings>("/team-settings", {


### PR DESCRIPTION
Environments can now own sandbox authentication proxy rules and credentials. Admins configure exact hosts, bearer/API-key headers, and credentials from each environment's settings; saved credentials are encrypted separately and the UI only returns configured status. Existing credentials can be retained, rotated, or removed without rebuilding a snapshot.

Sandbox creation, reuse, reset/recreation, snapshot builders, and GitHub token renewal resolve the current environment credentials on the server and inject opaque proxy headers. Only the environment slug is persisted in thread metadata. Missing/decryption failures stop preparation, and overlapping routing, authorization callbacks, or managed/provider authentication rules are rejected. Provider errors are sanitized so echoed credentials cannot reach logs. See `docs/ENVIRONMENT_AUTH.md` for usage and refresh timing.

Validation:
- 226 related Python tests and 8 UI interaction tests passed, including encrypted storage, API authorization/redaction, rotation/removal, proxy payloads, sandbox rebinding, and callback/provider conflicts.
- Ruff, Python type checking, UI TypeScript, and UI lint/format checks passed. Python tooling reports existing dependency/deprecation warnings.
- Proxy API calls are mocked in tests; no live credentials or running sandboxes were changed.
