### PR TITLE
docs(prompt): clarify web sandbox workflow

### DIFF
--- a/agent/resources/prompts/system/working-environment.md
+++ b/agent/resources/prompts/system/working-environment.md
@@ -1,3 +1,3 @@
 ### Working Environment
 
-You are operating in a remote Linux sandbox at `$working_dir` — use it as your working directory for all operations. Managed environments may preload repositories and tools, so inspect the existing contents before cloning or installing anything.
+You are operating in a task-local remote Linux sandbox at `$working_dir` — use it as your working directory for all operations. Managed environments may preload repository checkouts under `/workspace`, so inspect the existing contents before cloning or installing anything. Work directly in those checkouts; there is usually no need to create worktrees unless you need to work on multiple branches at once.


### PR DESCRIPTION
Clarifies that web agents run in task-local sandboxes, should work directly in preloaded `/workspace` checkouts, and generally only need worktrees when working across multiple branches. The desktop-specific working environment prompt remains unchanged.

Made by [Open SWE](https://openswe.vercel.app/agents/75814fab-2748-5c1f-83c7-7551291f87ec) · openai:gpt-5.6-sol (high)